### PR TITLE
Do not attempt to delete original WCS

### DIFF
--- a/lib/drizzlepac/wcs_functions.py
+++ b/lib/drizzlepac/wcs_functions.py
@@ -488,6 +488,8 @@ def removeAllAltWCS(hdulist,extlist):
         wkeys.remove(' ')
     for extn in extlist:
         for wkey in wkeys:
+            if wkey == 'O':
+                continue
             altwcs.deleteWCS(hdulist,extn,wkey)
 
         # Forcibly remove OPUS WCS Keywords, since deleteWCS will not do it


### PR DESCRIPTION
Currently (see https://github.com/spacetelescope/drizzlepac/issues/34) code attempts to delete original WCS and this results in multiple info messages warning about this. This PR modifies the code not to attempt to delete original WCS. This addresses the issue https://github.com/spacetelescope/drizzlepac/issues/34

CC: @stsci-hack 