### PR TITLE
Create median does not print image background value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,9 @@ DrizzlePac v2.2.3 (not yet released)
   and `Issue #129 <https://github.com/spacetelescope/drizzlepac/issues/129>`_
   for more details.
 
+- Fixed a bug in a print statement in the create median step due to which
+  background values for input images used in this step were not printed.
+
 DrizzlePac v2.2.2 (18-April-2018)
 =================================
 - Fixed a bug in ``TweakReg`` introduced in ``v2.2.0`` due to which, when

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -289,7 +289,7 @@ def _median(imageObjectList, paramDict):
             backgroundValueList.append(bsky)
             readnoiseList.append(rdnoise)
 
-            print("reference sky value for image '{}' is "
+            print("reference sky value for image '{}' is {}"
                   .format(image._filename, backgroundValueList[-1]))
         #
         # END Loop over input image list


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/spacetelescope/drizzlepac/pull/104/files#diff-a8dcc868b4ea304820717b4986c3ae0aR292