### PR TITLE
Fix deprecated 'clobber' parameter in astropy.io.fits write functions

### DIFF
--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -10,6 +10,7 @@ import copy
 
 import numpy as np
 #import pywcs
+import astropy
 from astropy import wcs as pywcs
 import astropy.coordinates as coords
 from astropy import units as u
@@ -25,6 +26,9 @@ import pyregion
 #import idlphot
 from . import tweakutils, util
 from .mapreg import _AuxSTWCS
+
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
 
 COLNAME_PARS = ['xcol','ycol','fluxcol']
 CATALOG_ARGS = ['sharpcol','roundcol','hmin','fwhm','maxflux','minflux','fluxunits','nbright']+COLNAME_PARS
@@ -529,7 +533,10 @@ class ImageCatalog(Catalog):
         #DEBUG:
         if mask is not None:
             fn = os.path.splitext(self.fname)[0] + '_srcfind_mask.fits'
-            fits.writeto(fn, mask.astype(dtype=np.uint8), clobber=True)
+            if USE_FITS_OVERWRITE:
+                fits.writeto(fn, mask.astype(dtype=np.uint8), overwrite=True)
+            else:
+                fits.writeto(fn, mask.astype(dtype=np.uint8), clobber=True)
 
         return mask
 

--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, division, print_function
 import os, sys
 import copy
+from distutils.version import LooseVersion
 
 import numpy as np
 #import pywcs
@@ -27,10 +28,7 @@ import pyregion
 from . import tweakutils, util
 from .mapreg import _AuxSTWCS
 
-# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
-                       astropy.version.minor >= 3) or
-                      astropy.version.major >= 2)
+ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 COLNAME_PARS = ['xcol','ycol','fluxcol']
 CATALOG_ARGS = ['sharpcol','roundcol','hmin','fwhm','maxflux','minflux','fluxunits','nbright']+COLNAME_PARS
@@ -535,7 +533,7 @@ class ImageCatalog(Catalog):
         #DEBUG:
         if mask is not None:
             fn = os.path.splitext(self.fname)[0] + '_srcfind_mask.fits'
-            if USE_FITS_OVERWRITE:
+            if ASTROPY_VER_GE13:
                 fits.writeto(fn, mask.astype(dtype=np.uint8), overwrite=True)
             else:
                 fits.writeto(fn, mask.astype(dtype=np.uint8), clobber=True)

--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -28,7 +28,9 @@ from . import tweakutils, util
 from .mapreg import _AuxSTWCS
 
 # USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
+                       astropy.version.minor >= 3) or
+                      astropy.version.major >= 2)
 
 COLNAME_PARS = ['xcol','ycol','fluxcol']
 CATALOG_ARGS = ['sharpcol','roundcol','hmin','fwhm','maxflux','minflux','fluxunits','nbright']+COLNAME_PARS

--- a/lib/drizzlepac/staticMask.py
+++ b/lib/drizzlepac/staticMask.py
@@ -24,7 +24,9 @@ from . import util
 from . import processInput
 
 # USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
+USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
+                       astropy.version.minor >= 3) or
+                      astropy.version.major >= 2)
 
 __taskname__ = "drizzlepac.staticMask"
 _step_num_ = 1
@@ -282,6 +284,9 @@ class staticMask(object):
             if not virtual:
                 if not(fileutil.checkFileExists(filename)):
                     try:
+                        print("USE_FITS_OVERWRITE {}".format(USE_FITS_OVERWRITE))
+                        print(astropy.version.major)
+                        print(astropy.version.minor)
                         if USE_FITS_OVERWRITE:
                             newHDU.writeto(filename, overwrite=True)
                         else:

--- a/lib/drizzlepac/staticMask.py
+++ b/lib/drizzlepac/staticMask.py
@@ -17,11 +17,14 @@ import sys
 
 import numpy as np
 from stsci.tools import fileutil, teal, logutil
+import astropy
 from astropy.io import fits
 from stsci.imagestats import ImageStats
 from . import util
 from . import processInput
 
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
 
 __taskname__ = "drizzlepac.staticMask"
 _step_num_ = 1
@@ -279,7 +282,10 @@ class staticMask(object):
             if not virtual:
                 if not(fileutil.checkFileExists(filename)):
                     try:
-                        newHDU.writeto(filename, clobber=True)
+                        if USE_FITS_OVERWRITE:
+                            newHDU.writeto(filename, overwrite=True)
+                        else:
+                            newHDU.writeto(filename, clobber=True)
                         log.info("Saving static mask to disk: %s" % filename)
 
                     except IOError:

--- a/lib/drizzlepac/staticMask.py
+++ b/lib/drizzlepac/staticMask.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function  # confidence h
 
 import os
 import sys
+from distutils.version import LooseVersion
 
 import numpy as np
 from stsci.tools import fileutil, teal, logutil
@@ -23,10 +24,7 @@ from stsci.imagestats import ImageStats
 from . import util
 from . import processInput
 
-# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
-USE_FITS_OVERWRITE = ((astropy.version.major == 1 and
-                       astropy.version.minor >= 3) or
-                      astropy.version.major >= 2)
+ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 __taskname__ = "drizzlepac.staticMask"
 _step_num_ = 1
@@ -284,10 +282,7 @@ class staticMask(object):
             if not virtual:
                 if not(fileutil.checkFileExists(filename)):
                     try:
-                        print("USE_FITS_OVERWRITE {}".format(USE_FITS_OVERWRITE))
-                        print(astropy.version.major)
-                        print(astropy.version.minor)
-                        if USE_FITS_OVERWRITE:
+                        if ASTROPY_VER_GE13:
                             newHDU.writeto(filename, overwrite=True)
                         else:
                             newHDU.writeto(filename, clobber=True)


### PR DESCRIPTION
The ``clobber`` parameter in ``astropy.io.fits`` write functions has been deprecated and it has been replaced with ``overwrite``: see https://github.com/astropy/astropy/pull/5171.

This has caused our code (see, e.g., ``drizzlepac`` - https://github.com/spacetelescope/drizzlepac/issues/15) to issue numerous deprecation warnings.

This PR updates the code in ``stsci.tools`` so that it uses ``overwrite`` for versions of astropy  >= 1.3 and ``clobber`` for verions < 1.3 (for backward compatibility).

This PR addresses issue described in https://github.com/spacetelescope/drizzlepac/issues/15

@stsci-hack Please review this PR.