### PR TITLE
Add JenkinsfileRT for use in testing against new astropy.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ TEST_DEPS = "pytest pytest-remotedata crds"
 
 // Conda needs explicit dependencies listed
 DEPS = "fitsblender graphviz nictools numpydoc \
-        pytest pytest-remotedata pyregion \
+        pytest=3.8.2 pytest-remotedata pyregion \
         scipy spherical-geometry sphinx sphinx_rtd_theme \
         stsci_rtd_theme stsci.convolve stsci.image \
         stsci.imagemanip stsci.imagestats stsci.ndimage \

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -1,0 +1,54 @@
+// Obtain files from source control system.
+if (utils.scm_checkout()) return
+
+
+def test_env = [
+    'PATH=./miniconda-bconf0/bin:$PATH',
+    'HOME=./',
+    'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory'
+]
+
+
+// Configure artifactory ingest
+data_config = new DataConfig()
+data_config.server_id = 'bytesalad'
+data_config.root = 'tests_output'
+data_config.match_prefix = '(.*)_result' // .json is appended automatically
+
+
+bc = new BuildConfig()
+bc.nodetype = 'linux'
+bc.env_vars = test_env
+bc.name = '3.6'
+bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
+bc.conda_packages = ['numpy',
+                     'fitsblender',
+                     'graphviz',
+                     'nictools',
+                     'numpydoc',
+                     'pyregion',
+                     'pytest=3.8.2',
+                     'pytest-remotedata',
+                     'crds',
+                     'scipy',
+                     'spherical-geometry',
+                     'sphinx',
+                     'sphinx_rtd_theme',
+                     'stsci_rtd_theme',
+                     'stsci.convolve',
+                     'stsci.image',
+                     'stsci.imagemanip',
+                     'stsci.imagestats',
+                     'stsci.ndimage',
+                     'stsci.skypac',
+                     'stregion',
+                     'stsci.stimage',
+                     'setuptools',
+                     'python=3.6']
+bc.build_cmds = ["conda install -q astropy stwcs -c http://ssb.stsci.edu/astroconda-dev",
+                 "python setup.py install"]
+bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
+bc.test_configs = [data_config]
+
+utils.run([bc])
+


### PR DESCRIPTION
This builds and tests `drizzlepac` in an environment consisting of all stable packages except for
   * `astropy`
   * `stwcs`
which are taken from the latest master snapshot provided by astroconda-dev.

For now, this will be run in a special purpose Jenkins job on the RT Jenkins instance.