### PR TITLE
Explicitly set memory mapping to False

### DIFF
--- a/lib/drizzlepac/ablot.py
+++ b/lib/drizzlepac/ablot.py
@@ -79,7 +79,7 @@ def run(configObj,wcsmap=None):
     # output from PyDrizzle (which will always be a FITS file)
     # Open the input (drizzled?) image
     _fname,_sciextn = fileutil.parseFilename(configObj['data'])
-    _inimg = fileutil.openImage(_fname)
+    _inimg = fileutil.openImage(_fname, memmap=False)
     _expin = fileutil.getKeyword(configObj['data'],scale_pars['expkey'],handle=_inimg)
 
     # Return the PyFITS HDU corresponding to the named extension
@@ -160,7 +160,7 @@ def run(configObj,wcsmap=None):
     # to a blotted SCI extension...
     outputimage.writeSingleFITS(_outsci,blot_wcs, configObj['outdata'],configObj['reference'])
 
-    
+
 #
 #### Top-level interface from inside AstroDrizzle
 #
@@ -283,7 +283,7 @@ def run_blot(imageObjectList,output_wcs,paramDict,wcsmap=wcs_functions.WCSMap):
             else:
                 outMedian = outMedianObj
                 _fname,_sciextn = fileutil.parseFilename(outMedian)
-                _inimg = fileutil.openImage(_fname)
+                _inimg = fileutil.openImage(_fname, memmap=False)
 
             # Return the PyFITS HDU corresponding to the named extension
             _scihdu = fileutil.getExtn(_inimg,_sciextn)

--- a/lib/drizzlepac/buildmask.py
+++ b/lib/drizzlepac/buildmask.py
@@ -107,7 +107,7 @@ def buildMaskImage(rootname, bitvalue, output, extname='DQ', extver=1):
         fileutil.removeFile(maskname)
 
     # Open input file with DQ array
-    fdq = fileutil.openImage(rootname, memmap=0, mode='readonly')
+    fdq = fileutil.openImage(rootname, mode='readonly', memmap=False)
     try:
         _extn = fileutil.findExtname(fdq, extname, extver=extver)
         if _extn is not None:
@@ -130,7 +130,7 @@ def buildMaskImage(rootname, bitvalue, output, extname='DQ', extver=1):
         # Build mask array from DQ array
         maskarr = buildMask(dqarr,bitvalue)
         #Write out the mask file as simple FITS file
-        fmask = fits.open(maskname, 'append')
+        fmask = fits.open(maskname, mode='append', memmap=False)
         maskhdu = fits.PrimaryHDU(data = maskarr)
         fmask.append(maskhdu)
 
@@ -230,7 +230,7 @@ def buildShadowMaskImage(dqfile,detnum,extnum,maskname,bitvalue=None,binned=1):
                     del bmaskarr
 
                 #Write out the mask file as simple FITS file
-                fmask = fits.open(_mask,'append')
+                fmask = fits.open(_mask, mode='append', memmap=False)
                 maskhdu = fits.PrimaryHDU(data=maskarr)
                 fmask.append(maskhdu)
 
@@ -244,8 +244,7 @@ def buildShadowMaskImage(dqfile,detnum,extnum,maskname,bitvalue=None,binned=1):
         #
         # Build full mask based on .c1h and shadow mask
         #
-        fdq = fileutil.openImage(dqfile)
-        #fsmask = fits.open(_mask,memmap=1,mode='readonly')
+        fdq = fileutil.openImage(dqfile, mode='readonly', memmap=False)
         try:
             # Read in DQ array from .c1h and from shadow mask files
             dqarr = fdq[int(extnum)].data
@@ -255,7 +254,7 @@ def buildShadowMaskImage(dqfile,detnum,extnum,maskname,bitvalue=None,binned=1):
             dqmaskarr = buildMask(dqarr,bitvalue)
 
             #Write out the mask file as simple FITS file
-            fdqmask = fits.open(maskname,'append')
+            fdqmask = fits.open(maskname, mode='append', memmap=False)
             maskhdu = fits.PrimaryHDU(data=dqmaskarr)
             fdqmask.append(maskhdu)
 

--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -443,7 +443,7 @@ class ImageCatalog(Catalog):
         self.fnamenoext = self.fname if extind < 0 else self.fname[:extind]
         if self.wcs.extname == ('',None):
             self.wcs.extname = (0)
-        self.source = fits.getdata(self.wcs.filename,ext=self.wcs.extname)
+        self.source = fits.getdata(self.wcs.filename,ext=self.wcs.extname, memmap=False)
 
 
     def _combine_exclude_mask(self, mask):
@@ -469,7 +469,7 @@ class ImageCatalog(Catalog):
            basicFITScheck(reg_file_name):
             # likely we are dealing with a FITS file.
             # check that the file is a simple with 2 axes:
-            hdulist = fits.open(reg_file_name)
+            hdulist = fits.open(reg_file_name, memmap=False)
             extlist = get_extver_list(hdulist,extname=None)
             for ext in extlist:
                 usermask = hdulist[ext].data

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -210,7 +210,7 @@ def _median(imageObjectList, paramDict):
             if virtual:
                 _single_hdr = singleDriz[wcs_extnum].header
             else:
-                _single_hdr = fits.getheader(singleDriz_name,ext=wcs_extnum)
+                _single_hdr = fits.getheader(singleDriz_name, ext=wcs_extnum, memmap=False)
 
         _singleImage=iterfile.IterFitsFile(iter_singleDriz)
         if virtual:

--- a/lib/drizzlepac/drizCR.py
+++ b/lib/drizzlepac/drizCR.py
@@ -164,7 +164,7 @@ def _drizCr(sciImage, virtual_outputs, paramDict):
                     raise # raise orig error
 
                 try:
-                    __blotImage = fits.open(blotImageName,mode="readonly") # !!! ,memmap=False) ?
+                    __blotImage = fits.open(blotImageName, mode="readonly", memmap=False)
                 except IOError:
                     print("Problem opening blot images")
                     raise
@@ -364,7 +364,7 @@ def createCorrFile(outfile, arrlist, template):
         os.remove(outfile)
         print("Removing old corr file:",outfile)
 
-    ftemplate = fits.open(template)
+    ftemplate = fits.open(template, memmap=False)
     for arr in arrlist:
         ftemplate[arr['sciext']].data = arr['corrFile']
         if arr['dqext'][0] != arr['sciext'][0]:

--- a/lib/drizzlepac/imageObject.py
+++ b/lib/drizzlepac/imageObject.py
@@ -164,8 +164,8 @@ class baseImageObject(object):
         extnum = self._interpretExten(exten)
         if self._image[extnum].data is None:
             if os.path.exists(fname):
-                _image=fileutil.openImage(fname,clobber=False,memmap=0)
-                _data=fileutil.getExtn(_image,extn=exten).data
+                _image=fileutil.openImage(fname, clobber=False, memmap=False)
+                _data=fileutil.getExtn(_image, extn=exten).data
                 _image.close()
                 del _image
                 self._image[extnum].data = _data
@@ -181,7 +181,7 @@ class baseImageObject(object):
             is used instead of fits to account for non-FITS
             input images. openImage returns a fits object.
         """
-        _image=fileutil.openImage(self._filename,clobber=False,memmap=0)
+        _image=fileutil.openImage(self._filename, clobber=False, memmap=False)
         _header=fileutil.getExtn(_image,extn=exten).header
         _image.close()
         del _image
@@ -212,7 +212,7 @@ class baseImageObject(object):
             the original input file for this object.
         """
         _extnum=self._interpretExten(exten)
-        fimg = fileutil.openImage(self._filename,mode='update')
+        fimg = fileutil.openImage(self._filename, mode='update', memmap=False)
         fimg[_extnum].data = data
         fimg[_extnum].header = self._image[_extnum].header
         fimg.close()
@@ -542,7 +542,7 @@ class baseImageObject(object):
         filename = fileutil.osfn(self._image["PRIMARY"].header[self.flatkey])
 
         try:
-            handle = fileutil.openImage(filename, mode='readonly', memmap=0)
+            handle = fileutil.openImage(filename, mode='readonly', memmap=False)
             hdu = fileutil.getExtn(handle,extn=exten)
             if hdu.data.shape[0] != sci_chip.image_shape[0]:
                 _ltv2 = np.round(sci_chip.ltv2)
@@ -754,7 +754,7 @@ class baseImageObject(object):
             extn = "IVM,{}".format(chip)
 
             #Open the mask image for updating and the IVM image
-            ivm =  fileutil.openImage(ivmname, mode='readonly')
+            ivm =  fileutil.openImage(ivmname, mode='readonly', memmap=False)
             ivmfile = fileutil.getExtn(ivm, extn)
 
             # Multiply the IVM file by the input mask in place.
@@ -981,7 +981,7 @@ class imageObject(baseImageObject):
 
         #filutil open returns a fits object
         try:
-            self._image=fileutil.openImage(filename,clobber=False,memmap=0)
+            self._image=fileutil.openImage(filename, clobber=False, memmap=False)
 
         except IOError:
             raise IOError("Unable to open file: %s" % filename)
@@ -1025,7 +1025,7 @@ class imageObject(baseImageObject):
         self._isSimpleFits = False
 
         # Clean out any stray MDRIZSKY keywords from PRIMARY headers
-        fimg = fileutil.openImage(filename,mode='update')
+        fimg = fileutil.openImage(filename, mode='update', memmap=False)
         if 'MDRIZSKY' in fimg['PRIMARY'].header:
             del fimg['PRIMARY'].header['MDRIZSKY']
         fimg.close()

--- a/lib/drizzlepac/imgclasses.py
+++ b/lib/drizzlepac/imgclasses.py
@@ -858,7 +858,7 @@ class Image(object):
                         wnames[' '] = ''
                     pri_wcsname = wnames[' ']
 
-                next_pkey = altwcs.getKeyFromName(fits.getheader(self.name,extlist[0]),pri_wcsname)
+                next_pkey = altwcs.getKeyFromName(fits.getheader(self.name, extlist[0], memmap=False),pri_wcsname)
                 log.info('    Saving Primary WCS to alternate WCS: "%s"'%next_pkey)
 
                 altwcs.archiveWCS(self._im.hdu, extlist,

--- a/lib/drizzlepac/irData.py
+++ b/lib/drizzlepac/irData.py
@@ -53,7 +53,7 @@ class IRInputImage(imageObject):
 
         """
         try:
-            hdulist = fileutil.openImage(self.name,mode='readonly',memmap=0)
+            hdulist = fileutil.openImage(self.name, mode='readonly', memmap=False)
             extnhdulist = fileutil.getExtn(hdulist,extn="SAMP")
             sampimage = extnhdulist.data[self.ltv2:self.size2,self.ltv1:self.size1]
         except:

--- a/lib/drizzlepac/mapreg.py
+++ b/lib/drizzlepac/mapreg.py
@@ -173,7 +173,7 @@ def map_region_files(input_reg, images, img_wcs_ext='sci',
     # image extension from the input_reg and chip_reg regions
     for fname in imgfnames:
         imghdu = None
-        imghdu = fits.open(fname)
+        imghdu = fits.open(fname, memmap=False)
         catreg = []
         try:
             for extp in cregext:
@@ -563,7 +563,7 @@ def build_reg_refwcs_header_list(input_reg, refimg, ref_wcs_ext, verbose):
 
         # load headers containing WCS from the reference input FITS file:
         ref_wcs_headers = [None if extn is None \
-                           else fits.getheader(refimg_fname, ext=extn) \
+                           else fits.getheader(refimg_fname, ext=extn, memmap=False) \
                            for extn in ref_wcs_exts ] #TODO: return WCS instead of header
 
     else:
@@ -621,7 +621,7 @@ def build_img_ext_reg_list(images, chip_reg=None, img_wcs_ext='sci',
     # Get the HDU list of the first file in the list of images. This will be
     # re-used to check available extensions.
     try:
-        hdulist = fits.open(imgfnames[0])
+        hdulist = fits.open(imgfnames[0], memmap=False)
         hdulist.close()
     except IOError as e:
         cmsg = "Unable to open the image file \'%s\'." % imgfnames[0]
@@ -919,7 +919,7 @@ def count_extensions(img, extname='SCI'):
     HDU headers.
     """
     if isinstance(img, str):
-        img = fits.open(img)
+        img = fits.open(img, memmap=False)
         img.close()
     elif not isinstance(img, fits.HDUList):
         raise TypeError("Argument 'img' must be either a file name (string) " \
@@ -951,7 +951,7 @@ def get_extver_list(img, extname='SCI'):
     'img' can be either a file name or a HDU List object (from fits).
     """
     if isinstance(img, str):
-        img = fits.open(img)
+        img = fits.open(img, memmap=False)
         img.close()
     elif not isinstance(img, fits.HDUList):
         raise TypeError("Argument 'img' must be either a file name (string) "  \
@@ -1046,7 +1046,7 @@ def _check_FITS_extensions(img, extensions):
 
     # if 'img' is a file name - open the FITS file:
     if isinstance(img, str):
-        img = fits.open(img)
+        img = fits.open(img, memmap=False)
         img.close()
     elif not isinstance(img, fits.HDUList):
         raise TypeError("Argument 'img' must be either a file name (string) " \

--- a/lib/drizzlepac/mdzhandler.py
+++ b/lib/drizzlepac/mdzhandler.py
@@ -46,7 +46,7 @@ def getMdriztabParameters(files):
 
     # Open MDRIZTAB file.
     try:
-        _mdriztab = fits.open(_tableName)
+        _mdriztab = fits.open(_tableName, memmap=False)
     except:
         raise IOError("MDRIZTAB table '%s' not valid!" % _tableName)
 

--- a/lib/drizzlepac/nicmosData.py
+++ b/lib/drizzlepac/nicmosData.py
@@ -65,8 +65,7 @@ class NICMOSInputImage(imageObject):
         """
 
          # Image information
-        #_handle = fileutil.openImage(self._filename,mode='update',memmap=0)
-        _handle = fileutil.openImage(self._filename,mode='readonly')
+        _handle = fileutil.openImage(self._filename, mode='readonly', memmap=False)
 
         for det in range(1,self._numchips+1,1):
 

--- a/lib/drizzlepac/pixreplace.py
+++ b/lib/drizzlepac/pixreplace.py
@@ -78,7 +78,7 @@ def replace(input, **pars):
     files = parseinput.parseinput(input)[0]
 
     for f in files:
-        fimg = fits.open(f, mode='update')
+        fimg = fits.open(f, mode='update', memmap=False)
 
         if ext is None:
             # replace pixels in ALL extensions

--- a/lib/drizzlepac/processInput.py
+++ b/lib/drizzlepac/processInput.py
@@ -376,7 +376,7 @@ def _getInputImage (input,group=None):
     sci_ext = 'SCI'
     if group in [None,'']:
         exten = '[sci,1]'
-        phdu = fits.getheader(input)
+        phdu = fits.getheader(input, memmap=False)
     else:
         # change to use fits more directly here?
         if group.find(',') > 0:
@@ -387,8 +387,8 @@ def _getInputImage (input,group=None):
                 grp = int(grp[0])
         else:
             grp = int(group)
-        phdu = fits.getheader(input)
-        phdu.extend(fits.getheader(input, ext=grp))
+        phdu = fits.getheader(input, memmap=False)
+        phdu.extend(fits.getheader(input, ext=grp, memmap=False))
 
     # Extract the instrument name for the data that is being processed by Multidrizzle
     _instrument = phdu['INSTRUME']
@@ -471,7 +471,7 @@ def processFilenames(input=None,output=None,infilesOnly=False):
             if output in ["",None,"None"]:
                 output = oldasndict['output'].lower() # insure output name is lower case
 
-        asnhdr = fits.getheader(input)
+        asnhdr = fits.getheader(input, memmap=False)
         # Only perform duplication check if not already completed...
         dupcheck = asnhdr.get('DUPCHECK',default="PERFORM") == "PERFORM"
 
@@ -751,7 +751,7 @@ def changeSuffixinASN(asnfile, suffix):
     shutil.copy(asnfile,_new_asn)
 
     # Open up the new copy and convert all MEMNAME's to include suffix
-    fasn = fits.open(_new_asn,'update')
+    fasn = fits.open(_new_asn, mode='update', memmap=False)
     fasn[0].header['DUPCHECK'] = "COMPLETE"
     newdata = fasn[1].data.tolist()
     for i in range(len(newdata)):
@@ -962,7 +962,7 @@ def buildEmptyDRZ(input, output):
     # the DRZ file.
     try :
         log.info('Building empty DRZ file from %s' % inputfile[0])
-        img = fits.open(inputfile[0])
+        img = fits.open(inputfile[0], memmap=False)
     except:
         raise IOError('Unable to open file %s \n' % inputfile)
 
@@ -1087,13 +1087,13 @@ def checkDGEOFile(filenames):
 
     for inputfile in filenames:
         try:
-            dgeofile = fits.getval(inputfile, 'DGEOFILE')
+            dgeofile = fits.getval(inputfile, 'DGEOFILE', memmap=False)
         except KeyError:
             continue
         if dgeofile not in ["N/A", "n/a", ""]:
             message = msg.format(inputfile)
             try:
-                npolfile = fits.getval(inputfile, 'NPOLFILE')
+                npolfile = fits.getval(inputfile, 'NPOLFILE', memmap=False)
             except KeyError:
                 ustop = userStop(message)
                 while ustop is None:

--- a/lib/drizzlepac/resetbits.py
+++ b/lib/drizzlepac/resetbits.py
@@ -130,7 +130,7 @@ def reset_dq_bits(input,bits,extver=None,extname='dq'):
     flist, fcol = parseinput.parseinput(input)
     for filename in flist:
         # open input file in write mode to allow updating the DQ array in-place
-        p = fits.open(filename,mode='update')
+        p = fits.open(filename, mode='update', memmap=False)
 
         # Identify the DQ array to be updated
         # If no extver is specified, build a list of all DQ arrays in the file

--- a/lib/drizzlepac/runastrodriz.py
+++ b/lib/drizzlepac/runastrodriz.py
@@ -151,7 +151,7 @@ def process(inFile,force=False,newpath=None, inmemory=False, num_cores=None,
         _fname = fileutil.buildRootname(_cal_prodname,ext=['_drz.fits'])
 
         # Retrieve the first member's rootname for possible use later
-        _fimg = fits.open(inFilename)
+        _fimg = fits.open(inFilename, memmap=False)
         for name in _fimg[1].data.field('MEMNAME'):
             if name[-1] != '*':
                 _mname = name.split('\0', 1)[0].lower()
@@ -203,7 +203,7 @@ def process(inFile,force=False,newpath=None, inmemory=False, num_cores=None,
     if force: dcorr = 'PERFORM'
     else:
         if _mname :
-            _fimg = fits.open(fileutil.buildRootname(_mname,ext=['_raw.fits']))
+            _fimg = fits.open(fileutil.buildRootname(_mname,ext=['_raw.fits']), memmap=False)
             _phdr = _fimg['PRIMARY'].header
             if dkey in _phdr:
                 dcorr = _phdr[dkey]
@@ -290,7 +290,7 @@ def process(inFile,force=False,newpath=None, inmemory=False, num_cores=None,
 
         # Save this for when astropy.io.fits can modify a file 'in-place'
         # Update calibration switch
-        _fimg = fits.open(_cal_prodname, mode='update')
+        _fimg = fits.open(_cal_prodname, mode='update', memmap=False)
         _fimg['PRIMARY'].header[dkey] = 'COMPLETE'
         _fimg.close()
         del _fimg
@@ -383,7 +383,7 @@ def _lowerAsn(asnfile):
     shutil.copy(asnfile,_new_asn)
 
     # Open up the new copy and convert all MEMNAME's to lower-case
-    fasn = fits.open(_new_asn,'update')
+    fasn = fits.open(_new_asn, mode='update', memmap=False)
     for i in range(len(fasn[1].data)):
         fasn[1].data[i].setfield('MEMNAME',fasn[1].data[i].field('MEMNAME').lower())
     fasn.close()

--- a/lib/drizzlepac/sky.py
+++ b/lib/drizzlepac/sky.py
@@ -399,10 +399,18 @@ def _buildStaticDQUserMask(img, ext, sky_bits, use_static, umask,
                 smask = img.virtualOutputs[staticMaskName].data
         else:
             if staticMaskName is not None and os.path.isfile(staticMaskName):
-                sm, dq = openImageEx(staticMaskName, mode='readonly',
-                            saveAsMEF=False, clobber=False,
-                            imageOnly=True, openImageHDU=True, openDQHDU=False,
-                            preferMEF=False, verbose=False)
+                sm, dq = openImageEx(
+                    staticMaskName,
+                    mode='readonly',
+                    memmap=False,
+                    saveAsMEF=False,
+                    clobber=False,
+                    imageOnly=True,
+                    openImageHDU=True,
+                    openDQHDU=False,
+                    preferMEF=False,
+                    verbose=False
+                )
                 if sm.hdu is not None:
                     smask = sm.hdu[0].data
                     sm.release()

--- a/lib/drizzlepac/sky.py
+++ b/lib/drizzlepac/sky.py
@@ -649,7 +649,7 @@ def _skySub(imageSet,paramDict,saveFile=False):
             imageSet[myext].data=imageSet.getData(myext)
 
             image=imageSet[myext]
-            _skyValue= _computeSky(image, paramDict, memmap=0)
+            _skyValue= _computeSky(image, paramDict, memmap=False)
             #scale the sky value by the area on sky
             # account for the case where no IDCSCALE has been set, due to a
             # lack of IDCTAB or to 'coeffs=False'.
@@ -691,7 +691,7 @@ def _skySub(imageSet,paramDict,saveFile=False):
 ##  Helper functions follow  ##
 ###############################
 
-def _computeSky(image, skypars, memmap=0):
+def _computeSky(image, skypars, memmap=False):
 
     """
     Compute the sky value for the data array passed to the function
@@ -732,7 +732,7 @@ def _extractSkyValue(imstatObject,skystat):
 
 
 
-def _subtractSky(image,skyValue,memmap=0):
+def _subtractSky(image,skyValue,memmap=False):
     """
     subtract the given sky value from each the data array
     that has been passed. image is a fits object that
@@ -757,7 +757,7 @@ def _updateKW(image, filename, exten, skyKW, Value):
     else:
         strexten = '[%s]'%(exten)
     log.info('Updating keyword %s in %s' % (skyKW, filename + strexten))
-    fobj = fileutil.openImage(filename, mode='update')
+    fobj = fileutil.openImage(filename, mode='update', memmap=False)
     fobj[exten].header[skyKW] = (Value, 'Sky value computed by AstroDrizzle')
     fobj.close()
 
@@ -771,7 +771,7 @@ def _addDefaultSkyKW(imageObjList):
         fname = imageSet._filename
         numchips=imageSet._numchips
         sciExt=imageSet.scienceExt
-        fobj = fileutil.openImage(fname, mode='update')
+        fobj = fileutil.openImage(fname, mode='update', memmap=False)
         for chip in range(1,numchips+1,1):
             ext = (sciExt,chip)
             if not imageSet[ext].group_member:

--- a/lib/drizzlepac/skytopix.py
+++ b/lib/drizzlepac/skytopix.py
@@ -160,49 +160,8 @@ def rd2xy(input,ra=None,dec=None,coordfile=None,colnames=None,
     if single_coord:
         outx = outx[0]
         outy = outy[0]
-    return outx,outy
 
-    """ Convert colnames input into list of column numbers
-    """
-    cols = []
-    if not isinstance(colnames,list):
-        colnames = colnames.split(',')
-
-    # parse column names from coords file and match to input values
-    if coordfile is not None and fileutil.isFits(coordfile)[0]:
-        # Open FITS file with table
-        ftab = fits.open(coordfile)
-        # determine which extension has the table
-        for extn in ftab:
-            if isinstance(extn, fits.BinTableHDU):
-                # parse column names from table and match to inputs
-                cnames = extn.columns.names
-                if colnames is not None:
-                    for c in colnames:
-                        for name,i in zip(cnames,list(range(len(cnames)))):
-                            if c == name.lower(): cols.append(i)
-                    if len(cols) < len(colnames):
-                        errmsg = "Not all input columns found in table..."
-                        ftab.close()
-                        raise ValueError(errmsg)
-                else:
-                    cols = cnames[:2]
-                break
-        ftab.close()
-    else:
-        for c in colnames:
-            if isinstance(c, str):
-                if c[0].lower() == 'c':
-                    cols.append(int(c[1:])-1)
-                else:
-                    cols.append(int(c))
-            else:
-                if isinstance(c, int):
-                    cols.append(c)
-                else:
-                    errmsg = "Unsupported column names..."
-                    raise ValueError(errmsg)
-    return cols
+    return outx, outy
 
 
 #--------------------------

--- a/lib/drizzlepac/stisData.py
+++ b/lib/drizzlepac/stisData.py
@@ -76,8 +76,7 @@ class STISInputImage (imageObject):
 
         """
          # Image information
-        #_handle = fileutil.openImage(self._filename,mode='update',memmap=0)
-        _handle = fileutil.openImage(self._filename,mode='readonly')
+        _handle = fileutil.openImage(self._filename, mode='readonly', memmap=False)
 
         for det in range(1,self._numchips+1,1):
 

--- a/lib/drizzlepac/tweakback.py
+++ b/lib/drizzlepac/tweakback.py
@@ -158,7 +158,7 @@ def tweakback(drzfile, input=None,  origwcs = None,
         fltfiles = [fltfiles]
 
     sciext = determine_extnum(drzfile, extname='SCI')
-    scihdr = fits.getheader(drzfile, ext=sciext)
+    scihdr = fits.getheader(drzfile, ext=sciext, memmap=False)
 
     ### Step 1: Read in updated and original WCS solutions
     # determine keys for all alternate WCS solutions in drizzled image header
@@ -197,12 +197,12 @@ def tweakback(drzfile, input=None,  origwcs = None,
     crderr2kw = 'CRDER2'+wkeys[-1]
 
     if crderr1kw in scihdr:
-        crderr1 = fits.getval(drzfile, crderr1kw, ext=sciext)
+        crderr1 = fits.getval(drzfile, crderr1kw, ext=sciext, memmap=False)
     else:
         crderr1 = 0.0
 
     if crderr2kw in scihdr:
-        crderr2 = fits.getval(drzfile, crderr2kw, ext=sciext)
+        crderr2 = fits.getval(drzfile, crderr2kw, ext=sciext, memmap=False)
     else:
         crderr2 = 0.0
     del scihdr
@@ -216,7 +216,7 @@ def tweakback(drzfile, input=None,  origwcs = None,
             log.info(logstr)
 
         # reset header WCS keywords to original (OPUS generated) values
-        imhdulist = fits.open(fname, mode='update', memmap=True)
+        imhdulist = fits.open(fname, mode='update', memmap=False)
         extlist = get_ext_list(imhdulist, extname='SCI')
         if not extlist:
             extlist = [0]
@@ -354,7 +354,7 @@ def extract_input_filenames(drzfile):
     """
     Generate a list of filenames from a drizzled image's header
     """
-    data_kws = fits.getval(drzfile, 'd*data', ext=0)
+    data_kws = fits.getval(drzfile, 'd*data', ext=0, memmap=False)
     if len(data_kws) == 0:
         return None
     fnames = []
@@ -367,7 +367,7 @@ def extract_input_filenames(drzfile):
 
 def determine_extnum(drzfile, extname='SCI'):
     # Determine what kind of drizzled file input has been provided: MEF or single
-    hdulist = fits.open(drzfile)
+    hdulist = fits.open(drzfile, memmap=False)
     numext = len(hdulist)
     sciext = 0
     for e,i in zip(hdulist,list(range(numext))):

--- a/lib/drizzlepac/tweakutils.py
+++ b/lib/drizzlepac/tweakutils.py
@@ -470,7 +470,7 @@ def readcols(infile, cols=None):
 def read_FITS_cols(infile,cols=None):
     """ Read columns from FITS table
     """
-    ftab = fits.open(infile)
+    ftab = fits.open(infile, memmap=False)
     extnum = 0
     extfound = False
     for extn in ftab:

--- a/lib/drizzlepac/updatehdr.py
+++ b/lib/drizzlepac/updatehdr.py
@@ -205,7 +205,7 @@ def updatewcs_with_shift(image,reference,wcsname=None, reusename=False,
     if isinstance(reference, wcsutil.HSTWCS) or isinstance(reference, pywcs.WCS):
         wref = reference
     else:
-        refimg = fits.open(reference)
+        refimg = fits.open(reference, memmap=False)
         wref = None
         for extn in refimg:
             if 'extname' in extn.header and extn.header['extname'] == 'WCS':
@@ -249,7 +249,7 @@ def updatewcs_with_shift(image,reference,wcsname=None, reusename=False,
     # insure that input PRIMARY WCS has been archived before overwriting
     # with new solution
     if open_image:
-        fimg = fits.open(image, mode='update')
+        fimg = fits.open(image, mode='update', memmap=False)
         image_update = True
     else:
         fimg = image
@@ -440,7 +440,7 @@ def update_wcs(image,extnum,new_wcs,wcsname="",reusename=False,verbose=False):
 
     fimg_open=False
     if not isinstance(image, fits.HDUList):
-        fimg = fits.open(image, mode='update')
+        fimg = fits.open(image, mode='update', memmap=False)
         fimg_open = True
         fimg_update = True
     else:

--- a/lib/drizzlepac/updatenpol.py
+++ b/lib/drizzlepac/updatenpol.py
@@ -177,7 +177,7 @@ def update(input,refdir="jref$",local=None,interactive=False,wcsupdate=True):
         print('Updating: ',f)
         fdir = os.path.split(f)[0]
         # Open each file...
-        fimg = fits.open(f, mode='update')
+        fimg = fits.open(f, mode='update', memmap=False)
         phdr = fimg['PRIMARY'].header
         fdet = phdr['detector']
         # get header of DGEOFILE
@@ -185,7 +185,7 @@ def update(input,refdir="jref$",local=None,interactive=False,wcsupdate=True):
         if dfile in ['N/A','',' ',None]:
             npolname = ''
         else:
-            dhdr = fits.getheader(fu.osfn(dfile))
+            dhdr = fits.getheader(fu.osfn(dfile), memmap=False)
             if not interactive:
                 # search all new NPOLFILEs for one that matches current DGEOFILE config
                 npol = find_npolfile(ngeofiles,fdet,[phdr['filter1'],phdr['filter2']])
@@ -261,7 +261,7 @@ def find_d2ifile(flist,detector):
     """
     d2ifile = None
     for f in flist:
-        fdet = fits.getval(f,'detector')
+        fdet = fits.getval(f, 'detector', memmap=False)
         if fdet == detector:
             d2ifile = f
     return d2ifile
@@ -272,11 +272,11 @@ def find_npolfile(flist,detector,filters):
     """
     npolfile = None
     for f in flist:
-        fdet = fits.getval(f,'detector')
+        fdet = fits.getval(f, 'detector', memmap=False)
         if fdet == detector:
-            filt1 = fits.getval(f,'filter1')
-            filt2 = fits.getval(f,'filter2')
-            fdate = fits.getval(f,'date')
+            filt1 = fits.getval(f, 'filter1', memmap=False)
+            filt2 = fits.getval(f, 'filter2', memmap=False)
+            fdate = fits.getval(f, 'date', memmap=False)
             if filt1 == 'ANY' or \
              (filt1 == filters[0] and filt2 == filters[1]):
                 npolfile = f

--- a/lib/drizzlepac/util.py
+++ b/lib/drizzlepac/util.py
@@ -429,12 +429,18 @@ def count_sci_extensions(filename):
     """
     num_sci = 0
     extname = 'SCI'
-    for extn in fileutil.openImage(filename):
+
+    hdu_list = fileutil.openImage(filename, memmap=False)
+
+    for extn in hdu_list:
         if 'extname' in extn.header and extn.header['extname'] == extname:
             num_sci += 1
+
     if num_sci == 0:
         extname = 'PRIMARY'
         num_sci = 1
+
+    hdu_list.close()
 
     return num_sci,extname
 
@@ -460,7 +466,7 @@ def verifyUpdatewcs(fname):
     updated = True
     numsci,extname = count_sci_extensions(fname)
     for n in range(1,numsci+1):
-        hdr = fits.getheader(fname, extname=extname, extver=n)
+        hdr = fits.getheader(fname, extname=extname, extver=n, memmap=False)
         if 'wcsname' not in hdr:
             updated = False
             break
@@ -528,7 +534,7 @@ def findWCSExtn(filename):
     rootname,extroot = fileutil.parseFilename(filename)
     extnum = None
     if extroot is None:
-        fimg = fits.open(rootname)
+        fimg = fits.open(rootname, memmap=False)
         for i,extn in enumerate(fimg):
             if 'crval1' in extn.header:
                 refwcs = wcsutil.HSTWCS('{}[{}]'.format(rootname,i))
@@ -1024,7 +1030,7 @@ def parse_colnames(colnames,coords=None):
     # parse column names from coords file and match to input values
     if coords is not None and fileutil.isFits(coords)[0]:
         # Open FITS file with table
-        ftab = fits.open(coords)
+        ftab = fits.open(coords, memmap=False)
         # determine which extension has the table
         for extn in ftab:
             if isinstance(extn, fits.BinTableHDU):

--- a/lib/drizzlepac/wcs_functions.py
+++ b/lib/drizzlepac/wcs_functions.py
@@ -1009,7 +1009,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
     """
     log.setLevel(logging.WARNING)
     if isinstance(fobj, str):
-        fobj = fits.open(fobj)
+        fobj = fits.open(fobj, memmap=False)
 
     hdr = altwcs._getheader(fobj, ext)
     try:

--- a/lib/drizzlepac/wfc3Data.py
+++ b/lib/drizzlepac/wfc3Data.py
@@ -174,8 +174,7 @@ class WFC3IRInputImage(WFC3InputImage):
          photometry keywords will be calculated as such, so no image
          manipulation needs be done between native and electrons """
          # Image information
-        #_handle = fileutil.openImage(self._filename,mode='update',memmap=0)
-        _handle = fileutil.openImage(self._filename,mode='readonly')
+        _handle = fileutil.openImage(self._filename, mode='readonly', memmap=False)
 
         for chip in self.returnAllChips(extname=self.scienceExt):
             conversionFactor = 1.0
@@ -263,7 +262,7 @@ class WFC3IRInputImage(WFC3InputImage):
         # keyword in the primary keyword of the science data.
         try:
             filename = self.header["DARKFILE"]
-            handle = fileutil.openImage(filename,mode='readonly',memmap=0)
+            handle = fileutil.openImage(filename, mode='readonly', memmap=False)
             hdu = fileutil.getExtn(handle,extn="sci,1")
             darkobj = hdu.data[sci_chip.ltv2:sci_chip.size2,sci_chip.ltv1:sci_chip.size1]
 

--- a/lib/drizzlepac/wfpc2Data.py
+++ b/lib/drizzlepac/wfpc2Data.py
@@ -93,7 +93,7 @@ class WFPC2InputImage (imageObject):
 
         #dq_suffix = DQ_EXTNS[suffix[1:]]
         if os.path.exists(dqfile):
-            dq_suffix = fits.getval(dqfile, "EXTNAME", ext=1)
+            dq_suffix = fits.getval(dqfile, "EXTNAME", ext=1, memmap=False)
         else:
             dq_suffix = "SCI"
 
@@ -193,8 +193,7 @@ class WFPC2InputImage (imageObject):
             gets done, even if only 1 chip was specified to be processed.
         """
          # Image information
-        #_handle = fileutil.openImage(self._filename,mode='update',memmap=0)
-        _handle = fileutil.openImage(self._filename,mode='readonly')
+        _handle = fileutil.openImage(self._filename, mode='readonly', memmap=False)
 
         # Now convert the SCI array(s) units
         for det in range(1,self._numchips+1):
@@ -302,7 +301,7 @@ class WFPC2InputImage (imageObject):
         sci_chip.dqmaskname = dqmask_name
         sci_chip.outputNames['dqmask'] = dqmask_name
         sci_chip.outputNames['tmpmask'] = 'wfpc2_inmask%d.fits'%(sci_chip.detnum)
-        dqmask = fits.getdata(dqmask_name, 0)
+        dqmask = fits.getdata(dqmask_name, ext=0, memmap=False)
         return dqmask
 
     def _assignSignature(self, chip):


### PR DESCRIPTION
This PR explicitly turns off memory mapping in fits IO functions. This is done in order to reduce the number of file handles used by ``astrodrizzle``. This PR partially addresses issue https://github.com/spacetelescope/drizzlepac/issues/39.

CC: @stsci-hack 