### PR TITLE
Replace final __vdate__ reference

### DIFF
--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -27,7 +27,7 @@ from . import util
 #
 # This is specifically NOT intended to match the package-wide version information.
 __version__ = '1.4.6'
-__vdate__ = '19-March-2018'
+__version_date__ = '19-March-2018'
 
 from . import tweakutils
 from . import imgclasses


### PR DESCRIPTION
Bug introduced by #116 ::

```python
Traceback (most recent call last):
  File "/Users/shared/iraf_conda/bldtmp/pr7S/p/envs/dev/lib/python3.5/site-packages/drizzlepac/util.py", line 218, in wrapper
    func(*args, **kwargs)
  File "/Users/shared/iraf_conda/bldtmp/pr7S/p/envs/dev/lib/python3.5/site-packages/drizzlepac/tweakreg.py", line 103, in run
    __version__,__version_date__,util._ptime()[0]))
NameError: name '__version_date__' is not defined
```

This PR replaces `__vdate__` with `__version_date__`.