### PR TITLE
Fix drizzlepac lowering the case of paths of output products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.so
 *.dylib
 *.pyc
+.DS_Store

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,13 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+Drizzlepac v2.1.18 (not released)
+=================================
+
+- ``drizzlepac`` lowers the case of the path of output images.
+  See https://github.com/spacetelescope/drizzlepac/issues/79 for more
+  details.
+
 DrizzlePac v2.1.17 (13-June-2017)
 =================================
 

--- a/lib/drizzlepac/imageObject.py
+++ b/lib/drizzlepac/imageObject.py
@@ -336,7 +336,7 @@ class baseImageObject(object):
 
         extname=self._image[self.scienceExt,chip].header["EXTNAME"].lower()
         extver=self._image[self.scienceExt,chip].header["EXTVER"]
-        expname = self._rootname.lower()
+        expname = self._rootname
 
         # record extension-based name to reflect what extension a mask file corresponds to
         self._image[self.scienceExt,chip].rootname=expname + "_" + extname + str(extver)


### PR DESCRIPTION
This PR should address the problem of ``drizzlepac`` lowering the case of the path of output products - see https://github.com/spacetelescope/drizzlepac/issues/79 for more details.