### PR TITLE
Fix input file bug in TweakReg

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -14,6 +14,13 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+
+DrizzlePac v2.2.2 (18-April-2018)
+=================================
+- Fixed a bug in ``TweakReg`` introduced in ``v2.2.0`` due to which, when
+  ``TweakReg`` is run from the interpreter, the code may crash when trying to
+  interpret input files.
+
 DrizzlePac v2.2.1 (12-April-2018)
 =================================
 - Fixed problems with processing WFPC2 data provided by the archive.  User will

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -26,8 +26,8 @@ from . import util
 # in one location only.
 #
 # This is specifically NOT intended to match the package-wide version information.
-__version__ = '1.4.6'
-__version_date__ = '19-March-2018'
+__version__ = '1.4.7'
+__version_date__ = '18-April-2018'
 
 from . import tweakutils
 from . import imgclasses
@@ -125,14 +125,14 @@ def run(configobj):
     util.printParams(configobj, log=log)
 
     # start interpretation of input parameters
-    input = configobj['input']
+    input_files = configobj['input']
     # Start by interpreting the inputs
     use_catfile = True
     expand_refcat = configobj['expand_refcat']
     enforce_user_order = configobj['enforce_user_order']
 
-    filenames,catnames = tweakutils.parse_input(
-        input, sort_wildcards=not enforce_user_order
+    filenames, catnames = tweakutils.parse_input(
+        input_files, sort_wildcards=not enforce_user_order
     )
 
     catdict = {}
@@ -143,7 +143,7 @@ def run(configobj):
             catdict[f] = None
 
     if not filenames:
-        print('No filenames matching input %r were found.' % input)
+        print('No filenames matching input %r were found.' % input_files)
         raise IOError
 
     # Verify that files are writable (based on file permissions) so that
@@ -777,8 +777,8 @@ def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
         # load 'astrodrizzle' parameter defaults as described in the docs:
         configobj = teal.load(__taskname__, defaults=True)
 
-    if input and not util.is_blank(input):
-        input_dict['input'] = input
+    if files and not util.is_blank(files):
+        input_dict['input'] = files
     elif configobj is None:
         raise TypeError("TweakReg() needs either 'files' or "
                         "'configobj' arguments")


### PR DESCRIPTION
In https://github.com/spacetelescope/drizzlepac/commit/77fbde16c6de551fb7bbc3b29fa80d78a1e2a8e7#diff-fa6016220e25e86c26d2ae334eb367a2R780 I made a mistake of copy/paste a fix from `astrodrizzle.py` to `tweakreg.py`. However, I missed the fact that input files are provided through the `files` argument in `TweakReg` vs. `input` (yes, same as the built-in method) in `AstroDrizzle` and so I failed to update the fix to work for `TweakReg`. This in effect, introduced a bug in `TweakReg` v.1.4.6. This PR fixes this bug.