### PR TITLE
Undo changes that make exptime set to 1 in single sci images

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,8 +14,12 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-Drizzlepac v2.1.21 (Unreleased)
-===============================
+Drizzlepac v2.1.21 (12-January-2018)
+====================================
+
+- Restore recording of correct ``EXPTIME`` value in the headers of
+  single drizzled ("single_sci") images. See
+  https://github.com/spacetelescope/drizzlepac/issues/93 for more details.
 
 - Fixed a bug in `drizzlepac` due to which user provided `combine_lthresh` or
   `combine_hthresh` in the `CREATE MEDIAN IMAGE` step were not converted

--- a/lib/drizzlepac/outputimage.py
+++ b/lib/drizzlepac/outputimage.py
@@ -134,7 +134,7 @@ class OutputImage:
             _outweight = plist[0]['outSWeight']
             _outcontext = plist[0]['outSContext']
             # Only report values appropriate for single exposure
-            self.texptime = 1.0 # plist[0]['exptime']
+            self.texptime = plist[0]['exptime']
             self.expstart = plist[0]['expstart']
             self.expend = plist[0]['expend']
         else:
@@ -454,7 +454,7 @@ class OutputImage:
             logging.disable(logging.INFO)
             wcs_functions.removeAllAltWCS(fo,wcs_ext)
             logging.disable(logging.NOTSET)
- 
+
             # add table of combined header keyword values to FITS file
             if newtab is not None:
                 fo.append(newtab)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,10 @@ description-file = README
 name = drizzlepac
 author = Megan Sosey, Warren Hack, Christopher Hanley, Chris Sontag, Mihai Cara
 requires-python = >=2.6
-vdate = 07-October-2017
+vdate = 12-January-2018
 home-page = http://www.stsci.edu/resources/software_hardware/stsci_python
 summary = drizzle tools: combines astronomical images, including modeling distortion, removing cosmic rays, and generally improving fidelity of data in the final image
-version = 2.1.20
+version = 2.1.21
 requires-dist =
 	stsci.tools
 	stsci.convolve


### PR DESCRIPTION
This PR undoes changes from  [this github adaptation](https://github.com/spacetelescope/drizzlepac/commit/fa70e27c77c5c9d1224bb15d26268ca5433af1e9#diff-1ec325ef04e8462150c016437086037cR137) due to which `EXPTIME` was set to 1 in "single sci" image headers. Without correct `EXPTIME` it is impossible to convert single sci images from rates to counts. This PR addresses issue https://github.com/spacetelescope/drizzlepac/issues/93