### PR TITLE
Convert sky background from native input units to electrons for 'minmed' combine type

### DIFF
--- a/lib/drizzlepac/astrodrizzle.help
+++ b/lib/drizzlepac/astrodrizzle.help
@@ -398,15 +398,48 @@ combine_maskpt : float (Default = 0.3)
 
 
 combine_type : str {'median', 'mean', 'minmed', 'imedian', 'imean', 'iminmed'} (Default = 'minmed')
-    This parameter defines the method that will be used to create the median image.  The 'mean' and 'median' options set the calculation type when running 'numcombine', a numpy method for median-combining arrays to create the median image. The "minmed" option will produce an image that is generally the same as the median, except in cases where the median is significantly higher than the minimum good pixel value. In this case, "minmed" will choose the minimum value. The sigma thresholds for this decision are provided by the "combine_nsigma" parameter. However, as the "combine_nsigma" parameter does not adjust for the larger probability of a single "nsigma" event with a greater number of images, "minmed" will bias the comparison image low for a large number of images. "minmed" is highly recommended for three images, and is good for four to six images, but should be avoided for ten or more images.
+    This parameter defines the method that will be used to create the median
+    image.  The 'mean' and 'median' options set the calculation type when
+    running 'numcombine', a numpy method for median-combining arrays to create
+    the median image. The "minmed" option will produce an image that is
+    generally the same as the median, except in cases where the median is
+    significantly higher than the minimum good pixel value. In this case,
+    "minmed" will choose the minimum value. The sigma thresholds for this
+    decision are provided by the "combine_nsigma" parameter. The value of
+    sigma is computed as :math:`\sigma = \sqrt(D + S + R^2)`,
+    where *D* is image data, *S* is the value of the subtracted sky, and
+    *R* is the value of the readout noise. However, as the
+    "combine_nsigma" parameter does not adjust for the larger probability of
+    a single "nsigma" event with a greater number of images, "minmed"
+    will bias the comparison image low for a large number of images.
+    "minmed" is highly recommended for three images, and is good for four
+    to six images, but should be avoided for ten or more images.
 
-    A value of 'median' is the recommended method for a large number of images, and works equally well as minmed down to approximately four images. However, the user should set the "combine_nhigh" parameter to a value of 1 when using "median" with four images, and consider raising this parameter's value for larger numbers of images. As a median averages the two inner values when the number of values being considered is even, the user may want to keep the total number of images minus "combine_nhigh" odd when using "median".
+    A value of 'median' is the recommended method for a large number of images,
+    and works equally well as minmed down to approximately four images.
+    However, the user should set the "combine_nhigh" parameter to a value of 1
+    when using "median" with four images, and consider raising this parameter's
+    value for larger numbers of images. As a median averages the two inner
+    values when the number of values being considered is even, the user may
+    want to keep the total number of images minus "combine_nhigh" odd when
+    using "median".
 
-    The options starting with 'i', such as 'imedian', works just like the normal median operation except when dealing with a pixel were all the values are flagged as 'bad'.  In this case, the 'i' functions return the last pixel in the stack as if it were good.  This will prevent saturated pixels in the image from leaving holes in the middle of the stars, for example.
+    The options starting with 'i', such as 'imedian', works just like the
+    normal median operation except when dealing with a pixel were all the
+    values are flagged as 'bad'.  In this case, the 'i' functions return the
+    last pixel in the stack as if it were good.  This will prevent saturated
+    pixels in the image from leaving holes in the middle of the stars,
+    for example.
 
 
 combine_nsigma : float (Default = '4 3')
-    This parameter defines the sigmas used for accepting minimum values, rather than median values, when using the 'minmed' combination method. If two values are specified the first value will be used in the initial choice between median and minimum, while the second value will be used in the "growing" step to reject additional pixels around those identified in the first step. If only one value is specified, then it is used in both steps.
+    This parameter defines the sigmas used for accepting minimum values,
+    rather than median values, when using the 'minmed' combination method.
+    If two values are specified the first value will be used in the initial
+    choice between median and minimum, while the second value will be used
+    in the "growing" step to reject additional pixels around those identified
+    in the first step. If only one value is specified, then it is used in
+    both steps.
 
 
 combine_nlow : int (Default = 0)

--- a/lib/drizzlepac/astrodrizzle.help
+++ b/lib/drizzlepac/astrodrizzle.help
@@ -405,15 +405,15 @@ combine_type : str {'median', 'mean', 'minmed', 'imedian', 'imean', 'iminmed'} (
     generally the same as the median, except in cases where the median is
     significantly higher than the minimum good pixel value. In this case,
     "minmed" will choose the minimum value. The sigma thresholds for this
-    decision are provided by the "combine_nsigma" parameter. The value of
-    sigma is computed as :math:`\sigma = \sqrt(D + S + R^2)`,
-    where *D* is image data, *S* is the value of the subtracted sky, and
-    *R* is the value of the readout noise. However, as the
+    decision are provided by the "combine_nsigma" parameter. However, as the
     "combine_nsigma" parameter does not adjust for the larger probability of
     a single "nsigma" event with a greater number of images, "minmed"
     will bias the comparison image low for a large number of images.
-    "minmed" is highly recommended for three images, and is good for four
-    to six images, but should be avoided for ten or more images.
+    The value of sigma is computed as :math:`\sigma = \sqrt(M + S + R^2)`,
+    where *M* is the median image data (in electrons), *S* is the value of the
+    subtracted sky (in electrons), and *R* is the value of the readout noise
+    (in electrons). "minmed" is highly recommended for three images, and is
+    good for four to six images, but should be avoided for ten or more images.
 
     A value of 'median' is the recommended method for a large number of images,
     and works equally well as minmed down to approximately four images.

--- a/lib/drizzlepac/createMedian.help
+++ b/lib/drizzlepac/createMedian.help
@@ -49,9 +49,31 @@ combine_maskpt : float (Default = 0.7)
 
 
 combine_type : str {'average', 'median', 'sum', 'minmed'} (Default = 'minmed')
-    This parameter defines the method that will be used to create the median image.  The 'average', 'median', and 'sum' options set the calculation type when running 'numcombine', a numpy method for median-combining arrays to create the median image. The "minmed" option will produce an image that is generally the same as the median, except in cases where the median is significantly higher than the minimum good pixel value. In this case, "minmed" will choose the minimum value. The sigma thresholds for this decision are provided by the "combine_nsigma" parameter. However, as the "combine_nsigma" parameter does not adjust for the larger probability of a single "nsigma" event with a greater number of images, "minmed" will bias the comparison image low for a large number of images. "minmed" is highly recommended for three images, and is good for four to six images, but should be avoided for ten or more images.
+    This parameter defines the method that will be used to create the median
+    image.  The 'average', 'median', and 'sum' options set the calculation
+    type when running 'numcombine', a numpy method for median-combining arrays
+    to create the median image. The "minmed" option will produce an image that
+    is generally the same as the median, except in cases where the median is
+    significantly higher than the minimum good pixel value. In this case,
+    "minmed" will choose the minimum value. The sigma thresholds for this
+    decision are provided by the "combine_nsigma" parameter. However, as
+    the "combine_nsigma" parameter does not adjust for the larger probability
+    of a single "nsigma" event with a greater number of images, "minmed" will
+    bias the comparison image low for a large number of images.
+    The value of sigma is computed as :math:`\sigma = \sqrt(M + S + R^2)`,
+    where *M* is the median image data (in electrons), *S* is the value of the
+    subtracted sky (in electrons), and *R* is the value of the readout noise
+    (in electrons). "minmed" is highly recommended for three images, and is
+    good for four to six images, but should be avoided for ten or more images.
 
-    A value of 'median' is the recommended method for a large number of images, and works equally well as minmed down to approximately four images. However, the user should set the "combine_nhigh" parameter to a value of 1 when using "median" with four images, and consider raising this parameter's value for larger numbers of images. As a median averages the two inner values when the number of values being considered is even, the user may want to keep the total number of images minus "combine_nhigh" odd when using "median".
+    A value of 'median' is the recommended method for a large number of images,
+    and works equally well as minmed down to approximately four images.
+    However, the user should set the "combine_nhigh" parameter to a value of 1
+    when using "median" with four images, and consider raising this parameter's
+    value for larger numbers of images. As a median averages the two inner
+    values when the number of values being considered is even, the user may
+    want to keep the total number of images minus "combine_nhigh" odd when
+    using "median".
 
 
 combine_nsigma : float (Default = '4 3')

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -262,7 +262,7 @@ def _median(imageObjectList, paramDict):
             for chip in image.returnAllChips(extname=image.scienceExt):
                 # compute sky value as sky/pixel using the single_drz pixel scale
                 if bsky is None or bsky > chip.subtractedSky:
-                    bsky = chip.subtractedSky
+                    bsky = chip.subtractedSky * chip._conversionFactor
 
                 # Extract the readnoise value for the chip
                 rdnoise += (chip._rdnoise)**2


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/spacetelescope/drizzlepac/issues/12 due to which sky background values are not converted to electrons from native units (as recorded in input image headers) leading to an underestimation of sigma that results in a more aggressive cosmic ray rejection, possibly flagging many good pixels as cosmic rays.

@stsci-hack 