### PR TITLE
Allow existing static masks to be overwritten

### DIFF
--- a/lib/drizzlepac/staticMask.py
+++ b/lib/drizzlepac/staticMask.py
@@ -282,7 +282,7 @@ class staticMask(object):
 
             else:
                 try:
-                    newHDU.writeto(filename, overwrite=True)
+                    newHDU.writeto(filename, clobber=True)
                     log.info("Saving static mask to disk: %s" % filename)
 
                 except IOError:

--- a/lib/drizzlepac/staticMask.py
+++ b/lib/drizzlepac/staticMask.py
@@ -285,7 +285,10 @@ class staticMask(object):
 
             else:
                 try:
-                    newHDU.writeto(filename, clobber=True)
+                    if ASTROPY_VER_GE13:
+                        newHDU.writeto(filename, overwrite=True)
+                    else:
+                        newHDU.writeto(filename, clobber=True)
                     log.info("Saving static mask to disk: %s" % filename)
 
                 except IOError:

--- a/lib/drizzlepac/staticMask.py
+++ b/lib/drizzlepac/staticMask.py
@@ -270,25 +270,25 @@ class staticMask(object):
 
         for key in self.masklist.keys():
             #check to see if the file already exists on disk
-            filename=self.masknames[key]
+            filename = self.masknames[key]
             #create a new fits image with the mask array and a standard header
             #open a new header and data unit
             newHDU = fits.PrimaryHDU()
             newHDU.data = self.masklist[key]
 
-            if not virtual:
-                if not(fileutil.checkFileExists(filename)):
-                    try:
-                        newHDU.writeto(filename, clobber=True)
-                        log.info("Saving static mask to disk: %s" % filename)
-
-                    except IOError:
-                        log.error("Problem saving static mask file: %s to "
-                                  "disk!\n" % filename)
-                        raise IOError
-            else:
+            if virtual:
                 for img in imageObjectList:
                     img.saveVirtualOutputs({filename:newHDU})
+
+            else:
+                try:
+                    newHDU.writeto(filename, overwrite=True)
+                    log.info("Saving static mask to disk: %s" % filename)
+
+                except IOError:
+                    log.error("Problem saving static mask file: %s to "
+                              "disk!\n" % filename)
+                    raise IOError
 
 
 def help(file=None):


### PR DESCRIPTION
This PR modifies code so that if there is an existing static mask in the working directory, this mask will be overwritten when code runs. This addresses the issue https://github.com/spacetelescope/drizzlepac/issues/23 