### PR TITLE
Make astrodrizzle and tweakreg load defaults from package instead of user's local .teal

### DIFF
--- a/lib/drizzlepac/astrodrizzle.py
+++ b/lib/drizzlepac/astrodrizzle.py
@@ -87,8 +87,11 @@ def AstroDrizzle(input=None, mdriztab=False, editpars=False, configobj=None,
             raise RuntimeError('Cannot find .cfg file: '+configobj)
         configobj = teal.load(configobj, strict=False)
 
-    if configobj is None or configobj == 'defaults':
+    if configobj is None:
         configobj = teal.load(__taskname__)
+
+    elif configobj == 'defaults':
+        configobj = teal.load(__taskname__, defaults=True)
 
     if 'updatewcs' in input_dict: # user trying to explicitly turn on updatewcs
         configobj['updatewcs'] = input_dict['updatewcs']

--- a/lib/drizzlepac/tweakreg.py
+++ b/lib/drizzlepac/tweakreg.py
@@ -771,12 +771,14 @@ def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
 
     # Get default or user-specified configobj for primary task
     if isinstance(configobj, str):
-        if not os.path.exists(configobj):
+        if configobj == 'defaults':
+            configobj = teal.load(__taskname__, defaults=True)
+        elif not os.path.exists(configobj):
             print('Cannot find .cfg file: '+configobj)
-            return
-        configobj = teal.load(configobj, strict=False)
+        else:
+            configobj = teal.load(configobj, strict=False)
 
-    if configobj is None:
+    elif configobj is None:
         configobj = teal.load(__taskname__)
 
     if 'updatewcs' in input_dict: # user trying to explicitly turn on updatewcs


### PR DESCRIPTION
This PR adresses https://github.com/spacetelescope/drizzlepac/issues/111 by identifying when `configobj` is set to `'defaults'` and then it loads the defaults from the `drizzlepac`'s own `pars` directory instead of user's local `~/.teal/`.