### PR TITLE
Make sure integer division stays integer div in Python 3

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,13 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+DrizzlePac v2.1.19 (29-September-2017)
+======================================
+
+- Fixed a bug in computing optimal order of expanding reference catalog that
+  resulted in code crashes.
+  See https://github.com/spacetelescope/drizzlepac/pull/86 for more details.
+
 Drizzlepac v2.1.18 (05-September-2017)
 ======================================
 

--- a/lib/drizzlepac/tweakreg.py
+++ b/lib/drizzlepac/tweakreg.py
@@ -697,7 +697,7 @@ def _max_overlap_pair(images, expand_refcat, enforce_user_order):
     imgs = [f.name for f in images]
     n = m.shape[0]
     index = m.argmax()
-    i = index / n
+    i = index // n
     j = index % n
     si = np.sum(m[i])
     sj = np.sum(m[:,j])


### PR DESCRIPTION
This bug was reported by Jennifer Mack. When running ``tweakreg`` with ``expand_refcat=True``, the code may crash when trying to ``pop`` an image from a list using a float index. This bug was introduced in [changeset r40216](https://trac.stsci.edu/ssb/stsci_python/changeset/40216/drizzlepac/trunk/lib/drizzlepac/tweakreg.py). The critical change was:
```python
from __future__ import division
```
which resulted integer divisions producing floating point numbers. This resulted in the code crashing at a later point.

This PR modifies the code so that integer division will produce integer results in both Python 2 and 3.

CC: @stsci-hack @bernie-simon 