### PR TITLE
Suppress info messages

### DIFF
--- a/lib/drizzlepac/ablot.py
+++ b/lib/drizzlepac/ablot.py
@@ -35,6 +35,7 @@ except ImportError:
 __taskname__ = 'drizzlepac.ablot'
 _blot_step_num_ = 5
 
+import logging
 log = logutil.create_logger(__name__)
 
 
@@ -105,6 +106,7 @@ def run(configObj,wcsmap=None):
 
     # read in WCS from source (drizzled) image
     source_wcs = stwcs.wcsutil.HSTWCS(configObj['data'])
+
     if source_wcs.wcs.is_unity():
         print("WARNING: No valid WCS found for input drizzled image: {}!".format(configObj['data']))
 
@@ -160,7 +162,7 @@ def run(configObj,wcsmap=None):
     # to a blotted SCI extension...
     outputimage.writeSingleFITS(_outsci,blot_wcs, configObj['outdata'],configObj['reference'])
 
-
+    
 #
 #### Top-level interface from inside AstroDrizzle
 #

--- a/lib/drizzlepac/ablot.py
+++ b/lib/drizzlepac/ablot.py
@@ -35,7 +35,6 @@ except ImportError:
 __taskname__ = 'drizzlepac.ablot'
 _blot_step_num_ = 5
 
-import logging
 log = logutil.create_logger(__name__)
 
 
@@ -106,7 +105,6 @@ def run(configObj,wcsmap=None):
 
     # read in WCS from source (drizzled) image
     source_wcs = stwcs.wcsutil.HSTWCS(configObj['data'])
-
     if source_wcs.wcs.is_unity():
         print("WARNING: No valid WCS found for input drizzled image: {}!".format(configObj['data']))
 

--- a/lib/drizzlepac/outputimage.py
+++ b/lib/drizzlepac/outputimage.py
@@ -50,7 +50,7 @@ DRIZ_KEYWORDS = {
                 'WKEY':{'value':"",'comment':'Input image WCS Version used'}
                 }
 
-
+import logging
 log = logutil.create_logger(__name__)
 
 
@@ -450,8 +450,11 @@ class OutputImage:
             fo.append(hdu)
 
             # remove all alternate WCS solutions from headers of this product
-            wcs_functions.removeAllAltWCS(fo,wcs_ext)
 
+            logging.disable(logging.INFO)
+            wcs_functions.removeAllAltWCS(fo,wcs_ext)
+            logging.disable(logging.NOTSET)
+ 
             # add table of combined header keyword values to FITS file
             if newtab is not None:
                 fo.append(newtab)


### PR DESCRIPTION
This supresses log.INFO messages comping from astropy.wcs in cases which I believe are benign and are safe to ignore. My local testing shows it produces a clean log as desired by some.