### PR TITLE
mdriz: Fix broken imports

### DIFF
--- a/drizzlepac/mdriz.py
+++ b/drizzlepac/mdriz.py
@@ -8,10 +8,11 @@ Main program for running MultiDrizzle from the command line.
 
 """
 from __future__ import absolute_import, division, print_function # confidence high
+import getopt
 import sys, os
-from drizzlepac import AstroDrizzle
+from drizzlepac.astrodrizzle import AstroDrizzle
 from drizzlepac.version import __version__
-from . import util
+from drizzlepac import util
 
 
 #-------------------------------------------------------------------------------

--- a/drizzlepac/mdriz.py
+++ b/drizzlepac/mdriz.py
@@ -15,6 +15,11 @@ from drizzlepac.version import __version__
 from drizzlepac import util
 
 
+ruler = '-' * 80
+print('{0:s}\nDEPRECATION WARNING:\n'
+      '    This module (mdriz) will be removed in a future release.\n'
+      '    Please execute "runastrodriz" instead.\n{0:s}\n'.format(ruler), file=sys.stderr)
+
 #-------------------------------------------------------------------------------
 # a main program for running MultiDrizzle from the command line
 


### PR DESCRIPTION
Given the state of this module and what it refers to... can it be deprecated?

This is only being fixed so that my import tests will succeed.

https://ssbjenkins.stsci.edu/blue/organizations/jenkins/STScI%2Fdrizzlepac/detail/PR-132/11/pipeline