### PR TITLE
Sphinx brain

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -35,8 +35,8 @@ def setup(app):
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('../../'))
+sys.path.insert(0, os.path.abspath('../../.eggs'))
 sys.path.insert(0, os.path.abspath('../../src/'))
-
 
 #sys.path.insert(0, os.path.abspath('../'))
 #sys.path.insert(0, os.path.abspath('packagename/'))

--- a/setup.py
+++ b/setup.py
@@ -90,8 +90,11 @@ docs_compiled_dest = os.path.normpath('{0}/htmlhelp'.format(NAME))
 
 
 class InstallCommand(install):
-    """Drizzlepac requires C extensions to import at the project level.
-    This ensures RTD can import the package relative to the documentation post-install"""
+    """Ensure drizzlepac's C extensions are available when imported relative
+    to the documentation, instead of relying on `site-packages`. What comes
+    from `site-packages` may not be the same drizzlepac that was *just*
+    compiled.
+    """
     def run(self):
         build_cmd = self.reinitialize_command('build_ext')
         build_cmd.inplace = 1

--- a/setup.py
+++ b/setup.py
@@ -155,8 +155,10 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     setup_requires=[
+        'numpydoc',
         'stsci_rtd_theme',
         'sphinx',
+        'sphinx-automodapi',
         'sphinx_rtd_theme',
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,9 @@ class InstallCommand(install):
         self.run_command('build_ext')
         install.run(self)
         if not os.path.exists(docs_compiled_dest):
-            print('warning: Sphinx "htmlhelp" documentation was NOT bundled!', file=sys.stderr)
+            print('warning: Sphinx "htmlhelp" documentation was '
+                  'NOT bundled!', file=sys.stderr)
+
 
 CMDCLASS['install'] = InstallCommand
 
@@ -111,7 +113,7 @@ try:
     from sphinx.setup_command import BuildDoc
 
     class BuildSphinx(BuildDoc):
-        """Build Sphinx documentation after compiling C source files"""
+        """Build Sphinx documentation after compiling C extensions"""
 
         description = 'Build Sphinx documentation'
 
@@ -127,6 +129,7 @@ try:
             self.run_command('build_ext')
             build_main(['-b', 'html', 'doc/source', 'build/sphinx/html'])
 
+            # Bundle documentation inside of drizzlepac
             if os.path.exists(docs_compiled_src):
                 if os.path.exists(docs_compiled_dest):
                     shutil.rmtree(docs_compiled_dest)
@@ -136,7 +139,8 @@ try:
     CMDCLASS['build_sphinx'] = BuildSphinx
 
 except ImportError:
-    print('warning: Sphinx is not installed! "htmlhelp" documention cannot be compiled!', file=sys.stderr)
+    print('warning: Sphinx is not installed! "htmlhelp" documention cannot '
+          'be compiled!', file=sys.stderr)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ try:
             build_cmd = self.reinitialize_command('build_ext')
             build_cmd.inplace = 1
             self.run_command('build_ext')
-            build_main(['-b', 'html', 'doc', 'build/sphinx/html'])
+            build_main(['-b', 'html', 'doc/source', 'build/sphinx/html'])
 
             if os.path.exists(docs_compiled_src):
                 if os.path.exists(docs_compiled_dest):

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ try:
             build_cmd = self.reinitialize_command('build_ext')
             build_cmd.inplace = 1
             self.run_command('build_ext')
-            build_main(['-b', 'html', 'docs', 'build/sphinx/html'])
+            build_main(['-b', 'html', 'doc', 'build/sphinx/html'])
 
             if os.path.exists(docs_compiled_src):
                 if os.path.exists(docs_compiled_dest):


### PR DESCRIPTION
- Sphinx
  - `conf.py` adds the `.eggs` directory populated by `setup_requires`. This is useful if compiling the docs outside of Conda.

- Setuptools
  - Implement `BuildSphinx`  wrapper ripped straight from `stsci-jwst/jwst.git`. The overall logic was modified slightly to prevent a chicken/egg scenario when Sphinx wasn't available. (see the `CMDCLASS` dictionary)
  - Implement `InstallCommand` wrapper to ensure C extensions are compiled/available on `sys.path` when importing `drizzlepac` from a path relative to the project. (RTD support)
  - Does not touch `develop` since that build mode already performs `build_ext --inplace` by design
  - Does not change behavior of `cd doc/source && make html`. Doing this manually still might not work unless you have the correct dependencies pre-installed, either manually, provided by `setup_requires`, or a conda recipe, _and_ `python setup.py build_ext --inplace` has been executed beforehand.

If a general user or developer wants to install drizzlepac with the `htmlhelp` docs bundled:
```bash
$ conda install sphinx graphviz
# ^ Graphviz is not a Python package so pip/pypi/virtualenv users are on their own at this point

$ python setup.py build_sphinx
$ python setup.py install
```

If a user or developer wants to install drizzlepac without the `htmlhelp` docs bundled:
```bash
$ python setup.py install
```

RTD executes the following command prior to building the docs. The `InstallCommand` wrapper should trap this, build the extension(s), and continue without failure:
```bash
$ python setup.py install --force
```



