### PR TITLE
Changes to isolate tweakreg plots from user environment

### DIFF
--- a/lib/drizzlepac/catalogs.py
+++ b/lib/drizzlepac/catalogs.py
@@ -357,12 +357,12 @@ class Catalog(object):
 
         """
         try:
-            from matplotlib import pyplot as pl
+            from matplotlib import pyplot as plt
         except:
-            pl = None
+            plt = None
 
-        if pl is not None: # If the pyplot package could be loaded...
-            pl.clf()
+        if plt is not None: # If the pyplot package could be loaded...
+            plt.clf()
             pars = kwargs.copy()
 
             if 'marker' not in pars:
@@ -382,8 +382,9 @@ class Catalog(object):
                 pl_vmax = pars['vmax']
                 del pars['vmax']
 
-            pl.imshow(self.source,cmap=pl_cmap,vmin=pl_vmin,vmax=pl_vmax)
-            pl.plot(self.xypos[0]-1,self.xypos[1]-1,pars['marker'])
+            plt.imshow(self.source,cmap=pl_cmap,vmin=pl_vmin,vmax=pl_vmax)
+            plt.plot(self.xypos[0]-1,self.xypos[1]-1,pars['marker'])
+            plt.figure() # create new figure for subsequent plots (by user?)
 
     def writeXYCatalog(self,filename):
         """ Write out the X,Y catalog to a file
@@ -740,13 +741,15 @@ class UserCatalog(Catalog):
 
         """
         try:
-            from matplotlib import pyplot as pl
+            from matplotlib import pyplot as plt
         except:
-            pl = None
+            plt = None
 
-        if pl is not None:
-            pl.clf()
-            pl.plot(self.xypos[0],self.xypos[1],**kwargs)
+        if plt is not None:
+            plt.clf()
+            plt.plot(self.xypos[0],self.xypos[1],**kwargs)
+
+            plt.figure()  # create new figure for subsequent plots (by user?)
 
 
 class RefCatalog(UserCatalog):

--- a/lib/drizzlepac/tweakutils.py
+++ b/lib/drizzlepac/tweakutils.py
@@ -783,7 +783,15 @@ def make_vector_plot(coordfile,columns=[1,2,3,4],data=None,figure_id=None,
             Write out plot to a file with this name if specified.
 
     """
+    import matplotlib
     from matplotlib import pyplot as plt
+    interactive = matplotlib.is_interactive()
+    turn_interactive_off = False
+
+    if not interactive:
+        plt.ion()
+        if not interactive:
+            turn_interactive_off = True
 
     if data is None:
         data = readcols(coordfile,cols=columns)
@@ -828,6 +836,7 @@ def make_vector_plot(coordfile,columns=[1,2,3,4],data=None,figure_id=None,
         write_xy_file(output,[xy1x,xy1y,dx,dy])
 
     fig = plt.figure(num=figure_id)
+
     if not append:
         plt.clf()
 
@@ -937,7 +946,11 @@ def make_vector_plot(coordfile,columns=[1,2,3,4],data=None,figure_id=None,
             if suffix[1:] in ['png','pdf','ps','eps','svg']:
                 format=suffix[1:]
         plt.savefig(plotname,format=format)
+    plt.figure(num=figure_id+1)
 
+    if turn_interactive_off:
+        print("Turning interactive off...")
+        plt.ioff()
 
 def apply_db_fit(data,fit,xsh=0.0,ysh=0.0):
     xy1x = data[0]
@@ -1029,7 +1042,11 @@ def plot_zeropoint(pars):
     Pars will be a dictionary containing:
         data, figure_id, vmax, title_str, xp,yp, searchrad
     """
+    import matplotlib
     from matplotlib import pyplot as plt
+    interactive = matplotlib.is_interactive()
+    turn_interactive_off = False
+    turn_interactive_on = False
 
     xp = pars['xp']
     yp = pars['yp']
@@ -1040,8 +1057,12 @@ def plot_zeropoint(pars):
 
     if pars['interactive']:
         plt.ion()
+        if not interactive:
+            turn_interactive_off = True
     else:
         plt.ioff()
+        if interactive:
+            turn_interactive_on = True
 
     a=plt.imshow(pars['data'],vmin=0,vmax=pars['vmax'],interpolation='nearest')
     plt.jet()#gray()
@@ -1064,6 +1085,12 @@ def plot_zeropoint(pars):
                 format=suffix[1:]
         plt.savefig(pars['plotname'],format=format)
 
+    if turn_interactive_on:
+        print("Turning interactive back on...")
+        plt.ion()
+    if turn_interactive_off:
+        print("Turning interactive back off...")
+        plt.ioff()
 
 def build_xy_zeropoint(imgxy,refxy,searchrad=3.0,histplot=False,figure_id=1,
                         plotname=None, interactive=True):


### PR DESCRIPTION
These changes are intended to address the plot interaction plot raised in issue #85.  The changes isolate the interaction with matplotlib inside tweakreg by resetting the matplotlib interactive setting to the starting user value while also creating a new figure upon finishing the plotting.

This combination of changes allowed, under interactive testing using the commands provided in issue #85, to properly render the user plots after tweakreg has completed, regardless of whether tweakreg had 'interactive' turned on or not. 

Additional changes were implemented to simply keep references to the pyplot library consistent within the package.  