### PR TITLE
Fix unit conversion for combine thresholds

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,15 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+Drizzlepac v2.1.21 (Unreleased)
+===============================
+
+- Fixed a bug in `drizzlepac` due to which user provided `combine_lthresh` or
+  `combine_hthresh` in the `CREATE MEDIAN IMAGE` step were not converted
+  correctly to electrons (processing unit). This bug affected processing of
+  WFPC2, STIS, NICMOS, and WFC3 data. See
+  https://github.com/spacetelescope/drizzlepac/issues/94 for more details.
+
 DrizzlePac v2.1.20 (07-October-2017)
 ====================================
 

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -169,22 +169,22 @@ def _median(imageObjectList, paramDict):
 
         if lthresh is not None and proc_units.lower() == 'native':
             if native_units.lower() == 'counts':
-                lthresh = lthresh * det_gain
+                lthresh *= det_gain
             elif native_units.lower() == 'counts/s':
-                lthresh = lthresh * det_gain * img_exptime
+                lthresh *= det_gain * img_exptime
             elif native_units.lower() == 'electrons/s':
-                lthresh = lthresh * img_exptime
+                lthresh *= img_exptime
             else:
                 raise ValueError("Unexpected native units: '{}'"
                                  .format(native_units))
 
         if hthresh is not None and proc_units.lower() == 'native':
             if native_units.lower().startswith('counts'):
-                hthresh = hthresh * det_gain
+                hthresh *= det_gain
             elif native_units.lower() == 'counts/s':
-                hthresh = hthresh * det_gain * img_exptime
+                hthresh *= det_gain * img_exptime
             elif native_units.lower() == 'electrons/s':
-                hthresh = hthresh * img_exptime
+                hthresh *= img_exptime
             else:
                 raise ValueError("Unexpected native units: '{}'"
                                  .format(native_units))

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -168,16 +168,22 @@ def _median(imageObjectList, paramDict):
         native_units = image.native_units
         if lthresh is not None:
             if proc_units.lower() == 'native':
-                if native_units.lower() == "counts":
+                if native_units.lower() == 'counts':
                     lthresh = lthresh * det_gain
-                    if native_units.lower() == "counts/s":
-                        lthresh = lthresh * img_exptime
+                elif native_units.lower() in ['counts/s', 'electrons/s']:
+                    lthresh = lthresh * img_exptime
+                else:
+                    raise ValueError("Unexpected native units: '{}'"
+                                     .format(native_units))
         if hthresh is not None:
             if proc_units.lower() == 'native':
-                if native_units.lower() == "counts":
+                if native_units.lower() == 'counts':
                     hthresh = hthresh * det_gain
-                    if native_units.lower() == "counts/s":
-                        hthresh = hthresh * img_exptime
+                elif native_units.lower() == ['counts/s', 'electrons/s']:
+                    hthresh = hthresh * img_exptime
+                else:
+                    raise ValueError("Unexpected native units: '{}'"
+                                     .format(native_units))
 
         singleDriz = image.getOutputName("outSingle")
         singleDriz_name = image.outputNames['outSingle']

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -166,28 +166,25 @@ def _median(imageObjectList, paramDict):
         det_gain = image.getGain(1)
         img_exptime = image._image['sci',1]._exptime
         native_units = image.native_units
+        native_units_lc = native_units.lower()
 
-        if lthresh is not None and proc_units.lower() == 'native':
-            if native_units.lower() == 'counts':
-                lthresh *= det_gain
-            elif native_units.lower() == 'counts/s':
-                lthresh *= det_gain * img_exptime
-            elif native_units.lower() == 'electrons/s':
-                lthresh *= img_exptime
-            else:
+        if proc_units.lower() == 'native':
+            if native_units_lc not in ['counts', 'electrons', 'counts/s',
+                                       'electrons/s']:
                 raise ValueError("Unexpected native units: '{}'"
-                                 .format(native_units))
+                                     .format(native_units))
 
-        if hthresh is not None and proc_units.lower() == 'native':
-            if native_units.lower().startswith('counts'):
-                hthresh *= det_gain
-            elif native_units.lower() == 'counts/s':
-                hthresh *= det_gain * img_exptime
-            elif native_units.lower() == 'electrons/s':
-                hthresh *= img_exptime
-            else:
-                raise ValueError("Unexpected native units: '{}'"
-                                 .format(native_units))
+            if lthresh is not None:
+                if native_units_lc.starswith('counts'):
+                    lthresh *= det_gain
+                if native_units_lc.endswith('/s'):
+                    lthresh *= img_exptime
+
+            if hthresh is not None:
+                if native_units_lc.starswith('counts'):
+                    hthresh *= det_gain
+                if native_units_lc.endswith('/s'):
+                    hthresh *= img_exptime
 
         singleDriz = image.getOutputName("outSingle")
         singleDriz_name = image.outputNames['outSingle']

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -175,13 +175,13 @@ def _median(imageObjectList, paramDict):
                                      .format(native_units))
 
             if lthresh is not None:
-                if native_units_lc.starswith('counts'):
+                if native_units_lc.startswith('counts'):
                     lthresh *= det_gain
                 if native_units_lc.endswith('/s'):
                     lthresh *= img_exptime
 
             if hthresh is not None:
-                if native_units_lc.starswith('counts'):
+                if native_units_lc.startswith('counts'):
                     hthresh *= det_gain
                 if native_units_lc.endswith('/s'):
                     hthresh *= img_exptime

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -166,24 +166,28 @@ def _median(imageObjectList, paramDict):
         det_gain = image.getGain(1)
         img_exptime = image._image['sci',1]._exptime
         native_units = image.native_units
-        if lthresh is not None:
-            if proc_units.lower() == 'native':
-                if native_units.lower() == 'counts':
-                    lthresh = lthresh * det_gain
-                elif native_units.lower() in ['counts/s', 'electrons/s']:
-                    lthresh = lthresh * img_exptime
-                else:
-                    raise ValueError("Unexpected native units: '{}'"
-                                     .format(native_units))
-        if hthresh is not None:
-            if proc_units.lower() == 'native':
-                if native_units.lower() == 'counts':
-                    hthresh = hthresh * det_gain
-                elif native_units.lower() == ['counts/s', 'electrons/s']:
-                    hthresh = hthresh * img_exptime
-                else:
-                    raise ValueError("Unexpected native units: '{}'"
-                                     .format(native_units))
+
+        if lthresh is not None and proc_units.lower() == 'native':
+            if native_units.lower() == 'counts':
+                lthresh = lthresh * det_gain
+            elif native_units.lower() == 'counts/s':
+                lthresh = lthresh * det_gain * img_exptime
+            elif native_units.lower() == 'electrons/s':
+                lthresh = lthresh * img_exptime
+            else:
+                raise ValueError("Unexpected native units: '{}'"
+                                 .format(native_units))
+
+        if hthresh is not None and proc_units.lower() == 'native':
+            if native_units.lower().startswith('counts'):
+                hthresh = hthresh * det_gain
+            elif native_units.lower() == 'counts/s':
+                hthresh = hthresh * det_gain * img_exptime
+            elif native_units.lower() == 'electrons/s':
+                hthresh = hthresh * img_exptime
+            else:
+                raise ValueError("Unexpected native units: '{}'"
+                                 .format(native_units))
 
         singleDriz = image.getOutputName("outSingle")
         singleDriz_name = image.outputNames['outSingle']


### PR DESCRIPTION
This PR should address the issue of unit conversion for either `combine_lthresh` or `combine_hthresh` parameters from the `CREATE MEDIAN IMAGE` step - see https://github.com/spacetelescope/drizzlepac/issues/94 for more details.