### PR TITLE
Fix sectioning algorithm in Create Median step

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,19 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+Drizzlepac v2.1.22 (not released)
+=================================
+
+- Changed the definition of Megabyte used to describe the size of the buffer
+  for create median step (``combine_bufsize``). Previously a mixed
+  (base-2 and base-10) definition was used with 1MB = 1000x1024B = 1024000B.
+  Now 1MB is defined in base-2 (MiB) as 1MB = 1024x1024B = 1048576B.
+
+- Redesigned the logic in ``createMedian`` step used to split large
+  ``single_sci`` images into smaller chunks: new logic is more straightforward
+  and fixes errors in the old algorithm that resulted in crashes or
+  unnecessarily small chunk sizes that slowed down ``createMedian`` step.
+
 Drizzlepac v2.1.21 (12-January-2018)
 ====================================
 

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -27,6 +27,12 @@ Drizzlepac v2.1.22 (not released)
   and fixes errors in the old algorithm that resulted in crashes or
   unnecessarily small chunk sizes that slowed down ``createMedian`` step.
 
+- Due to the above mentioned redesign in the logic for splitting large images
+  into smaller chunks, now `overlap` can be set to 0 if so desired in the
+  ``minmed`` combine type. Also, it is automatically ignored (set to 0) for all
+  non-``minmed`` combine types. This will result in additional speed-up in the
+  Create Median step.
+
 Drizzlepac v2.1.21 (12-January-2018)
 ====================================
 

--- a/lib/drizzlepac/createMedian.help
+++ b/lib/drizzlepac/createMedian.help
@@ -100,7 +100,9 @@ combine_grow : int (Default = 1)
     Width, in pixels, beyond the limit set by the rejection algorithm being
     used, for additional pixels to be rejected in an image. This parameter
     is used to set the 'grow' parameter in 'imcombine' for use in creating
-    the median image.
+    the median image **only when** ``combine_type`` is ``'(i)minmed'``.
+    When ``combine_type`` is anything other than ``'(i)minmed'``, this
+    parameter is ignored (set to 0).
 
 
 combine_bufsize : float (Default = None)

--- a/lib/drizzlepac/createMedian.help
+++ b/lib/drizzlepac/createMedian.help
@@ -97,11 +97,19 @@ combine_hthresh : float (Default = INDEF)
 
 
 combine_grow : int (Default = 1)
-    Width, in pixels, beyond the limit set by the rejection algorithm being used, for additional pixels to be rejected in an image. This parameter is used to set the 'grow' parameter in 'imcombine' for use in creating the median image.
+    Width, in pixels, beyond the limit set by the rejection algorithm being
+    used, for additional pixels to be rejected in an image. This parameter
+    is used to set the 'grow' parameter in 'imcombine' for use in creating
+    the median image.
 
 
 combine_bufsize : float (Default = None)
-    Size of buffer, in Mb, to use when reading in each section of each input image.  The default buffer size is 1Mb.  The larger the buffer size, the fewer times the code needs to open each input image and the more memory will be required to create the median image.  A larger buffer can be helpful when using compression, since slower copies need to be made of each set of rows from each input image instead of using memory-mapping.
+    Size of buffer, in MB (MiB), to use when reading in each section of each
+    input image. The default buffer size is 1MB. The larger the buffer size,
+    the fewer times the code needs to open each input image and the more memory
+    will be required to create the median image. A larger buffer can be
+    helpful when using compression, since slower copies need to be made of
+    each set of rows from each input image instead of using memory-mapping.
 
 
 Examples

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -298,7 +298,7 @@ def _median(imageObjectList, paramDict):
     # create an array for the median output image, use the size of the first
     # image in the list. Store other useful image characteristics:
     single_driz_data = singleDrizList[0].data
-    single_driz_data_size = single_driz_data.itemsize
+    data_item_size = single_driz_data.itemsize
     imrows, imcols = single_driz_data.shape
 
     medianImageArray = np.zeros_like(single_driz_data)
@@ -316,12 +316,11 @@ def _median(imageObjectList, paramDict):
     # has enough rows to span the kernel used in the boxcar method
     # within minmed.
     overlap = 2 * grow
-    buffsize = BUFSIZE if bufsizeMb is None else (BUFSIZE * bufsizeMb)
-    section_nrows = max(imrows,
-                        int(buffsize / (imcols * single_driz_data_size)))
+    buffsize = BUFSIZE if bufsizeMB is None else (BUFSIZE * bufsizeMB)
+    section_nrows = min(imrows, int(buffsize / (imcols * data_item_size)))
 
     if section_nrows == 0:
-        buffsize = imcols * single_driz_data_size
+        buffsize = imcols * data_item_size
         print("WARNING: Buffer size is too small to hold a single row.\n"
               "         Buffer size size will be increased to minimal "
               "required: {}MB".format(float(buffsize) / 1048576.0))

--- a/lib/drizzlepac/createMedian.py
+++ b/lib/drizzlepac/createMedian.py
@@ -1,23 +1,25 @@
 """
 Create a median image from the singly drizzled images.
 
-:Authors: Warren Hack
+:Authors: Warren Hack, Mihai Cara
 
 :License: `<http://www.stsci.edu/resources/software_hardware/pyraf/LICENSE>`_
 
 """
 
 # Import external packages
-from __future__ import absolute_import, division, print_function # confidence medium
+from __future__ import (absolute_import, division, unicode_literals,
+                        print_function)
 
+import os
 import sys
+import math
 import numpy as np
 from astropy.io import fits
-import os, math
 
 from stsci.imagestats import ImageStats
 from stsci.image import numcombine
-from stsci.tools import iterfile, nimageiter, teal, logutil
+from stsci.tools import iterfile, teal, logutil
 
 from . import imageObject
 from . import util
@@ -25,21 +27,22 @@ from .minmed import minmed
 from . import processInput
 from .adrizzle import _single_step_num_
 
-
 from .version import *
 
-__taskname__= "drizzlepac.createMedian" #looks in drizzlepac for createMedian.cfg
-_step_num_ = 4  #this relates directly to the syntax in the cfg file
+# look in drizzlepac for createMedian.cfg:
+__taskname__ = "drizzlepac.createMedian"
+_step_num_ = 4  # this relates directly to the syntax in the cfg file
+
+BUFSIZE = 1024*1024   # 1MB cache size
 
 log = logutil.create_logger(__name__)
 
 
-#this is the user access function
+# this is the user access function
 def median(input=None, configObj=None, editpars=False, **inputDict):
     """
     Create a median image from the seperately drizzled images.
     """
-
     if input is not None:
         inputDict["input"] = input
     else:
@@ -54,21 +57,24 @@ def median(input=None, configObj=None, editpars=False, **inputDict):
         run(configObj)
 
 
-#this is the function that will be called from TEAL
+# this is the function that will be called from TEAL
 def run(configObj):
+    imgObjList, outwcs = processInput.setCommonInput(
+        configObj,
+        createOutwcs=False
+    )  # outwcs is not needed here
+    createMedian(imgObjList, configObj)
 
-    imgObjList,outwcs = processInput.setCommonInput(configObj,createOutwcs=False) #outwcs is not needed here
 
-    createMedian(imgObjList,configObj)
+# ###################################################
+# ## Top-level interface from inside AstroDrizzle  ##
+# ###################################################
+def createMedian(imgObjList, configObj, procSteps=None):
+    """ Top-level interface to createMedian step called from top-level
+    AstroDrizzle.
 
-#
-#### Top-level interface from inside MultiDrizzle
-#
-def createMedian(imgObjList,configObj,procSteps=None):
-    """ Top-level interface to createMedian step called from top-level MultiDrizzle.
-
-    This function parses the input parameters then calls the `_median()` function
-    to median-combine the input images into a single image.
+    This function parses the input parameters then calls the `_median()`
+    function to median-combine the input images into a single image.
 
     """
     if imgObjList is None:
@@ -79,16 +85,16 @@ def createMedian(imgObjList,configObj,procSteps=None):
     if procSteps is not None:
         procSteps.addStep('Create Median')
 
-    step_name = util.getSectionName(configObj,_step_num_)
+    step_name = util.getSectionName(configObj, _step_num_)
     if not configObj[step_name]['median']:
         log.info('Median combination step not performed.')
         return
 
-    paramDict=configObj[step_name]
+    paramDict = configObj[step_name]
     paramDict['proc_unit'] = configObj['proc_unit']
 
     # include whether or not compression was performed
-    driz_sep_name = util.getSectionName(configObj,_single_step_num_)
+    driz_sep_name = util.getSectionName(configObj, _single_step_num_)
     driz_sep_paramDict = configObj[driz_sep_name]
     paramDict['compress'] = driz_sep_paramDict['driz_sep_compress']
 
@@ -106,24 +112,21 @@ def _median(imageObjectList, paramDict):
     """Create a median image from the list of image Objects
        that has been given.
     """
-
     newmasks = paramDict['median_newmasks']
-    comb_type = paramDict['combine_type']
+    comb_type = paramDict['combine_type'].lower()
     nlow = paramDict['combine_nlow']
     nhigh = paramDict['combine_nhigh']
-    grow = paramDict['combine_grow']
+    grow = paramDict['combine_grow'] if 'minmed' in comb_type else 0
     maskpt = paramDict['combine_maskpt']
     proc_units = paramDict['proc_unit']
     compress = paramDict['compress']
-    bufsizeMb = paramDict['combine_bufsize']
+    bufsizeMB = paramDict['combine_bufsize']
 
-    sigma=paramDict["combine_nsigma"]
-    sigmaSplit=sigma.split()
+    sigma = paramDict["combine_nsigma"]
+    sigmaSplit = sigma.split()
     nsigma1 = float(sigmaSplit[0])
     nsigma2 = float(sigmaSplit[1])
 
-    #print "Checking parameters:"
-    #print comb_type,nlow,nhigh,grow,maskpt,nsigma1,nsigma2
     if paramDict['combine_lthresh'] is None:
         lthresh = None
     else:
@@ -134,37 +137,35 @@ def _median(imageObjectList, paramDict):
     else:
         hthresh = float(paramDict['combine_hthresh'])
 
-    #the name of the output median file isdefined in the output wcs object
-    #and stuck in the image.outputValues["outMedian"] dict of every imageObject
-    medianfile=imageObjectList[0].outputNames["outMedian"]
+    # the name of the output median file isdefined in the output wcs object and
+    # stuck in the image.outputValues["outMedian"] dict of every imageObject
+    medianfile = imageObjectList[0].outputNames["outMedian"]
 
+    # Build combined array from single drizzled images.
 
-    """ Builds combined array from single drizzled images."""
     # Start by removing any previous products...
-    if(os.access(medianfile,os.F_OK)):
+    if os.access(medianfile, os.F_OK):
         os.remove(medianfile)
 
-
-    # Define lists for instrument specific parameters, these should be in the image objects
-    # need to be passed to the minmed routine
+    # Define lists for instrument specific parameters, these should be in
+    # the image objects need to be passed to the minmed routine
     readnoiseList = []
     exposureTimeList = []
-    backgroundValueList = [] #list of  MDRIZSKY *platescale values
-    singleDrizList=[] #these are the input images
-    singleWeightList=[] #pointers to the data arrays
-    #skylist=[] #the list of platescale values for the images
-    _wht_mean = [] # Compute the mean value of each wht image
+    backgroundValueList = []  # list of  MDRIZSKY *platescale values
+    singleDrizList = []  # these are the input images
+    singleWeightList = []  # pointers to the data arrays
+    wht_mean = []  # Compute the mean value of each wht image
 
-    _single_hdr = None
+    single_hdr = None
     virtual = None
 
-    #for each image object
+    # for each image object
     for image in imageObjectList:
         if virtual is None:
             virtual = image.inmemory
 
         det_gain = image.getGain(1)
-        img_exptime = image._image['sci',1]._exptime
+        img_exptime = image._image['sci', 1]._exptime
         native_units = image.native_units
         native_units_lc = native_units.lower()
 
@@ -172,7 +173,7 @@ def _median(imageObjectList, paramDict):
             if native_units_lc not in ['counts', 'electrons', 'counts/s',
                                        'electrons/s']:
                 raise ValueError("Unexpected native units: '{}'"
-                                     .format(native_units))
+                                 .format(native_units))
 
             if lthresh is not None:
                 if native_units_lc.startswith('counts'):
@@ -190,8 +191,6 @@ def _median(imageObjectList, paramDict):
         singleDriz_name = image.outputNames['outSingle']
         singleWeight = image.getOutputName("outSWeight")
         singleWeight_name = image.outputNames['outSWeight']
-        #singleDriz=image.outputNames["outSingle"] #all chips are drizzled to a single output image
-        #singleWeight=image.outputNames["outSWeight"]
 
         # If compression was used, reference ext=1 as CompImageHDU only writes
         # out MEF files, not simple FITS.
@@ -201,8 +200,9 @@ def _median(imageObjectList, paramDict):
         else:
             wcs_ext = '[0]'
             wcs_extnum = 0
+
         if not virtual:
-            if isinstance(singleDriz,str):
+            if isinstance(singleDriz, str):
                 iter_singleDriz = singleDriz + wcs_ext
                 iter_singleWeight = singleWeight + wcs_ext
             else:
@@ -212,46 +212,49 @@ def _median(imageObjectList, paramDict):
             iter_singleDriz = singleDriz_name + wcs_ext
             iter_singleWeight = singleWeight_name + wcs_ext
 
-        # read in WCS from first single drizzle image to use as WCS for median image
-        if _single_hdr is None:
+        # read in WCS from first single drizzle image to use as WCS for
+        # median image
+        if single_hdr is None:
             if virtual:
-                _single_hdr = singleDriz[wcs_extnum].header
+                single_hdr = singleDriz[wcs_extnum].header
             else:
-                _single_hdr = fits.getheader(singleDriz_name, ext=wcs_extnum, memmap=False)
+                single_hdr = fits.getheader(singleDriz_name, ext=wcs_extnum,
+                                            memmap=False)
 
-        _singleImage=iterfile.IterFitsFile(iter_singleDriz)
+        single_image = iterfile.IterFitsFile(iter_singleDriz)
         if virtual:
-            _singleImage.handle = singleDriz
-            _singleImage.inmemory = True
+            single_image.handle = singleDriz
+            single_image.inmemory = True
 
-        singleDrizList.append(_singleImage) #add to an array for bookkeeping
+        singleDrizList.append(single_image)  # add to an array for bookkeeping
 
         # If it exists, extract the corresponding weight images
-        if (not virtual and os.access(singleWeight,os.F_OK)) or (
+        if (not virtual and os.access(singleWeight, os.F_OK)) or (
                 virtual and singleWeight):
-            _weight_file=iterfile.IterFitsFile(iter_singleWeight)
+            weight_file = iterfile.IterFitsFile(iter_singleWeight)
             if virtual:
-                _weight_file.handle = singleWeight
-                _weight_file.inmemory = True
+                weight_file.handle = singleWeight
+                weight_file.inmemory = True
 
-            singleWeightList.append(_weight_file)
+            singleWeightList.append(weight_file)
             try:
-                tmp_mean_value = ImageStats(_weight_file.data, lower=1e-8,
-                    fields="mean", nclip=0).mean
+                tmp_mean_value = ImageStats(weight_file.data, lower=1e-8,
+                                            fields="mean", nclip=0).mean
             except ValueError:
                 tmp_mean_value = 0.0
-            _wht_mean.append(tmp_mean_value * maskpt)
+            wht_mean.append(tmp_mean_value * maskpt)
 
             # Extract instrument specific parameters and place in lists
 
             # If an image has zero exposure time we will
-            # redefine that value as '1'.  Although this will cause inaccurate scaling
-            # of the data to occur in the 'minmed' combination algorith, this is a
-            # necessary evil since it avoids divide by zero exceptions.  It is more
-            # important that the divide by zero exceptions not cause Multidrizzle to
-            # crash in the pipeline than it is to raise an exception for this obviously
-            # bad data even though this is not the type of data you would wish to process
-            # with Multidrizzle.
+            # redefine that value as '1'.  Although this will cause inaccurate
+            # scaling of the data to occur in the 'minmed' combination
+            # algorith, this is a necessary evil since it avoids divide by
+            # zero exceptions.  It is more important that the divide by zero
+            # exceptions not cause AstroDrizzle to crash in the pipeline than
+            # it is to raise an exception for this obviously bad data even
+            # though this is not the type of data you would wish to process
+            # with AstroDrizzle.
             #
             # Get the exposure time from the InputImage object
             #
@@ -264,17 +267,18 @@ def _median(imageObjectList, paramDict):
 
             # Use only "commanded" chips to extract subtractedSky and rdnoise:
             rdnoise = 0.0
-            nchips  = 0
-            bsky    = None # minimum sky across **used** chips
+            nchips = 0
+            bsky = None  # minimum sky across **used** chips
 
             for chip in image.returnAllChips(extname=image.scienceExt):
-                # compute sky value as sky/pixel using the single_drz pixel scale
+                # compute sky value as sky/pixel using the single_drz
+                # pixel scale:
                 if bsky is None or bsky > chip.subtractedSky:
                     bsky = chip.subtractedSky * chip._conversionFactor
 
                 # Extract the readnoise value for the chip
-                rdnoise += (chip._rdnoise)**2
-                nchips  += 1
+                rdnoise += chip._rdnoise**2
+                nchips += 1
 
             if bsky is None:
                 bsky = 0.0
@@ -285,203 +289,167 @@ def _median(imageObjectList, paramDict):
             backgroundValueList.append(bsky)
             readnoiseList.append(rdnoise)
 
-            ## compute sky value as sky/pixel using the single_drz pixel scale
-            #bsky = image._image[image.scienceExt,1].subtractedSky# * (image.outputValues['scale']**2)
-            #backgroundValueList.append(bsky)
-
-            ## Extract the readnoise value for the chip
-            #sci_chip = image._image[image.scienceExt,1]
-            #readnoiseList.append(sci_chip._rdnoise) #verify this is calculated correctly in the image object
-
-            print("reference sky value for image ",image._filename," is ", backgroundValueList[-1])
+            print("reference sky value for image '{}' is "
+                  .format(image._filename, backgroundValueList[-1]))
         #
         # END Loop over input image list
         #
 
-    # create an array for the median output image, use the size of the first image in the list
-    medianImageArray = np.zeros(singleDrizList[0].shape,dtype=singleDrizList[0].type())
+    # create an array for the median output image, use the size of the first
+    # image in the list. Store other useful image characteristics:
+    single_driz_data = singleDrizList[0].data
+    single_driz_data_size = single_driz_data.itemsize
+    imrows, imcols = single_driz_data.shape
 
-    if ( comb_type.lower() == "minmed") and not newmasks:
+    medianImageArray = np.zeros_like(single_driz_data)
+
+    del single_driz_data
+
+    if comb_type == "minmed" and not newmasks:
         # Issue a warning if minmed is being run with newmasks turned off.
-            print('\nWARNING: Creating median image without the application of bad pixel masks!\n')
+        print('\nWARNING: Creating median image without the application of '
+              'bad pixel masks!\n')
 
-    # create the master list to be used by the image iterator
-    masterList = []
-    masterList.extend(singleDrizList)
-    masterList.extend(singleWeightList)
-
-    print('\n')
-
-    # Specify the location of the drz image sections
-    startDrz = 0
-    endDrz = len(singleDrizList)+startDrz
-
-    # Specify the location of the wht image sections
-    startWht = len(singleDrizList)+startDrz
-    endWht = startWht + len(singleWeightList)
-    _weight_mask_list = None
-
-    # Fire up the image iterator
-    #
     # The overlap value needs to be set to 2*grow in order to
     # avoid edge effects when scrolling down the image, and to
     # insure that the last section returned from the iterator
-    # has enough row to span the kernel used in the boxcar method
+    # has enough rows to span the kernel used in the boxcar method
     # within minmed.
-    _overlap = 2*int(grow)
+    overlap = 2 * grow
+    buffsize = BUFSIZE if bufsizeMb is None else (BUFSIZE * bufsizeMb)
+    section_nrows = max(imrows,
+                        int(buffsize / (imcols * single_driz_data_size)))
 
-    #Start by computing the buffer size for the iterator
-    _imgarr = masterList[0].data
-    _bufsize = nimageiter.BUFSIZE
-    if bufsizeMb is not None:
-        _bufsize *= bufsizeMb
-    _imgrows = _imgarr.shape[0]
-    _nrows = nimageiter.computeBuffRows(_imgarr)
-#        _overlaprows = _nrows - (_overlap+1)
-#        _niter = int(_imgrows/_nrows)
-#        _niter = 1 + int( (_imgrows - _overlaprows)/_nrows)
-    niter = nimageiter.computeNumberBuff(_imgrows,_nrows,_overlap)
-    #computeNumberBuff actually returns (niter,buffrows)
-    _niter= niter[0]
-    _nrows = niter[1]
-    _lastrows = _imgrows - (_niter*(_nrows-_overlap))
+    if section_nrows == 0:
+        buffsize = imcols * single_driz_data_size
+        print("WARNING: Buffer size is too small to hold a single row.\n"
+              "         Buffer size size will be increased to minimal "
+              "required: {}MB".format(float(buffsize) / 1048576.0))
+        section_nrows = 1
 
-    # check to see if this buffer size will leave enough rows for
-    # the section returned on the last iteration
-    if _lastrows < _overlap+1:
-        _delta_rows = (_overlap+1 - _lastrows)//_niter
-        if _delta_rows < 1 and _delta_rows >= 0: _delta_rows = 1
-        _bufsize += (_imgarr.shape[1]*_imgarr.itemsize) * _delta_rows
+    if section_nrows < overlap + 1:
+        new_grow = int((section_nrows - 1) / 2)
+        if section_nrows == imrows:
+            print("'grow' parameter is too large for actual image size. "
+                  "Reducing 'grow' to {}".format(new_grow))
+        else:
+            print("'grow' parameter is too large for requested buffer size. "
+                  "Reducing 'grow' to {}".format(new_grow))
+        grow = new_grow
+        overlap = 2 * grow
 
-    if not virtual:
-        masterList[0].close()
-    del _imgarr
+    nbr = section_nrows - overlap
+    nsec = (imrows - overlap) // nbr
+    if (imrows - overlap) % nbr > 0:
+        nsec += 1
 
-    for imageSectionsList,prange in nimageiter.FileIter(masterList,overlap=_overlap,bufsize=_bufsize):
+    for k in range(nsec):
+        e1 = k * nbr
+        e2 = e1 + section_nrows
+        u1 = grow
+        u2 = u1 + nbr
 
-        if newmasks:
-            """ Build new masks from single drizzled images. """
-            _weight_mask_list = []
-            listIndex = 0
-            for _weight_arr in imageSectionsList[startWht:endWht]:
-                # Initialize an output mask array to ones
-                # This array will be reused for every output weight image
-                _weight_mask = np.zeros(_weight_arr.shape,dtype=np.uint8)
+        if k == 0:  # first section
+            u1 = 0
 
-                """ Generate new pixel mask file for median step.
-                This mask will be created from the single-drizzled
-                weight image for this image.
+        if k == nsec - 1:  # last section
+            e2 = min(e2, imrows)
+            e1 = min(e1, e2 - overlap - 1)
+            u2 = e2 - e1
 
-                The mean of the weight array will be computed and all
-                pixels with values less than 0.7 of the mean will be flagged
-                as bad in this mask.  This mask will then be used when
-                creating the median image.
-                """
+        imdrizSectionsList = [w[e1:e2] for w in singleDrizList]
+        weightSectionsList = [w[e1:e2] for w in singleWeightList]
+        weight_mask_list = None
+
+        if newmasks and weightSectionsList:
+            # Build new masks from single drizzled images.
+            weight_mask_list = []
+
+            for listIndex, weight_arr in enumerate(weightSectionsList):
+                # Generate new pixel mask file for median step.
+                # This mask will be created from the single-drizzled
+                # weight image for this image.
+
+                # The mean of the weight array will be computed and all
+                # pixels with values less than 0.7 of the mean will be flagged
+                # as bad in this mask.  This mask will then be used when
+                # creating the median image.
+
                 # Compute image statistics
-                _mean = _wht_mean[listIndex]
+                mean = wht_mean[listIndex]
 
                 # 0 means good, 1 means bad here...
-                np.putmask(_weight_mask, np.less(_weight_arr,_mean), 1)
-                #_weight_mask.info()
-                _weight_mask_list.append(_weight_mask)
-                listIndex += 1
+                weight_mask_list.append(
+                    np.less(weight_arr, mean).astype(np.uint8)
+                )
 
         # Do MINMED
-        if ( "minmed" in comb_type.lower()):
-            if comb_type.lower()[0] == 'i':
-                # set up use of 'imedian'/'imean' in minmed algorithm
-                fillval = True
-            else:
-                fillval = False
-
-            if (_weight_mask_list in [None,[]]):
-                _weight_mask_list = None
+        if 'minmed' in comb_type:
+            # set up use of 'imedian'/'imean' in minmed algorithm
+            fillval = comb_type.startswith('i')
 
             # Create the combined array object using the minmed algorithm
-            result = minmed(imageSectionsList[startDrz:endDrz],  # list of input data to be combined.
-                                imageSectionsList[startWht:endWht],# list of input data weight images to be combined.
-                                readnoiseList,                         # list of readnoise values to use for the input images.
-                                exposureTimeList,                      # list of exposure times to use for the input images.
-                                backgroundValueList,                   # list of image background values to use for the input images
-                                weightMaskList = _weight_mask_list,  # list of imput data weight masks to use for pixel rejection.
-                                combine_grow = grow,                   # Radius (pixels) for neighbor rejection
-                                combine_nsigma1 = nsigma1,             # Significance for accepting minimum instead of median
-                                combine_nsigma2 = nsigma2,              # Significance for accepting minimum instead of median
-                                fillval=fillval                      # turn on use of imedian/imean
-                            )
-#              medianOutput[prange[0]:prange[1],:] = result.out_file1
-#             minOutput[prange[0]:prange[1],:] = result.out_file2
+            result = minmed(
+                imdrizSectionsList,
+                weightSectionsList,
+                readnoiseList,
+                exposureTimeList,
+                backgroundValueList,
+                weightMaskList=weight_mask_list,
+                combine_grow=grow,
+                combine_nsigma1=nsigma1,
+                combine_nsigma2=nsigma2,
+                fillval=fillval
+            ).combArrObj
 
         # DO NUMCOMBINE
         else:
             # Create the combined array object using the numcombine task
-            result = numcombine.numCombine(imageSectionsList[startDrz:endDrz],
-                                    numarrayMaskList=_weight_mask_list,
-                                    combinationType=comb_type.lower(),
-                                    nlow=nlow,
-                                    nhigh=nhigh,
-                                    upper=hthresh,
-                                    lower=lthresh
-                                )
+            result = numcombine.numCombine(
+                imdrizSectionsList,
+                numarrayMaskList=weight_mask_list,
+                combinationType=comb_type,
+                nlow=nlow,
+                nhigh=nhigh,
+                upper=hthresh,
+                lower=lthresh
+            ).combArrObj
 
-        # We need to account for any specified overlap when writing out
-        # the processed image sections to the final output array.
-        if prange[1] != _imgrows:
-            medianImageArray[prange[0]:prange[1]-_overlap,:] = result.combArrObj[:-_overlap,:]
-        else:
-            medianImageArray[prange[0]:prange[1],:] = result.combArrObj
-
-
-    del result
-    del _weight_mask_list
-    _weight_mask_list = None
+        # Write out the processed image sections to the final output array:
+        medianImageArray[e1+u1:e1+u2, :] = result[u1:u2, :]
 
     # Write out the combined image
     # use the header from the first single drizzled image in the list
-    #header=fits.getheader(imageObjectList[0].outputNames["outSingle"])
-    _pf = _writeImage(medianImageArray, inputHeader=_single_hdr)
+    pf = _writeImage(medianImageArray, inputHeader=single_hdr)
 
     if virtual:
         mediandict = {}
-        mediandict[medianfile] = _pf
+        mediandict[medianfile] = pf
         for img in imageObjectList:
             img.saveVirtualOutputs(mediandict)
     else:
         try:
-            print("Saving output median image to: ",medianfile)
-            _pf.writeto(medianfile)
+            print("Saving output median image to: '{}'".format(medianfile))
+            pf.writeto(medianfile)
         except IOError:
-            msg = "Problem writing file: "+medianfile
+            msg = "Problem writing file '{}'".format(medianfile)
             print(msg)
             raise IOError(msg)
-
-    del _pf
 
     # Always close any files opened to produce median image; namely,
     # single drizzle images and singly-drizzled weight images
     #
-
     for img in singleDrizList:
         if not virtual:
             img.close()
-    singeDrizList = []
 
     # Close all singly drizzled weight images used to create median image.
     for img in singleWeightList:
         if not virtual:
             img.close()
-    singleWeightList = []
 
-    # If new median masks was turned on, close those files
-    if _weight_mask_list:
-        for arr in _weight_mask_list:
-            del arr
-        _weight_mask_list = None
 
-    del masterList
-    del medianImageArray
-
-def _writeImage( dataArray=None, inputHeader=None):
+def _writeImage(dataArray=None, inputHeader=None):
     """ Writes out the result of the combination step.
         The header of the first 'outsingle' file in the
         association parlist is used as the header of the
@@ -496,25 +464,10 @@ def _writeImage( dataArray=None, inputHeader=None):
             fits.header.Header object to use as basis for the PrimaryHDU header
 
     """
-
-    #_fname =inputFilename
-    #_file = fits.open(_fname, mode='readonly')
-    #_prihdu = fits.PrimaryHDU(header=_file[0].header,data=dataArray)
-
-    _prihdu = fits.PrimaryHDU(data=dataArray, header=inputHeader)
-    """
-    if inputHeader is None:
-        #use a general primary HDU
-        _prihdu = fits.PrimaryHDU(data=dataArray)
-
-    else:
-        _prihdu = inputHeader
-        _prihdu.data=dataArray
-    """
-    _pf = fits.HDUList()
-    _pf.append(_prihdu)
-
-    return _pf
+    prihdu = fits.PrimaryHDU(data=dataArray, header=inputHeader)
+    pf = fits.HDUList()
+    pf.append(prihdu)
+    return pf
 
 
 def help(file=None):
@@ -529,17 +482,18 @@ def help(file=None):
         writing out the help.
 
     """
-    helpstr = getHelpAsString(docstring=True, show_ver = True)
+    helpstr = getHelpAsString(docstring=True, show_ver=True)
     if file is None:
         print(helpstr)
     else:
-        if os.path.exists(file): os.remove(file)
-        f = open(file, mode = 'w')
+        if os.path.exists(file):
+            os.remove(file)
+        f = open(file, mode='w')
         f.write(helpstr)
         f.close()
 
 
-def getHelpAsString(docstring = False, show_ver = True):
+def getHelpAsString(docstring=False, show_ver=True):
     """
     return useful help from a file in the script directory called
     __taskname__.help
@@ -554,18 +508,20 @@ def getHelpAsString(docstring = False, show_ver = True):
         if show_ver:
             helpString = os.linesep + \
                 ' '.join([__taskname__, 'Version', __version__,
-                ' updated on ', __vdate__]) + 2*os.linesep
+                          ' updated on ', __vdate__]) + 2*os.linesep
         else:
             helpString = ''
+
         if os.path.exists(helpfile):
             helpString += teal.getHelpFileAsString(taskname, __file__)
         else:
             if __doc__ is not None:
                 helpString += __doc__ + os.linesep
+
     else:
         helpString = 'file://' + htmlfile
 
     return helpString
 
 
-median.__doc__ = getHelpAsString(docstring = True, show_ver = False)
+median.__doc__ = getHelpAsString(docstring=True, show_ver=False)


### PR DESCRIPTION
This PR fixes issues https://github.com/spacetelescope/drizzlepac/issues/102 and https://github.com/spacetelescope/drizzlepac/issues/103 by providing a completely redesigned algorithm for splitting `single_sci` images into smaller chunks according to user-specified buffer size. The new algorithm is much more simple than previous algorithm and does not depend  `stsci.tools.nimageiter` module anymore [which should be removed from `stsci.tools`].

I run several tests on Jennifer Mack's data and also on some other (WFPC2) data with varying settings for buffer size and overlap size and everything seems to work as expected.