### PR TITLE
Fix catalog source doubling and catalog filtering

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,21 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+DrizzlePac v2.1.20 (07-October-2017)
+====================================
+
+- Fixed a bug in exanding reference catalog in `tweakreg` that would result
+  in the code crashing.
+  See https://github.com/spacetelescope/drizzlepac/pull/87 for more details.
+
+- Fixed a bug due to which user catalog fluxes would be interpreted as
+  magnitudes when `fluxunits` was set to `'cps'`.
+  See https://github.com/spacetelescope/drizzlepac/pull/88 for more details.
+
+- Fixed a bug due to which user-supplied flux limits were ignored for
+  the reference catalog.
+  See https://github.com/spacetelescope/drizzlepac/pull/89 for more details.
+
 DrizzlePac v2.1.19 (29-September-2017)
 ======================================
 

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -17,7 +17,7 @@ of the list).
 DrizzlePac v2.1.20 (07-October-2017)
 ====================================
 
-- Fixed a bug in exanding reference catalog in `tweakreg` that would result
+- Fixed a bug in expanding reference catalog in `tweakreg` that would result
   in the code crashing.
   See https://github.com/spacetelescope/drizzlepac/pull/87 for more details.
 

--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -306,6 +306,9 @@ class Catalog(object):
         else:
             all_xypos = [xy[flux_mask].copy() for xy in self.xypos]
 
+        nrem = flux_mask.size - np.count_nonzero(flux_mask)
+        print("     Removed {:d} sources based on flux limits.".format(nrem))
+
         if self.nbright is not None:
             print("Selecting catalog based on {} brightest sources".format(self.nbright))
             fluxes = fluxes[flux_mask]

--- a/lib/drizzlepac/imgclasses.py
+++ b/lib/drizzlepac/imgclasses.py
@@ -268,8 +268,8 @@ class Image(object):
         # Build full list of all sky positions from all chips
         self.buildSkyCatalog()
         tsrc = 0 if self.all_radec is None else len(self.all_radec[0])
-        print("===  Found a TOTAL of {:d} objects in image '{:s}'"
-              .format(tsrc, filename))
+        print("===  FINAL number of objects in image '{:s}': {:d}"
+              .format(filename, tsrc))
 
         if self.pars['writecat']:
             catname = self.rootname+"_sky_catalog.coo"
@@ -354,16 +354,15 @@ class Image(object):
             if skycat is not None:
                 ralist.append(skycat[0])
                 declist.append(skycat[1])
-                if len(xycat) > 2:
+                if xycat is not None and len(xycat) > 2:
                     fluxlist.append(xycat[2])
                     idlist.append(xycat[3])
-                if len(skycat) > 2:
+                elif len(skycat) > 2:
                     fluxlist.append(skycat[2])
                     idlist.append(skycat[3])
                 else:
                     fluxlist.append([999.0]*len(skycat[0]))
                     idlist.append(np.arange(len(skycat[0])))
-
 
                 self.all_radec = [np.concatenate(ralist),np.concatenate(declist),
                         np.concatenate(fluxlist),np.concatenate(idlist)]

--- a/lib/drizzlepac/tweakreg.help
+++ b/lib/drizzlepac/tweakreg.help
@@ -16,17 +16,8 @@ file : str or list of str  (Default = ``'*flt.fits'``)
      - filename of an association (ASN)table
      - wild-card specification for files in directory (using ``\*``, ``?`` etc.)
      - comma-separated list of filenames
-     - ``@file`` filelist containing list of desired input filenames
-       (and optional inverse variance map filenames)
-
-    The ``@file`` filelist needs to be provided as an ASCII text file
-    containing a list of filenames for all input images with one
-    filename on each line of the file. If inverse variance maps have
-    also been created by the user and are to be used (by specifying
-    ``IVM`` to the parameter `final_wht_type` described further below),
-    then these are simply provided as a second column in the filelist,
-    with each ``IVM`` filename listed on the same line as a second entry,
-    after its corresponding exposure filename.
+     - ``@file`` filelist containing list of desired input filenames with one
+       filename on each line of the file.
 
 editpars : bool (Default = False)
     A parameter that allows user to edit input parameters by hand in the GUI.
@@ -295,7 +286,6 @@ maxflux : float (Default = None)
     objects with fluxes brighter than the minimum specified in `minflux`
     will be used. If both values are set to `None`, all objects will be used.
 
-
 minflux : float (Default = None)
     Limiting flux value for selecting valid objects in the input image's
     catalog. If specified, this flux value will serve as the lower limit
@@ -303,7 +293,6 @@ minflux : float (Default = None)
     identified in the reference image. If the value is set to `None`, all
     objects fainter than the limit specified by `maxflux` will be used.
     If both values are set to `None`, all objects will be used.
-
 
 fluxunits : str {'counts', 'cps', 'mag'} (Default = 'counts')
     This allows the task to correctly interpret the flux limits specified

--- a/lib/drizzlepac/tweakreg.py
+++ b/lib/drizzlepac/tweakreg.py
@@ -24,8 +24,8 @@ from . import util
 # in one location only.
 #
 # This is specifically NOT intended to match the package-wide version information.
-__version__ = '1.4.4'
-__vdate__ = '28-Aug-2017'
+__version__ = '1.4.5'
+__vdate__ = '7-Oct-2017'
 
 from . import tweakutils
 from . import imgclasses

--- a/lib/drizzlepac/tweakreg.py
+++ b/lib/drizzlepac/tweakreg.py
@@ -227,7 +227,6 @@ def run(configobj):
 
     # Verify that we have the same number of catalog files as input images
     if catnames is not None and (len(catnames) > 0):
-        rcat = configobj['REFERENCE CATALOG DESCRIPTION']['refcat']
         missed_files = []
 
         for f in filenames:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,10 @@ description-file = README
 name = drizzlepac
 author = Megan Sosey, Warren Hack, Christopher Hanley, Chris Sontag, Mihai Cara
 requires-python = >=2.6
-vdate = 05-September-2017
+vdate = 07-October-2017
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 summary = drizzle tools: combines astronomical images, including modeling distortion, removing cosmic rays, and generally improving fidelity of data in the final image
-version = 2.1.18
+version = 2.1.20
 requires-dist =
 	stsci.tools
 	stsci.convolve


### PR DESCRIPTION
This PR addresses several issues in tweakreg stemming from issues reported by Jennifer Mack as described in https://github.com/spacetelescope/drizzlepac/pull/86 and https://github.com/spacetelescope/drizzlepac/issues/87. When researching the code to fix https://github.com/spacetelescope/drizzlepac/issues/87, additional issues have been uncovered as described in https://github.com/spacetelescope/drizzlepac/issues/88 and https://github.com/spacetelescope/drizzlepac/issues/89. 

This PR fixes issues https://github.com/spacetelescope/drizzlepac/issues/87, https://github.com/spacetelescope/drizzlepac/issues/88, and https://github.com/spacetelescope/drizzlepac/issues/89.

In addition, the following code enhancements have been implemented:

1. when `radec` is filtered out, `xypos` member of the `Catalog` class is filtered as well so that both tables contain identical sources. As it was, the code was using `xypos` to display `tweakreg` plots and thus it would display more sources than actually have been used in fitting.
2. `apply_flux_limits` would keep only three columns (ra, dec, flux) in `radec` member after filtering. Now it will carry over the rest of the table columns.
3. fixed an error in the description of the `file` parameter in `tweakreg.help`.
4. notify user that flux filtering is being applied and print flux filtering parameters.