### PR TITLE
Zero negative values before computing image's Poisson errors

### DIFF
--- a/lib/drizzlepac/acsData.py
+++ b/lib/drizzlepac/acsData.py
@@ -220,10 +220,10 @@ class SBCInputImage (ACSInputImage):
         self.full_shape = (1024,1024)
         self._detector=self._image['PRIMARY'].header["DETECTOR"]
 
+        # no cte correction for SBC so set cte_dir=0.
+        print('WARNING: No cte correction will be made for this SBC data.')
         for chip in range(1,self._numchips+1,1):
             self._assignSignature(chip) #this is used in the static mask
-            # no cte correction for SBC so set cte_dir=0.
-            print('WARNING: No cte correction will be made for this SBC data.')
             self._image[self.scienceExt,chip].cte_dir = 0
 
 

--- a/lib/drizzlepac/acsData.py
+++ b/lib/drizzlepac/acsData.py
@@ -223,7 +223,7 @@ class SBCInputImage (ACSInputImage):
         for chip in range(1,self._numchips+1,1):
             self._assignSignature(chip) #this is used in the static mask
             # no cte correction for SBC so set cte_dir=0.
-            print('\nWARNING: No cte correction will be made for this SBC data.\n')
+            print('WARNING: No cte correction will be made for this SBC data.')
             self._image[self.scienceExt,chip].cte_dir = 0
 
 

--- a/lib/drizzlepac/stisData.py
+++ b/lib/drizzlepac/stisData.py
@@ -210,7 +210,7 @@ class NUVInputImage(STISInputImage):
         self._detector=self._image["PRIMARY"].header["DETECTOR"]
 
         # no cte correction for STIS/NUV-MAMA so set cte_dir=0.
-        print('\nWARNING: No cte correction will be made for this STIS/NUV-MAMA data.\n')
+        print('WARNING: No cte correction will be made for this STIS/NUV-MAMA data.')
 
         for chip in range(1,self._numchips+1,1):
             self._image[self.scienceExt,chip].cte_dir = 0
@@ -333,7 +333,7 @@ class FUVInputImage(STISInputImage):
         self._detector=self._image["PRIMARY"].header["DETECTOR"]
 
         # no cte correction for STIS/FUV-MAMA so set cte_dir=0.
-        print('\nWARNING: No cte correction will be made for this STIS/FUV-MAMA data.\n')
+        print('WARNING: No cte correction will be made for this STIS/FUV-MAMA data.')
         for chip in range(1,self._numchips+1,1):
             self._image[self.scienceExt,chip].cte_dir = 0
             self._image[self.scienceExt,chip].darkcurrent = self.getdarkcurrent()


### PR DESCRIPTION
This PR solves the issue of negative values under square root that produce warnings reported in https://github.com/spacetelescope/drizzlepac/issues/22. Fundamentally, the code now will set to zero any negative data values before computing Poisson noise.

This PR also removed unnecessary double underscores from variable names + removes extra new lines reported in https://github.com/spacetelescope/stsci.tools/issues/22#issuecomment-277808856