### PR TITLE
Add skypac as dependency of drizzlepac

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ requires-dist =
 	stsci.imagemanip
 	stsci.imagestats
 	stsci.ndimage
+	stsci.skypac
 	stsci.stimage
 	nictools
 	stwcs (>=1.1.9)


### PR DESCRIPTION
Add `stsci.skypac` as dependency of `drizzlepac` - see https://github.com/spacetelescope/drizzlepac/issues/105