### PR TITLE
Fix a bug in computation of readnoise_file in minmed

### DIFF
--- a/lib/drizzlepac/minmed.py
+++ b/lib/drizzlepac/minmed.py
@@ -515,9 +515,13 @@ def min_med(images, weight_images, readnoise_list, exptime_list,
     if weight_masks is None:
         rdn2 = sum((r**2 for r in readnoise_list))
         readnoise_file = rdn2 * np.ones_like(images[0])
+
     else:
-        readnoise_file = np.sum(np.logical_not(weight_masks) *
-                                (np.asarray(readnoise_list)**2)[:, None, None])
+        readnoise_file = np.sum(
+            np.logical_not(weight_masks) *
+            (np.asarray(readnoise_list)**2)[:, None, None],
+            axis=0
+        )
 
     # Create an image of the total effective exposure time per pixel:
     # (which is simply the sum of all the drizzle output weight files)


### PR DESCRIPTION
Fixes a small mistake in updated 'minmed' code with large consequences for the create median step. This resulted in multiple regression tests failing.

With fixed code, there are still small differences in some tests (~400 pixels). So, I still expect drizzlepac tests to fail but I may OKify them if the number of differences is small.