### PR TITLE
fix incorrect 2x2 inverse matrix computation

### DIFF
--- a/lib/drizzlepac/updatehdr.py
+++ b/lib/drizzlepac/updatehdr.py
@@ -318,12 +318,12 @@ def _inv2x2(x):
     det = inv[0,0]*inv[1,1] - inv[0,1]*inv[1,0]
     if np.abs(det) < np.finfo(np.float64).tiny:
         raise ArithmeticError('Singular matrix.')
-    a = inv[0.0]
-    d = inv[1,1]
-    inv[1,0] *= -1.0
-    inv[0,1] *= -1.0
-    inv[0,0] = d
-    inv[1,1] = d
+    a = inv[0, 0]
+    d = inv[1, 1]
+    inv[1, 0] *= -1.0
+    inv[0, 1] *= -1.0
+    inv[0, 0] = d
+    inv[1, 1] = a
     inv /= det
     inv = inv.astype(np.float64)
     if not np.all(np.isfinite(inv)):


### PR DESCRIPTION
It seems that I have made a mistake in computation of inverse of a 2x2 matrix (likely due to copy/paste). The typo of ``[0.0]`` (instead of ``[0,0]``) had no effect due to the copy/paste bug. This PR may result in slightly different results in tweakreg though local tests indicate no change in the shifts/rotations obtained by tweakreg and no change in the found WCS parameters (CD matrix, CRVALs).