### PR TITLE
Fixes to let WFPC2 data process

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,11 +14,11 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-DrizzlePac v2.2.0 (12-April-2018)
+DrizzlePac v2.2.1 (12-April-2018)
 =================================
 - Fixed problems with processing WFPC2 data provided by the archive.  User will
   need to make sure they run ``updatewcs`` on all input WFPC2 data before
-  combining them with ``astrodrizzle``.  
+  combining them with ``astrodrizzle``.
 
 Drizzlepac v2.2.0 (11-April-2018)
 =================================

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,12 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+DrizzlePac v2.2.0 (12-April-2018)
+=================================
+- Fixed problems with processing WFPC2 data provided by the archive.  User will
+  need to make sure they run ``updatewcs`` on all input WFPC2 data before
+  combining them with ``astrodrizzle``.  
+
 Drizzlepac v2.2.0 (11-April-2018)
 =================================
 

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -687,7 +687,10 @@ def buildFileListOrig(input, output=None, ivmlist=None,
     filelist, ivmlist = check_files.checkFITSFormat(filelist, ivmlist)
 
     # check for non-polynomial distortion correction
-    filelist = checkDGEOFile(filelist)
+    if not updatewcs:
+        # with updatewcs turned on, any problems will get resolved
+        # so we do not need to be concerned about the state of the DGEOFILEs
+        filelist = checkDGEOFile(filelist)
 
     # run all WCS updating
     updated_input = _process_input_wcs(filelist, wcskey, updatewcs)

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -119,11 +119,8 @@ class WFPC2InputImage (imageObject):
         pri_header = self._image[0].header
         self.proc_unit = instrpars['proc_unit']
 
-        if self._isNotValid (instrpars['gain'], instrpars['gnkeyword']):
-            instrpars['gnkeyword'] = 'ATODGAIN'
-
-        if self._isNotValid (instrpars['rdnoise'], instrpars['rnkeyword']):
-            instrpars['rnkeyword'] = None
+        instrpars['gnkeyword'] = 'ATODGAIN'  # hard-code for WFPC2 data
+        instrpars['rnkeyword'] = None
 
         if self._isNotValid (instrpars['exptime'], instrpars['expkeyword']):
             instrpars['expkeyword'] = 'EXPTIME'
@@ -133,7 +130,6 @@ class WFPC2InputImage (imageObject):
                                                      instrpars['gnkeyword'])
             chip._exptime       = self.getInstrParameter(instrpars['exptime'], pri_header,
                                                      instrpars['expkeyword'])
-
             # We need to treat Read Noise as a special case since it is
             # not populated in the WFPC2 primary header
             if instrpars['rnkeyword'] is None:


### PR DESCRIPTION
These fixes were needed in order to allow WFPC2 data from the archive to be processed again.  