### PR TITLE
Run updatewcs on newly unpacked/created files if requested

### DIFF
--- a/lib/drizzlepac/processInput.py
+++ b/lib/drizzlepac/processInput.py
@@ -694,6 +694,9 @@ def buildFileListOrig(input, output=None, ivmlist=None,
 
     newfilelist, ivmlist = check_files.checkFiles(updated_input, ivmlist)
 
+    if updatewcs:
+        uw.updatewcs(','.join(set(newfilelist) - set(filelist)))
+
     if len(ivmlist) > 0:
         ivmlist, filelist = list(zip(*ivmlist))
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,10 +44,10 @@ description-file = README
 name = drizzlepac
 author = Megan Sosey, Warren Hack, Christopher Hanley, Chris Sontag, Mihai Cara
 requires-python = >=2.6
-vdate = 24-Mar-2017
+vdate = 04-Apr-2017
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 summary = drizzle tools: combines astronomical images, including modeling distortion, removing cosmic rays, and generally improving fidelity of data in the final image
-version = 2.1.11
+version = 2.1.12
 requires-dist =
 	stsci.tools
 	stsci.convolve


### PR DESCRIPTION
Depending on input files, ``AstroDrizzle`` needs to create new input files and use them instead of the original input files, e.g., replace ``_c0f.fits`` files with ``_c0h.fits`` files or extract single exposures from "multi-imset STIS ``_flt`` files".

This PR updates ``buildFileListOrig()`` function to run ``stwcs.updatewcs.updatewcs()`` on these new images when so requested.

CC: @stsci-hack 