### PR TITLE
Bump version 2.1.5 -> 2.1.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ requires-python = >=2.6
 vdate = 9-Aug-2016
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 summary = drizzle tools: combines astronomical images, including modeling distortion, removing cosmic rays, and generally improving fidelity of data in the final image
-version = 2.1.5
+version = 2.1.6
 requires-dist =
 	stsci.tools
 	stsci.convolve


### PR DESCRIPTION
Release removes `astrolib.coords` as a dependency