### PR TITLE
Add support for user-provided image catalogs in degrees

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -17,13 +17,15 @@ of the list).
 Drizzlepac v2.1.18 (not released)
 =================================
 
-- ``astrodrizzle`` lowers the case of the path of output images.
+- Fixed ``astrodrizzle`` lowers the case of the path of output images issue.
   See https://github.com/spacetelescope/drizzlepac/issues/79 for more
   details.
 
-- ``tweakreg`` ignores user-specified units of image catalogs (provided through
-  the ``refcat`` parameter).
-  See https://github.com/spacetelescope/drizzlepac/issues/81 for more details.
+- Fixed ``tweakreg`` ignores user-specified units of image catalogs (provided
+  through the ``refcat`` parameter) issue. See https://github.com/spacetelescope/drizzlepac/issues/81 for more details.
+
+- Corrected a message printed by tweakreg about used WCS for alignment. Also
+  improved documentation for the ``refimage`` parameter.
 
 DrizzlePac v2.1.17 (13-June-2017)
 =================================

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -17,9 +17,13 @@ of the list).
 Drizzlepac v2.1.18 (not released)
 =================================
 
-- ``drizzlepac`` lowers the case of the path of output images.
+- ``astrodrizzle`` lowers the case of the path of output images.
   See https://github.com/spacetelescope/drizzlepac/issues/79 for more
   details.
+
+- ``tweakreg`` ignores user-specified units of image catalogs (provided through
+  the ``refcat`` parameter).
+  See https://github.com/spacetelescope/drizzlepac/issues/81 for more details.
 
 DrizzlePac v2.1.17 (13-June-2017)
 =================================

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,8 +14,8 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-Drizzlepac v2.1.18 (not released)
-=================================
+Drizzlepac v2.1.18 (05-September-2017)
+======================================
 
 - Fixed ``astrodrizzle`` lowers the case of the path of output images issue.
   See https://github.com/spacetelescope/drizzlepac/issues/79 for more

--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -737,7 +737,7 @@ class UserCatalog(Catalog):
             self.sharp_col = False
 
         if self.pars['xyunits'] == 'degrees':
-            self.radec = (self.xypos[0].copy(), self.xypos[1].copy())
+            self.radec = [self.xypos[0].copy(), self.xypos[1].copy()]
             if self.wcs is not None:
                 self.xypos[:2] = list(self.wcs.all_world2pix(np.array(self.xypos[:2]).T, self.origin).T)
 

--- a/lib/drizzlepac/tweakreg.help
+++ b/lib/drizzlepac/tweakreg.help
@@ -75,6 +75,10 @@ refimage : str (Default = '')
     Filename of reference image. Sources derived from this image will be
     used as the reference for matching with sources from all input images
     unless a separate catalog is provided through the `refcat` parameter.
+    In addition, this image file must contain a valid not distorted WCS that
+    will define the projection plane in which image alignment is performed
+    ("reference WCS"). When ``refimage`` is not provided, a reference WCS
+    will be derived from input images.
 
 expand_refcat : bool (Default = False)
     Specifies whether to add new sources from just matched images to

--- a/lib/drizzlepac/tweakreg.py
+++ b/lib/drizzlepac/tweakreg.py
@@ -24,8 +24,8 @@ from . import util
 # in one location only.
 #
 # This is specifically NOT intended to match the package-wide version information.
-__version__ = '1.4.3'
-__vdate__ = '01-Jul-2016'
+__version__ = '1.4.4'
+__vdate__ = '28-Aug-2017'
 
 from . import tweakutils
 from . import imgclasses

--- a/lib/drizzlepac/tweakreg.py
+++ b/lib/drizzlepac/tweakreg.py
@@ -495,8 +495,8 @@ def run(configobj):
         omitted_images.insert(0, refimg) # refimage *must* be first
         do_match_refimg = True
 
-    print('\n{0}\nAligning all input images to WCS defined by {1}\n{0}\n'
-          .format('='*20, refwcs_fname))
+    print("\n{0}\nPerforming alignment in the projection plane defined by the "
+          "WCS\nderived from '{1}'\n{0}\n".format('='*63, refwcs_fname))
 
     if refimage.outxy is not None:
         if cat_src is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,10 @@ description-file = README
 name = drizzlepac
 author = Megan Sosey, Warren Hack, Christopher Hanley, Chris Sontag, Mihai Cara
 requires-python = >=2.6
-vdate = 13-June-2017
+vdate = 28-August-2017
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 summary = drizzle tools: combines astronomical images, including modeling distortion, removing cosmic rays, and generally improving fidelity of data in the final image
-version = 2.1.17
+version = 2.1.18
 requires-dist =
 	stsci.tools
 	stsci.convolve

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ description-file = README
 name = drizzlepac
 author = Megan Sosey, Warren Hack, Christopher Hanley, Chris Sontag, Mihai Cara
 requires-python = >=2.6
-vdate = 28-August-2017
+vdate = 05-September-2017
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 summary = drizzle tools: combines astronomical images, including modeling distortion, removing cosmic rays, and generally improving fidelity of data in the final image
 version = 2.1.18


### PR DESCRIPTION
TweakReg is ignoring units of user-provided catalogs. Specifically, user-provided catalogs are assumed to be in "pixels" **regardless** of the value of the ``xyunits`` parameters.

This PR adds support for image catalogs with coordinates in degrees.

This bug was first reported by Will Waldron (UAH) who also proposed a solution partially implemented in this PR.

This PR addresses issue https://github.com/spacetelescope/drizzlepac/issues/81