### PR TITLE
Fix incorrect units in CR-cleaned images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,12 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-DrizzlePac (DEVELOPMENT)
-========================
+..
+  DrizzlePac (DEVELOPMENT)
+  ========================
+
+DrizzlePac v2.2.6 (02-Nov-2018)
+===============================
 
 - Fix a bug that results in ``tweakreg`` crashing when no sources are found
   with user-specified source-finding parameters and when ``tweakreg`` then

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ DrizzlePac (DEVELOPMENT)
 
 - Fix ``numpy`` "floating" deprecation warnings. [#175]
 
+- Fix incorrect units in CR-cleaned images created by ``astrodrizzle``. Now
+  CR-cleaned images should have the same units as input images. [#190]
+
 DrizzlePac v2.2.5 (14-Aug-2018)
 ===============================
 - Changed the color scheme of the ``hist2d`` plots to ``viridis``. [#167]

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -306,8 +306,8 @@ def _drizCr(sciImage, virtual_outputs, paramDict):
             np.bitwise_and(__dqMask,__crMask,__dqMask)
 
             ####### Create the corr file
-            __corrFile = np.zeros(__inputImage.shape,dtype=__inputImage.dtype)
-            __corrFile = np.where(np.equal(__dqMask,0),__blotData,__inputImage)
+            __corrFile = np.where(__dqMask, __inputImage, __blotData)
+            __corrFile /= scienceChip._conversionFactor
             __corrDQMask = np.where(np.equal(__dqMask,0),
                                     paramDict['crbit'],0).astype(np.uint16)
 


### PR DESCRIPTION
This PR should fix incorrect units in CR-cleaned images created by ``astrodrizzle`` - see #189. Now CR-cleaned images should have the same units as input images.
