### PR TITLE
Allow use of DEBUG logging level in drizzlepac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ DrizzlePac v2.2.3 (not yet released)
 - Fixed a bug in a print statement in the create median step due to which
   background values for input images used in this step were not printed.
 
+- Fixed a bug due to which ``TweakReg`` may have effectively ignored
+  ``verbose`` setting.
+
 DrizzlePac v2.2.2 (18-April-2018)
 =================================
 - Fixed a bug in ``TweakReg`` introduced in ``v2.2.0`` due to which, when

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -36,7 +36,7 @@ __all__ = ['blot', 'runBlot', 'help', 'getHelpAsString']
 __taskname__ = 'drizzlepac.ablot'
 _blot_step_num_ = 5
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 #

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -40,7 +40,7 @@ __taskname__ = "drizzlepac.adrizzle"
 _single_step_num_ = 3
 _final_step_num_ = 7
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 time_pre_all = []
 time_driz_all = []

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -57,7 +57,7 @@ __taskname__ = "astrodrizzle"
 # Pointer to the included Python class for WCS-based coordinate transformations
 PYTHON_WCSMAP = wcs_functions.WCSMap
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 def AstroDrizzle(input=None, mdriztab=False, editpars=False, configobj=None,

--- a/drizzlepac/catalogs.py
+++ b/drizzlepac/catalogs.py
@@ -39,7 +39,7 @@ REFCAT_ARGS = ['rmaxflux','rminflux','rfluxunits','refnbright']+REFCOL_PARS
 sortKeys = ['minflux','maxflux','nbright','fluxunits']
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 def generateCatalog(wcs, mode='automatic', catalog=None,

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -35,7 +35,7 @@ _step_num_ = 4  # this relates directly to the syntax in the cfg file
 
 BUFSIZE = 1024*1024   # 1MB cache size
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 # this is the user access function

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -27,7 +27,7 @@ __taskname__= "drizzlepac.drizCR"  # looks in drizzlepac for sky.cfg
 _step_num_ = 6  # this relates directly to the syntax in the cfg file
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 #this is the user access function

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -25,7 +25,7 @@ __all__ = ['baseImageObject', 'imageObject', 'WCSObject']
 
 IRAF_DTYPES={'float64':-64,'float32':-32,'uint8':8,'int16':16,'int32':32}
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 class baseImageObject(object):

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -46,7 +46,7 @@ IMGCLASSES_DEBUG = False
 # use convex hull for images? (this is tighter than chip's bounding box)
 IMAGE_USE_CONVEX_HULL = True
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 sortKeys = ['minflux','maxflux','nbright','fluxunits']
 

--- a/drizzlepac/linearfit.py
+++ b/drizzlepac/linearfit.py
@@ -23,7 +23,7 @@ __version__ = '0.4.0'
 __version_date__ = '10-Oct-2014'
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 if hasattr(np, 'float128'):
     ndfloat128 = np.float128

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -50,8 +50,7 @@ DRIZ_KEYWORDS = {
                 'WKEY':{'value':"",'comment':'Input image WCS Version used'}
                 }
 
-import logging
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 class OutputImage:
@@ -450,10 +449,9 @@ class OutputImage:
             fo.append(hdu)
 
             # remove all alternate WCS solutions from headers of this product
-
-            logging.disable(logging.INFO)
+            logutil.logging.disable(logutil.logging.INFO)
             wcs_functions.removeAllAltWCS(fo,wcs_ext)
-            logging.disable(logging.NOTSET)
+            logutil.logging.disable(logutil.logging.NOTSET)
 
             # add table of combined header keyword values to FITS file
             if newtab is not None:

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -55,7 +55,7 @@ from . import util
 from . import resetbits
 from . import mdzhandler
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 # list parameters which correspond to steps where multiprocessing can be used
 parallel_steps = [(3,'driz_separate'),(6,'driz_cr')]

--- a/drizzlepac/resetbits.py
+++ b/drizzlepac/resetbits.py
@@ -83,7 +83,7 @@ __version__ = '1.0.1'
 __version_date__ = '23-March-2017'
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 def reset_dq_bits(input,bits,extver=None,extname='dq'):

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import, division, print_function  # confidence m
 
 import os, sys
 
-import logging
 from .imageObject import imageObject
 from stsci.tools import fileutil, teal, logutil
 try:
@@ -39,7 +38,7 @@ __taskname__= "drizzlepac.sky" #looks in drizzlepac for sky.cfg
 _step_num_ = 2  #this relates directly to the syntax in the cfg file
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 #this is the user access function

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -30,7 +30,7 @@ __taskname__ = "drizzlepac.staticMask"
 _step_num_ = 1
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 #this is called by the user

--- a/drizzlepac/tweakback.py
+++ b/drizzlepac/tweakback.py
@@ -36,7 +36,7 @@ __version__ = '0.4.0'
 __version_date__ = '14-Oct-2014'
 
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 if hasattr(np, 'float128'):
     ndfloat128 = np.float128

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -43,7 +43,7 @@ PSET_SECTION_REFIMG = '_REF IMAGE SOURCE FINDING PARS_'
 # TEAL allows its data to stay alongside the expected data during a call to
 # TweakReg().  All of this needs to be revisited.
 
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 def _managePsets(configobj, section_name, task_name, iparsobj=None, input_dict=None):

--- a/drizzlepac/tweakutils.py
+++ b/drizzlepac/tweakutils.py
@@ -10,7 +10,7 @@ import string,os
 import numpy as np
 import stsci.ndimage as ndimage
 
-from stsci.tools import asnutil, irafglob, parseinput, fileutil
+from stsci.tools import asnutil, irafglob, parseinput, fileutil, logutil
 from astropy.io import fits
 import astropy.coordinates as coords
 import astropy.units as u
@@ -30,6 +30,8 @@ __all__ = [
     'build_xy_zeropoint', 'build_pos_grid'
 ]
 
+
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 def parse_input(input, prodonly=False, sort_wildcards=True):
     catlist = None

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -26,8 +26,7 @@ from . import linearfit
 __version__ = '0.2.0'
 __version_date__ = '10-Oct-2014'
 
-
-log = logutil.create_logger(__name__)
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 wcs_keys = ['CRVAL1','CRVAL2','CD1_1','CD1_2','CD2_1','CD2_2',
             'CRPIX1','CRPIX2','ORIENTAT']

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -135,14 +135,15 @@ def init_logging(logfile=DEFAULT_LOGNAME, default=None, level=logging.INFO):
         _log_file_handler.setLevel(level)
         _log_file_handler.setFormatter(
             logging.Formatter('[%(levelname)-8s] %(message)s'))
+        root_logger.setLevel(level)
         root_logger.addHandler(_log_file_handler)
 
         print('Setting up logfile : ', logname)
 
-        stdout_logger = logging.getLogger('stsci.tools.logutil.stdout')
+        #stdout_logger = logging.getLogger('stsci.tools.logutil.stdout')
         # Disable display of prints to stdout from all packages except
         # drizzlepac
-        stdout_logger.addFilter(logutil.EchoFilter(include=['drizzlepac']))
+        #stdout_logger.addFilter(logutil.EchoFilter(include=['drizzlepac']))
     else:
         print('No trailer file created...')
 
@@ -201,7 +202,7 @@ class WithLogging(object):
                     verbose_level=logging.INFO
                     if 'verbose' in configobj and configobj['verbose']:
                         verbose_level=logging.DEBUG
-                    init_logging(filename,level=verbose_level)
+                    init_logging(filename, level=verbose_level)
                 except (KeyError, IndexError, TypeError):
                     pass
 


### PR DESCRIPTION
This PR should address issue https://github.com/spacetelescope/drizzlepac/issues/146. While suspicion that `wcs_functions.py` may not be restoring previous logging level might still be true, now I think the main reason for the observed behavior lies in the call to `log = logutil.create_logger(__name__)` at the top of most modules in the `astrodrizzle`. By default the logger created with `create_logger()` have log level set to `INFO` and so all module-leve loggers are set to ignore `DEBUG`-level messages. This PR creates module-level loggers with `level` se to `NOTSET` and thus effectively using root logger's level which is set in `astrodrizzle.util.WithLogging`.