### PR TITLE
Deprecate astrolib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.eggs/
+__pycache__/
+build/
+dist/
+*.egg-info/
+*/*/version.py
+*.so
+*.dylib

--- a/lib/drizzlepac/tweakutils.py
+++ b/lib/drizzlepac/tweakutils.py
@@ -12,7 +12,6 @@ import stsci.ndimage as ndimage
 
 from stsci.tools import asnutil, irafglob, parseinput, fileutil
 from astropy.io import fits
-#import astrolib.coords as coords
 import astropy.coordinates as coords
 import astropy.units as u
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,6 @@ requires-dist =
 	nictools
 	stwcs (>=1.1.9)
 	fitsblender (>=0.2.2)
-	astrolib.coords (>=0.39.4)
 	astropy (>=1.0)
 	numpy (>=1.9)
 classifier =


### PR DESCRIPTION
Bonus: Introduces a `.gitignore` to help prevent accidental inclusion of generated files.