### PR TITLE
Fix logic for turning off sky subtraction

### DIFF
--- a/lib/drizzlepac/ablot.py
+++ b/lib/drizzlepac/ablot.py
@@ -302,9 +302,10 @@ def run_blot(imageObjectList,output_wcs,paramDict,wcsmap=wcs_functions.WCSMap):
             else:
                 skyval = paramDict['blot_skyval']
             _outsci /= chip._conversionFactor
-            _outsci += skyval
-            log.info('Applying sky value of %0.6f to blotted image %s'%
-                        (skyval,chip.outputNames['data']))
+            if skyval is not None:
+                _outsci += skyval
+                log.info('Applying sky value of %0.6f to blotted image %s'%
+                            (skyval,chip.outputNames['data']))
 
             # Write output Numpy objects to a PyFITS file
             # Blotting only occurs from a drizzled SCI extension

--- a/lib/drizzlepac/adrizzle.py
+++ b/lib/drizzlepac/adrizzle.py
@@ -771,8 +771,11 @@ def run_driz_chip(img,chip,output_wcs,outwcs,template,paramDict,single,
     _sciext = _handle[chip.header['extname'],chip.header['extver']]
 
     # Apply sky subtraction and unit conversion to input array
-    log.info("Applying sky value of %0.6f to %s"%(chip.computedSky,_expname))
-    _insci = _sciext.data - chip.computedSky
+    if chip.computedSky is None:
+        _insci = _sciext.data
+    else:
+        log.info("Applying sky value of %0.6f to %s"%(chip.computedSky,_expname))
+        _insci = _sciext.data - chip.computedSky
     _insci *= chip._effGain
 
     # Set additional parameters needed by 'drizzle'

--- a/lib/drizzlepac/imageObject.py
+++ b/lib/drizzlepac/imageObject.py
@@ -69,20 +69,14 @@ class baseImageObject(object):
         """ Overload the comparison operator
             just to check the filename of the object?
         """
-        if isinstance(other,imageObject):
-            if (self._filename == other._filename):
-                return True
-        return False
+        return (isinstance(other, imageObject) and self._filename == other._filename)
 
     def _isNotValid(self, par1, par2):
         """ Method used to determine if a value or keyword is
             supplied as input for instrument specific parameters.
         """
         invalidValues = [None,'None','INDEF','']
-        if (par1 in invalidValues) and (par2 in invalidValues):
-            return True
-        else:
-            return False
+        return (par1 in invalidValues and par2 in invalidValues)
 
     def info(self):
         """ Return fits information on the _image.
@@ -1115,17 +1109,20 @@ class imageObject(baseImageObject):
                 # Keep track of the sky value that should be subtracted from this chip
                 # Read in value from image header, in case user has already
                 # determined the sky level
-                if "MDRIZSKY" in sci_chip.header:
-                    subsky = sci_chip.header['MDRIZSKY']
-                    log.info('Reading in MDRIZSKY of %s' % subsky)
-                else:
-                    subsky = 0.0
+                #
                 # .computedSky:   value to be applied by the
                 #                 adrizzle/ablot steps.
                 # .subtractedSky: value already (or will be by adrizzle/ablot)
                 #                 subtracted from the image
-                sci_chip.subtractedSky = subsky
-                sci_chip.computedSky = subsky
+                #
+                if "MDRIZSKY" in sci_chip.header:
+                    subsky = sci_chip.header['MDRIZSKY']
+                    log.info('Reading in MDRIZSKY of %s' % subsky)
+                    sci_chip.subtractedSky = subsky
+                    sci_chip.computedSky = subsky
+                else:
+                    sci_chip.subtractedSky = 0.0
+                    sci_chip.computedSky = None
 
                 sci_chip.darkcurrent = 0.0
 

--- a/lib/drizzlepac/sky.py
+++ b/lib/drizzlepac/sky.py
@@ -164,7 +164,17 @@ def subtractSky(imageObjList,configObj,saveFile=False,procSteps=None):
                          .format(paramDict['skyuser']))
                 for image in imageObjList:
                     log.info('Working on sky for: %s' % image._filename)
-                    _skyUserFromHeaderKwd(image,paramDict)
+                    _skyUserFromHeaderKwd(image, paramDict)
+        else:
+            # reset "computedSky" chip's attribute:
+            for image in imageObjList:
+                numchips    = image._numchips
+                extname     = image.scienceExt
+                for extver in range(1, numchips + 1, 1):
+                    chip = image[extname, extver]
+                    if not chip.group_member:
+                        continue
+                    chip.computedSky = None
 
         if procSteps is not None:
             procSteps.endStep('Subtract Sky')
@@ -488,7 +498,7 @@ def _skyUserFromFile(imageObjList, skyFile, apply_sky=None):
                 # .subtractedSky: value already (or will be by adrizzle/ablot)
                 #                 subtracted from the image
                 if skyapplied:
-                    imageSet[chipext].computedSky = 0.0 # used by adrizzle/ablot
+                    imageSet[chipext].computedSky = None # used by adrizzle/ablot
                 else:
                     imageSet[chipext].computedSky = _skyValue
                 imageSet[chipext].subtractedSky = _skyValue
@@ -556,7 +566,7 @@ def _skyUserFromHeaderKwd(imageSet,paramDict):
 
                 # Update internal record with subtracted sky value
                 imageSet[chipext].subtractedSky = _skyValue
-                imageSet[chipext].computedSky = 0.0
+                imageSet[chipext].computedSky = None
                 print("Setting ",skyKW,"=",_skyValue)
 
 #this is the main function that does all the real work in computing the
@@ -620,7 +630,7 @@ def _skySub(imageSet,paramDict,saveFile=False):
 
                 # Update internal record with subtracted sky value
                 imageSet[chipext].subtractedSky = _skyValue
-                imageSet[chipext].computedSky = 0.0
+                imageSet[chipext].computedSky = None
                 print("Setting ",skyKW,"=",_skyValue)
 
     else:


### PR DESCRIPTION
As reported in https://github.com/spacetelescope/drizzlepac/issues/58, ``skysub`` option in ``AstroDrizzle`` is broken and setting ``skysub`` to ``False`` does not turn off subtraction of ``MDRIZSKY`` values read from image headers during initialization of ``AstroDrizzle``.

Initially, the capability of turning off sky subtraction was introduced in https://trac.stsci.edu/ssb/stsci_python/ticket/1208 but, unfortunately, it works *only when ``MDRIZSKY`` is not present in image headers.*

This PR fixes the logic for turning off sky subtraction.

CC: @stsci-hack 