### PR TITLE
Update setup version requirement for stsci.image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setup(
         'spherical_geometry',
         'stsci.tools',
         'stsci.convolve',
-        'stsci.image',
+        'stsci.image>=2.3.0',
         'stsci.imagemanip',
         'stsci.imagestats',
         'stsci.ndimage',


### PR DESCRIPTION
CC: @jhunkeler 

In Python 2.7 (my env after updating it) `stsci.image` was `2.2.0` but `drizzlepac` requires `2.3.0`.