### PR TITLE
Improve visual of the drizzlepac logs. Log full configobj

### DIFF
--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -99,7 +99,10 @@ def AstroDrizzle(input=None, mdriztab=False, editpars=False, configobj=None,
         configObj = util.getDefaultConfigObj(__taskname__, configobj,
                                              input_dict,
                                              loadOnly=(not editpars))
-        print("INPUT_DICT: {}".format(input_dict))
+        log.debug('')
+        log.debug("INPUT_DICT:")
+        util.print_cfg(input_dict, log.debug)
+        log.debug('')
         # If user specifies optional parameter for final_wcs specification in input_dict,
         #    insure that the final_wcs step gets turned on
         util.applyUserPars_steps(configObj, input_dict, step='3a')
@@ -166,6 +169,13 @@ def run(configobj, wcsmap=None):
     print("AstroDrizzle Version {:s} ({:s}) started at: {:s}\n"
           .format(__version__, __version_date__, util._ptime()[0]))
     util.print_pkg_versions(log=log)
+
+    log.debug('')
+    log.debug(
+        "==== AstroDrizzle was invoked with the following parameters: ===="
+    )
+    log.debug('')
+    util.print_cfg(configobj, log.debug)
 
     try:
         # Define list of imageObject instances and output WCSObject instance

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -180,8 +180,8 @@ class Image(object):
                 source = input_catalogs[sci_extn-1]
                 catalog_mode='user'
 
-            if exclusions[sci_extn-1] not in [ None, 'None', '', ' ', 'INDEF' ]:
-                excludefile = { 'region_file': exclusions[sci_extn-1] }
+            if exclusions[sci_extn-1] not in [None, 'None', '', ' ', 'INDEF']:
+                excludefile = {'region_file': exclusions[sci_extn-1]}
             else:
                 excludefile = None
 
@@ -285,7 +285,8 @@ class Image(object):
                 self.catalog_names['input_xy'].append(catname)
             self.catalog_names['fitmatch'] = self.rootname+"_catalog_fit.match"
 
-        print('\n')
+        print()
+
         # Set up products which need to be computed by methods of this class
         self.outxy = None
         self.refWCS = None # reference WCS assigned for the final fit

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -120,7 +120,13 @@ def run(configobj):
         _managePsets(configobj, PSET_SECTION_REFIMG,
                      refimagefindpars.__taskname__)
 
+    log.debug('')
+    log.debug("==== TweakReg was invoked with the following parameters: ====")
+    log.debug('')
+    util.print_cfg(configobj, log.debug)
+
     # print out user set input parameter values for running this task
+    log.info('')
     log.info("USER INPUT PARAMETERS common to all Processing Steps:")
     util.printParams(configobj, log=log)
 
@@ -274,12 +280,15 @@ def run(configobj):
     # verify a valid hdrname was provided, if headerlet was set to True
     imgclasses.verify_hdrname(**hdrlet_par)
 
-    print('\nFinding shifts for: ')
+    print('')
+    print('Finding shifts for: ')
     for f in filenames:
         print('    {}'.format(f))
+    print('')
 
     log.info("USER INPUT PARAMETERS for finding sources for each input image:")
     util.printParams(catfile_kwargs, log=log)
+    log.info('')
 
     try:
         minsources = max(1, catfit_pars['minobj'])
@@ -339,6 +348,7 @@ def run(configobj):
         ref_catfile_kwargs.update(ref_sourcefind_pars)
         ref_catfile_kwargs['updatehdr'] = False
 
+        log.info('')
         log.info("USER INPUT PARAMETERS for finding sources for "
                  "the reference image:")
         util.printParams(ref_catfile_kwargs, log=log)
@@ -427,6 +437,7 @@ def run(configobj):
         ref_catfile_kwargs.update(ref_sourcefind_pars)
         ref_catfile_kwargs['updatehdr'] = False
 
+        log.info('')
         log.info("USER INPUT PARAMETERS for finding sources for "
                  "the reference image (not used):")
         util.printParams(ref_catfile_kwargs, log=log)
@@ -507,14 +518,17 @@ def run(configobj):
             log.info("USER INPUT PARAMETERS for matching sources:")
             util.printParams(objmatch_par, log=log)
 
+            log.info('')
             log.info("USER INPUT PARAMETERS for fitting source lists:")
             util.printParams(configobj['CATALOG FITTING PARAMETERS'], log=log)
 
             if hdrlet_par['headerlet']:
+                log.info('')
                 log.info("USER INPUT PARAMETERS for creating headerlets:")
                 util.printParams(hdrlet_par, log=log)
 
             if shiftpars['shiftfile']:
+                log.info('')
                 log.info("USER INPUT PARAMETERS for creating a shiftfile:")
                 util.printParams(shiftpars, log=log)
 

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -165,7 +165,6 @@ def end_logging(filename=None):
         print('No trailer file saved...')
 
 
-
 class WithLogging(object):
     def __init__(self):
         self.depth = 0
@@ -249,7 +248,11 @@ def print_pkg_versions(packages=None, git=False, svn=False, log=None):
 
     output('Version Information')
     output('-' * 20)
-    output('Python Version %s' % sys.version)
+    sysver = sys.version.split('\n')
+    output('Python Version %s' % sysver.pop())
+    for ver in sysver:
+        output(ver)
+
     for software in pkgs:
         try:
             package = __import__(software)
@@ -322,6 +325,7 @@ class ProcSteps(object):
         self.end = ptime
 
         print('==== Processing Step ',key,' finished at ',ptime[0])
+        print('')
 
     def reportTimes(self):
         """
@@ -799,6 +803,37 @@ def printParams(paramDictionary, all=False, log=None):
                                          str(paramDictionary[key])]))
         if log is None:
             output('\n')
+
+
+def print_key(key, val, lev=0, logfn=print):
+    if isinstance(val, dict):
+        logfn('')
+        logfn('{}{}:'.format(2*lev*' ', key))
+        for kw, vl in val.items():
+            print_key(kw, vl, lev+1, logfn=logfn)
+        return
+    elif isinstance(val, str):
+        logfn("{}{}: '{:s}'".format(2*lev*' ', key, val))
+    else:
+        logfn("{}{}: {}".format(2*lev*' ', key, val))
+
+
+def print_cfg(cfg, logfn=None):
+    if logfn is None:
+        logfn = print
+
+    if not cfg:
+        logfn('No parameters were supplied')
+        return
+
+    keys = cfg.keys()
+    smkeys = [k for k in keys if k.islower() and k[0] != '_']
+    sectkeys = [k for k in keys if k.isupper() and k[0] != '_']
+    stepkeys = [k for k in sectkeys if k.startswith('STEP ')]
+    sectkeys = [k for k in sectkeys if k not in stepkeys]
+    for k in smkeys + sectkeys + stepkeys:
+        print_key(k, cfg[k], logfn=logfn)
+    logfn('')
 
 
 def isASNTable(inputFilelist):


### PR DESCRIPTION
Improve visual appearance of the drizzlepac's log (i.e., spacing between blocks). Output complete `configObj` in `astrodrizzle` and `tweakreg` when `verbose` is `True`.