### PR TITLE
Remove py2 support. Use WCS.pixel_shape instead of naxis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,11 @@ of the list).
 DrizzlePac (DEVELOPMENT)
 ========================
 
+- Replaced the use of ``WCS._naxis1`` and ``WCS._naxis2`` with
+  ``WCS.pixel_shape`` [#207]
+
+- Removed support for Python 2. Only versions >= 3.5 are supported. [#207]
+
 - Use a more numerically stable ``numpy.linalg.inv`` instead of own matrix
   inversion. [#205]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ if (utils.scm_checkout()) return
 
 // Generate installation compatibility matrix
 matrix_python = ["3.6", "3.7"]
-matrix_astropy = [">=3.0.5"]
+matrix_astropy = [">=3.1.0"]
 matrix_numpy = [">=1.14", "==1.15.0"]
 matrix = []
 
@@ -58,7 +58,7 @@ for (numpy_ver in matrix_numpy) {
     bc.build_cmds = ["python setup.py install"]
     bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
     bc.test_configs = [data_config]
-    matrix += bc 
+    matrix += bc
     matrix_id++
 }}}
 

--- a/drizzlepac/__init__.py
+++ b/drizzlepac/__init__.py
@@ -14,9 +14,6 @@ supported by this package include:
 cosmic-ray cleaned, and combined image as a FITS file.
 
 """
-
-from __future__ import absolute_import, division, print_function  # confidence high
-
 import os
 
 from .version import *

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -8,8 +8,6 @@ cosmic-rays.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function  # confidence medium
-
 import os
 import sys
 import numpy as np
@@ -367,7 +365,7 @@ def do_blot(source, source_wcs, blot_wcs, exptime, coeffs = True,
             `drizzlepac.wcs_functions.WCSMap`.
 
     """
-    _outsci = np.zeros((blot_wcs._naxis2,blot_wcs._naxis1),dtype=np.float32)
+    _outsci = np.zeros(blot_wcs.array_shape, dtype=np.float32)
 
     # Now pass numpy objects to callable version of Blot...
     build=False
@@ -375,9 +373,8 @@ def do_blot(source, source_wcs, blot_wcs, exptime, coeffs = True,
     kscale = 1.0
 
     xmin = 1
-    xmax = source_wcs._naxis1
     ymin = 1
-    ymax = source_wcs._naxis2
+    xmax, ymax = source_wcs.pixel_shape
 
     # compute the undistorted 'natural' plate scale for this chip
     if coeffs:
@@ -394,7 +391,11 @@ def do_blot(source, source_wcs, blot_wcs, exptime, coeffs = True,
         Use default C mapping function.
         """
         print('Using default C-based coordinate transformation...')
-        mapping = cdriz.DefaultWCSMapping(blot_wcs,source_wcs,int(blot_wcs._naxis1),int(blot_wcs._naxis2),stepsize)
+        mapping = cdriz.DefaultWCSMapping(
+            blot_wcs, source_wcs,
+            blot_wcs.pixel_shape[0], blot_wcs.pixel_shape[1],
+            stepsize
+        )
         pix_ratio = source_wcs.pscale/wcslin.pscale
     else:
         #

--- a/drizzlepac/acsData.py
+++ b/drizzlepac/acsData.py
@@ -6,8 +6,6 @@ Class used to model ACS specific instrument data.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence high
-
 from stsci.tools import fileutil
 import numpy as np
 from .imageObject import imageObject, baseImageObject

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -30,13 +30,8 @@ aspects of each of the processing steps.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function  # confidence high
-
-
 import os
 import sys
-
-from six import string_types
 
 from stsci.tools import teal, logutil, textutil
 
@@ -69,7 +64,7 @@ def AstroDrizzle(input=None, mdriztab=False, editpars=False, configobj=None,
     # parameters.
 
     # Load any user-specified configobj
-    if isinstance(configobj, string_types):
+    if isinstance(configobj, (str, bytes)):
         if configobj == 'defaults':
             # load "TEAL"-defaults (from ~/.teal/):
             configobj = teal.load(__taskname__)

--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -32,8 +32,6 @@ Functions to build mask files for PyDrizzle.
 #                   added output filename as input parameter to 'buildMask'
 #                   functions. WJH
 #
-from __future__ import absolute_import, division, print_function # confidence high
-
 import os
 
 from stsci.tools import fileutil, readgeis
@@ -45,13 +43,13 @@ except ImportError:
 from astropy.io import fits
 import numpy as np
 
-from . import processInput,util
+from . import processInput, util
 
 __taskname__ = 'drizzlepac.buildmask'
 #
 #### Interactive interface
 #
-def run(configObj=None,input_dict={},loadOnly=False):
+def run(configObj=None, input_dict={}, loadOnly=False):
     """ Build DQ masks from all input images, then apply static mask(s).
     """
     # If called from interactive user-interface, configObj will not be

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -6,8 +6,6 @@ Provides function for manipulating WCS in images.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 import sys, types, os, copy
 from . import util
 import numpy as np
@@ -261,9 +259,8 @@ def mergewcs(outwcs, customwcs, wcspars):
         if wcspars['crpix1'] is not None:
             outwcs.wcs.crpix = np.array([wcspars['crpix1'],wcspars['crpix2']])
         if wcspars['naxis1'] is not None:
-            outwcs._naxis1 = wcspars['naxis1']
-            outwcs._naxis2 = wcspars['naxis2']
-            outwcs.wcs.crpix = np.array([outwcs._naxis1/2.,outwcs._naxis2/2.])
+            outwcs.pixel_shape = (wcspars['naxis1'], wcspars['naxis2'])
+            outwcs.wcs.crpix = np.array(outwcs.pixel_shape) / 2.0
 
         pscale = wcspars['pscale']
         orient = wcspars['orientat']
@@ -281,8 +278,7 @@ def mergewcs(outwcs, customwcs, wcspars):
         outwcs.wcs.cd = customwcs.wcs.cd
         outwcs.wcs.crval = customwcs.wcs.crval
         outwcs.wcs.crpix = customwcs.wcs.crpix
-        outwcs._naxis1 = customwcs._naxis1
-        outwcs._naxis2 = customwcs._naxis2
+        outwcs.pixel_shape = customwcs.pixel_shape
     return outwcs
 
 def add_model(refwcs, newcoeffs):
@@ -345,8 +341,7 @@ def undistortWCS(refwcs):
     outwcs.inst_kw = refwcs.inst_kw
     for kw in refwcs.inst_kw:
         outwcs.__dict__[kw] = refwcs.__dict__[kw]
-    outwcs._naxis1 = wcslin._naxis1
-    outwcs._naxis2 = wcslin._naxis2
+    outwcs.pixel_shape = wcslin.pixel_shape
 
     return outwcs
 
@@ -365,8 +360,8 @@ def generate_headerlet(outwcs,template,wcsname,outname=None):
     if outwcs.sip is None:
         siphdr = False
     outwcs_hdr = outwcs.wcs2header(sip2hdr=siphdr)
-    outwcs_hdr['NPIX1'] = outwcs._naxis1
-    outwcs_hdr['NPIX2'] = outwcs._naxis2
+    outwcs_hdr['NPIX1'] = outwcs.pixel_shape[0]
+    outwcs_hdr['NPIX2'] = outwcs.pixel_shape[1]
 
     # create headerlet object in memory; either from a file or from scratch
     if template is not None and siphdr:

--- a/drizzlepac/catalogs.py
+++ b/drizzlepac/catalogs.py
@@ -4,7 +4,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import os, sys
 import copy
 from distutils.version import LooseVersion
@@ -28,7 +27,6 @@ import stregion as pyregion
 from . import tweakutils, util
 from .mapreg import _AuxSTWCS
 
-ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 COLNAME_PARS = ['xcol','ycol','fluxcol']
 CATALOG_ARGS = ['sharpcol','roundcol','hmin','fwhm','maxflux','minflux','fluxunits','nbright']+COLNAME_PARS
@@ -531,10 +529,7 @@ class ImageCatalog(Catalog):
         #DEBUG:
         if mask is not None:
             fn = os.path.splitext(self.fname)[0] + '_srcfind_mask.fits'
-            if ASTROPY_VER_GE13:
-                fits.writeto(fn, mask.astype(dtype=np.uint8), overwrite=True)
-            else:
-                fits.writeto(fn, mask.astype(dtype=np.uint8), clobber=True)
+            fits.writeto(fn, mask.astype(dtype=np.uint8), overwrite=True)
 
         return mask
 

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -6,11 +6,6 @@ Create a median image from the singly drizzled images.
 :License: :doc:`LICENSE`
 
 """
-
-# Import external packages
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
-
 import os
 import sys
 import math

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -7,8 +7,6 @@ image and the derivative of the model image.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
-
 import os
 import re
 

--- a/drizzlepac/findobj.py
+++ b/drizzlepac/findobj.py
@@ -181,7 +181,7 @@ def findstars(jdata, fwhm, threshold, skymode,
     ysigsq = (ratio**2) * xsigsq
 
     # convolve image with gaussian kernel
-    convdata = signal.convolve2d(jdata, nkern, boundary='symm', mode='same')
+    convdata = signal.convolve2d(jdata, nkern, boundary='symm', mode='same').astype(np.float32)
 
     # clip image to create regions around each source for segmentation
     if mask is None:
@@ -293,18 +293,17 @@ def findstars(jdata, fwhm, threshold, skymode,
         # Filter sources:
         if px is None:
             continue
-        if use_sharp_round:
-            if not satur and \
-               (round2 is None or round2 < roundlo or round2 > roundhi):
-                continue
 
-        fitind.append((px+xr0,py+yr0,sharp, round1, round2))
+        if use_sharp_round and not satur and \
+           (round2 is None or round2 < roundlo or round2 > roundhi):
+            continue
+
+        fitind.append((px + xr0, py + yr0, sharp, round1, round2))
         # compute a source flux value
         fluxes.append(src_flux)
 
-    fitindc,fluxesc = apply_nsigma_separation(fitind,fluxes,fwhm*nsigma/2)
+    fitindc, fluxesc = apply_nsigma_separation(fitind, fluxes, fwhm*nsigma / 2)
 
-    #print 'ninit: ',ninit,'   ninit2: ',ninit2,' final n: ',len(fitind)
     return fitindc, fluxesc
 
 

--- a/drizzlepac/findobj.py
+++ b/drizzlepac/findobj.py
@@ -6,16 +6,15 @@ A suite of functions for finding sources in images.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import sys
-
 import math
+
 import numpy as np
+from scipy import signal
 
-from stsci import convolve
-from stsci import ndimage as ndim
-
+import stsci.ndimage as ndim
 import stsci.imagestats as imagestats
+
 from . import cdriz
 
 __all__ = ['gaussian1', 'gausspars', 'gaussian', 'moments', 'errfunc',
@@ -28,7 +27,7 @@ __all__ = ['gaussian1', 'gausspars', 'gaussian', 'moments', 'errfunc',
 #def gaussian(amplitude, xcen, ycen, xsigma, ysigma):
 #from numpy import *
 
-fwhm2sig = 2*np.sqrt(2*np.log(2))
+FWHM2SIG = 2*np.sqrt(2*np.log(2))
 
 #def gaussian1(height, x0, y0, fwhm, nsigma=1.5, ratio=1., theta=0.0):
 def gaussian1(height, x0, y0, a, b, c):
@@ -56,7 +55,7 @@ def gausspars(fwhm, nsigma=1.5, ratio=1, theta=0.):
         quadratic form: a*(x-x0)^2+b(x-x0)*(y-y0)+c*(y-y0)^2 <= 2*f
     """
 
-    xsigma = fwhm/fwhm2sig
+    xsigma = fwhm / FWHM2SIG
     ysigma = ratio * xsigma
 
     f = nsigma**2/2.
@@ -178,11 +177,11 @@ def findstars(jdata, fwhm, threshold, skymode,
     # initialize values used for getting source centers
     relerr = 1./((rmask**2).sum() - (rmask.sum()**2/xyrmask.sum()))
 
-    xsigsq = (fwhm/fwhm2sig)**2
+    xsigsq = (fwhm / FWHM2SIG)**2
     ysigsq = (ratio**2) * xsigsq
 
     # convolve image with gaussian kernel
-    convdata = convolve.convolve2d(jdata, nkern).astype(np.float32)
+    convdata = signal.convolve2d(jdata, nkern, boundary='symm', mode='same')
 
     # clip image to create regions around each source for segmentation
     if mask is None:

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -6,8 +6,6 @@ A class which makes image objects for each input filename.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function  # confidence medium
-
 import copy, os, re, sys
 
 import numpy as np
@@ -457,8 +455,7 @@ class baseImageObject(object):
         outputvals = self.outputValues
 
         outputvals['output'] = output_wcs.outputNames['outFinal']
-        outputvals['outnx'] = output_wcs.wcs._naxis1
-        outputvals['outny'] = output_wcs.wcs._naxis2
+        outputvals['outnx'], outputvals['outny'] = output_wcs.wcs.pixel_shape
         outputvals['texptime'] = output_wcs._exptime
         outputvals['texpstart'] = output_wcs._expstart
         outputvals['texpend'] = output_wcs._expend

--- a/drizzlepac/imagefindpars.py
+++ b/drizzlepac/imagefindpars.py
@@ -4,7 +4,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, print_function
 import os, string
 from stsci.tools import teal
 from . import util

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -7,7 +7,6 @@ Used by ``TweakReg``.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import os
 import sys
 import copy

--- a/drizzlepac/irData.py
+++ b/drizzlepac/irData.py
@@ -6,8 +6,6 @@ Class used to model IR specific instrument data.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division # confidence high
-
 from .imageObject import imageObject
 
 class IRInputImage(imageObject):

--- a/drizzlepac/linearfit.py
+++ b/drizzlepac/linearfit.py
@@ -12,7 +12,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import division, print_function
 import numpy as np
 from numpy import linalg as npla
 from stsci.tools import logutil

--- a/drizzlepac/linearfit.py
+++ b/drizzlepac/linearfit.py
@@ -255,7 +255,7 @@ def fit_general(xy, uv):
     #   v = Q0 + Q1*x + Q2*y
     #
     try:
-        invM = np.linalg.inv(M)
+        invM = np.linalg.inv(M.astype(np.float64))
     except np.linalg.LinAlgError:
         raise SingularMatrixError(
             "Singular matrix: suspected colinear points."
@@ -332,7 +332,7 @@ def fit_arrays(uv, xy):
     #   v = Q0 + Q1*x + Q2*y
     #
     try:
-        invM = np.linalg.inv(M)
+        invM = np.linalg.inv(M.astype(np.float64))
     except np.linalg.LinAlgError:
         raise SingularMatrixError(
             "Singular matrix: suspected colinear points."
@@ -341,9 +341,6 @@ def fit_arrays(uv, xy):
     Q = np.dot(invM, V).astype(np.float64)
     if not (np.all(np.isfinite(P)) and np.all(np.isfinite(Q))):
         raise ArithmeticError('Singular matrix.')
-
-    #P = N.array([-0.434589, -0.893084, 285.420816])
-    #Q = N.array([0.907435, -0.433864, 45.553862])
 
     # Return the shift, rotation, and scale changes
     return build_fit(P, Q, 'general')

--- a/drizzlepac/mapreg.py
+++ b/drizzlepac/mapreg.py
@@ -8,7 +8,6 @@ of multiple images using the WCS information from the images.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 from astropy.io import fits
 import stregion as pyregion
 import stwcs

--- a/drizzlepac/mdriz.py
+++ b/drizzlepac/mdriz.py
@@ -7,7 +7,6 @@ Main program for running MultiDrizzle from the command line.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence high
 import getopt
 import sys, os
 from drizzlepac.astrodrizzle import AstroDrizzle

--- a/drizzlepac/mdzhandler.py
+++ b/drizzlepac/mdzhandler.py
@@ -7,8 +7,6 @@ processing as used in the pipeline.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import division, print_function # confidence high
-
 import string, os
 
 from astropy.io import fits

--- a/drizzlepac/minmed.py
+++ b/drizzlepac/minmed.py
@@ -24,8 +24,6 @@ or median image based up bad pixel identification.
 #        -- CJH -- 03/29/05
 #      Version 0.3.0: Rewritten to optimize the code and to bring
 #        code up to modern standards.-- Mihai Cara -- 02/19/2018
-from __future__ import (absolute_import, division, unicode_literals,
-                        print_function)
 import warnings
 import numpy as np
 from scipy import signal

--- a/drizzlepac/nicmosData.py
+++ b/drizzlepac/nicmosData.py
@@ -6,8 +6,6 @@ Class used to model NICMOS specific instrument data.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 from stsci.tools import fileutil
 from nictools import readTDD
 import numpy as np

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -6,8 +6,6 @@ This module manages the creation of the output image FITS file.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 from astropy.io import fits
 from stsci.tools import fileutil, readgeis, logutil
 

--- a/drizzlepac/pixtopix.py
+++ b/drizzlepac/pixtopix.py
@@ -95,8 +95,6 @@
                     output="xy_flt1.dat")
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 import os,copy
 import warnings
 import numpy as np

--- a/drizzlepac/pixtosky.py
+++ b/drizzlepac/pixtosky.py
@@ -81,8 +81,6 @@
        ...                      colnames=['c3','c4'], output="radec_sci1.dat")
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 import os,copy
 import warnings
 import numpy as np

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -28,8 +28,6 @@ as well to fully setup all inputs for use with the rest of the MultiDrizzle
 steps either as stand-alone tasks or internally to MultiDrizzle itself.
 
 """
-
-from __future__ import absolute_import, division, print_function  # confidence high
 import datetime
 import os
 import shutil
@@ -250,7 +248,7 @@ def reportResourceUsage(imageObjectList, outwcs, num_cores,
             owcs = outwcs.final_wcs
         else:
             owcs = outwcs
-        output_mem = owcs._naxis1*owcs._naxis2*4*3 # bytes used for output arrays
+        output_mem = np.prod(owcs.pixel_shape) * 4 * 3  # bytes used for output arrays
     img1 = imageObjectList[0]
     numchips = 0
     input_mem = 0
@@ -276,7 +274,7 @@ def reportResourceUsage(imageObjectList, outwcs, num_cores,
     print('*'*80)
     print('*')
     print('*  Estimated memory usage:  up to %d Mb.'%(max_mem))
-    print('*  Output image size:       %d X %d pixels. '%(owcs._naxis1,owcs._naxis2))
+    print('*  Output image size:       {:d} X {:d} pixels. '.format(*owcs.pixel_shape))
     print('*  Output image file:       ~ %d Mb. '%(output_mem//(1024*1024)))
     print('*  Cores available:         %d'%(pool_size))
     print('*')

--- a/drizzlepac/quickDeriv.py
+++ b/drizzlepac/quickDeriv.py
@@ -12,11 +12,8 @@ IS RETURNED BY :py:func:`quickderiv`.
 # VERSION:
 #   Version 0.1.0: created -- CJH
 #
-from __future__ import absolute_import, division # confidence high
-
-from .version import *
-# IMPORT EXTERNAL MODULES
 import numpy as np
+from .version import *
 
 def qderiv(array): # TAKE THE ABSOLUTE DERIVATIVE OF A NUMARRY OBJECT
     """Take the absolute derivate of an image in memory."""

--- a/drizzlepac/refimagefindpars.py
+++ b/drizzlepac/refimagefindpars.py
@@ -5,7 +5,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, print_function
 import os
 from stsci.tools import teal
 from . import util

--- a/drizzlepac/resetbits.py
+++ b/drizzlepac/resetbits.py
@@ -63,8 +63,6 @@
             >>> resetbits.reset_dq_bits("input_file_flt.fits", 2+32+64+4096, extver=2)
 
 """
-
-from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 from stsci.tools import stpyfits as fits

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -53,7 +53,6 @@ W.J. Hack  26 Nov 2012: Option to write out headerlets added and debugged
 
 """
 # Import standard Python modules
-from __future__ import division, print_function # confidence high
 import glob
 import os
 import shutil

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -9,8 +9,6 @@ input image while recording the subtracted value in the image header.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function  # confidence medium
-
 import os, sys
 
 from .imageObject import imageObject

--- a/drizzlepac/skytopix.py
+++ b/drizzlepac/skytopix.py
@@ -70,8 +70,6 @@
                 colnames=['c3','c4'], output="xy_sci1.dat")
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 import os,copy
 import numpy as np
 

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -9,9 +9,6 @@ For `staticMask`, the user interface function is :py:func:`createMask`.
 :License: :doc:`LICENSE`
 
 """
-
-from __future__ import absolute_import, division, print_function  # confidence high
-
 import os
 import sys
 from distutils.version import LooseVersion
@@ -23,8 +20,6 @@ from astropy.io import fits
 from stsci.imagestats import ImageStats
 from . import util
 from . import processInput
-
-ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 __taskname__ = "drizzlepac.staticMask"
 _step_num_ = 1
@@ -285,10 +280,7 @@ class staticMask(object):
 
             else:
                 try:
-                    if ASTROPY_VER_GE13:
-                        newHDU.writeto(filename, overwrite=True)
-                    else:
-                        newHDU.writeto(filename, clobber=True)
+                    newHDU.writeto(filename, overwrite=True)
                     log.info("Saving static mask to disk: %s" % filename)
 
                 except IOError:

--- a/drizzlepac/stisData.py
+++ b/drizzlepac/stisData.py
@@ -6,8 +6,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 from stsci.tools import fileutil
 import numpy as np
 from stsci.imagemanip import interp2d

--- a/drizzlepac/tweakback.py
+++ b/drizzlepac/tweakback.py
@@ -14,7 +14,6 @@ the "aligned" (to the new drizzled WCS) image coordinates.
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import os
 
 import numpy as np
@@ -281,10 +280,10 @@ def update_chip_wcs(chip_wcs, drz_old_wcs, drz_new_wcs,
     cd_eye = np.eye(chip_wcs.wcs.cd.shape[0])
 
     # estimate precision necessary for iterative processes:
+    naxis1, naxis2 = chip_wcs.pixel_shape
     maxiter = 100
     crpix2corners = np.dstack([i.flatten() for i in np.meshgrid(
-        [1, chip_wcs._naxis1],
-        [1, chip_wcs._naxis2])])[0] - chip_wcs.wcs.crpix
+        [1, naxis1], [1, naxis2])])[0] - chip_wcs.wcs.crpix
     maxUerr = 1.0e-5 / np.amax(np.linalg.norm(crpix2corners, axis=1))
 
     # estimate step for numerical differentiation. We need a step
@@ -293,9 +292,9 @@ def update_chip_wcs(chip_wcs, drz_old_wcs, drz_new_wcs,
     # TODO: The logic below should be revised at a later time so that it
     # better takes into account the two competing requirements.
     hx = max(1.0, min(20.0, (chip_wcs.wcs.crpix[0] - 1.0)/100.0,
-                      (chip_wcs._naxis1 - chip_wcs.wcs.crpix[0])/100.0))
+                      (naxis1 - chip_wcs.wcs.crpix[0])/100.0))
     hy = max(1.0, min(20.0, (chip_wcs.wcs.crpix[1] - 1.0)/100.0,
-                      (chip_wcs._naxis2 - chip_wcs.wcs.crpix[1])/100.0))
+                      (naxis2 - chip_wcs.wcs.crpix[1])/100.0))
 
     # compute new CRVAL for the image WCS:
     chip_wcs_orig = chip_wcs.deepcopy()

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -5,13 +5,10 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import os
 import sys
 import numpy as np
 from copy import copy
-
-from six import string_types
 
 from stsci.tools import parseinput, teal
 from stsci.tools import logutil, textutil
@@ -779,7 +776,7 @@ def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
     # then copy this into input_dict for merging with TEAL ConfigObj parameters
 
     # Get default or user-specified configobj for primary task
-    if isinstance(configobj, string_types):
+    if isinstance(configobj, (str, bytes)):
         if configobj == 'defaults':
             # load "TEAL"-defaults (from ~/.teal/):
             configobj = teal.load(__taskname__)

--- a/drizzlepac/tweakutils.py
+++ b/drizzlepac/tweakutils.py
@@ -4,7 +4,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import string,os
 
 import numpy as np
@@ -596,8 +595,8 @@ def createWcsHDU(wcs):
     header['EXTVER'] = 1
 
     # Now, update original image size information
-    header['NPIX1'] = (wcs._naxis1, "Length of array axis 1")
-    header['NPIX2'] = (wcs._naxis2, "Length of array axis 2")
+    header['NPIX1'] = (wcs.pixel_shape[0], "Length of array axis 1")
+    header['NPIX2'] = (wcs.pixel_shape[1], "Length of array axis 2")
     header['PIXVALUE'] = (0.0, "values of pixels in array")
 
     if hasattr(wcs, 'orientat'):

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -5,7 +5,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function
 import re
 import math
 import warnings
@@ -362,11 +361,12 @@ def update_refchip_with_shift(chip_wcs, wcslin, fitgeom='rscale',
     cd_eye = np.eye(chip_wcs.wcs.cd.shape[0], dtype=ndfloat128)
     zero_shift = np.zeros(2, dtype=ndfloat128)
 
+    naxis1, naxis2 = chip_wcs.pixel_shape
+
     # estimate precision necessary for iterative processes:
     maxiter = 100
     crpix2corners = np.dstack([i.flatten() for i in np.meshgrid(
-        [1,chip_wcs._naxis1],
-        [1,chip_wcs._naxis2])])[0] - chip_wcs.wcs.crpix
+        [1, naxis1], [1, naxis2])])[0] - chip_wcs.wcs.crpix
     maxUerr = 1.0e-5 / np.amax(np.linalg.norm(crpix2corners, axis=1))
 
     # estimate step for numerical differentiation. We need a step
@@ -374,10 +374,10 @@ def update_refchip_with_shift(chip_wcs, wcslin, fitgeom='rscale',
     # better precision for numerical differentiation.
     # TODO: The logic below should be revised at a later time so that it
     # better takes into account the two competing requirements.
-    hx = max(1.0, min(20.0, (chip_wcs.wcs.crpix[0] - 1.0)/100.0,
-                      (chip_wcs._naxis1 - chip_wcs.wcs.crpix[0])/100.0))
-    hy = max(1.0, min(20.0, (chip_wcs.wcs.crpix[1] - 1.0)/100.0,
-                      (chip_wcs._naxis2 - chip_wcs.wcs.crpix[1])/100.0))
+    hx = max(1.0, min(20.0, (chip_wcs.wcs.crpix[0] - 1.0) / 100.0,
+                      (naxis1 - chip_wcs.wcs.crpix[0]) / 100.0))
+    hy = max(1.0, min(20.0, (chip_wcs.wcs.crpix[1] - 1.0) / 100.0,
+                      (naxis2 - chip_wcs.wcs.crpix[1]) / 100.0))
 
     # compute new CRVAL for the image WCS:
     crpixinref = wcslin.wcs_world2pix(

--- a/drizzlepac/updatenpol.py
+++ b/drizzlepac/updatenpol.py
@@ -63,8 +63,6 @@ C version of MultiDrizzle (astrodrizzle).
     keyword can not be found for ACS.
 
 """
-
-from __future__ import absolute_import, division, print_function
 __docformat__ = 'restructuredtext'
 
 __taskname__ = "updatenpol"

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -8,8 +8,6 @@ A library of utility functions
 :License: :doc:`LICENSE`
 
 """
-
-from __future__ import absolute_import, division, print_function # confidence medium
 import logging
 import functools
 import os

--- a/drizzlepac/wcs_functions.py
+++ b/drizzlepac/wcs_functions.py
@@ -5,8 +5,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
-
 import os,copy
 import numpy as np
 from numpy import linalg
@@ -648,6 +646,7 @@ def mergeWCS(default_wcs, user_pars):
             _crpix = ((shape[0] + 1.0) / 2.0, (shape[1] + 1.0) / 2.0)
 
     else:
+        naxis1, naxis2 = outwcs.pixel_shape
         if _delta_rot is None:
             # no rotation is involved
 
@@ -656,8 +655,8 @@ def mergeWCS(default_wcs, user_pars):
 
                 # compute output image shape:
                 shape = (
-                    max(1, int(_py2round(_ratio * outwcs._naxis1))),
-                    max(1, int(_py2round(_ratio * outwcs._naxis2)))
+                    max(1, int(_py2round(_ratio * naxis1))),
+                    max(1, int(_py2round(_ratio * naxis2)))
                 )
 
                 # update CRPIX:
@@ -667,9 +666,9 @@ def mergeWCS(default_wcs, user_pars):
         else:
             _corners = np.array(
                 [[0.5, 0.5],
-                 [outwcs._naxis1 + 0.5, 0.5],
-                 [0.5, outwcs._naxis2 + 0.5],
-                 [outwcs._naxis1 + 0.5, outwcs._naxis2 + 0.5]]
+                 [naxis1 + 0.5, 0.5],
+                 [0.5, naxis2 + 0.5],
+                 [naxis1 + 0.5, naxis2 + 0.5]]
             ) - outwcs.wcs.crpix
 
             if _ratio is not None:
@@ -705,7 +704,7 @@ def mergeWCS(default_wcs, user_pars):
 
     if shape is not None:
         # update size:
-        outwcs._naxis1, outwcs._naxis2 = shape
+        outwcs.pixel_shape = shape
 
     # update reference position
     if _crpix is not None:

--- a/drizzlepac/wfc3Data.py
+++ b/drizzlepac/wfc3Data.py
@@ -6,10 +6,6 @@
 :License: :doc:`LICENSE`
 
 """
-
-from __future__ import absolute_import, division, print_function # confidence high
-
-
 from stsci.tools import fileutil
 from nictools import readTDD
 from .imageObject import imageObject

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -6,7 +6,6 @@
 :License: :doc:`LICENSE`
 
 """
-from __future__ import absolute_import, division, print_function # confidence medium
 import os
 
 from astropy.io import fits

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
-
 import inspect
 import os
 import pkgutil
@@ -175,13 +172,16 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     setup_requires=SETUP_REQUIRES,
+    python_requires='>=3.5',
     install_requires=[
-        'astropy',
+        'astropy>=3.1',
         'fitsblender',
         'nictools',
         'nose',
         'numpy',
         'scipy',
+        'matplotlib',
+        'acstools',
         'spherical-geometry',
         'stsci.tools',
         'stsci.image>=2.3.0',
@@ -192,7 +192,9 @@ setup(
         'stsci.stimage',
         'stwcs',
         'stregion',
+        'requests',
     ],
+    tests_require=['crds', 'pytest'],
     packages=find_packages(),
     package_data={
         '': ['README.md', 'LICENSE.txt'],

--- a/src/arrdrizmodule.c
+++ b/src/arrdrizmodule.c
@@ -1176,7 +1176,6 @@ static PyMethodDef cdriz_methods[] =
     {0, 0, 0, 0}                             /* sentinel */
   };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "cdriz",
@@ -1188,18 +1187,12 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-#endif
 
-#if PY_MAJOR_VERSION >= 3
 PyObject *PyInit_cdriz(void)
-#else
-void initcdriz(void)
-#endif
 {
   PyObject* m;
   driz_log_func = &cdriz_log_func;
 
-#if PY_MAJOR_VERSION >= 3
   if (PyType_Ready(&WCSMapType) < 0) {
     return NULL;
   }
@@ -1208,21 +1201,11 @@ void initcdriz(void)
     return NULL;
   }
 
-#else
-  if (PyType_Ready(&WCSMapType) < 0)
-    return;
-  m = Py_InitModule("cdriz", cdriz_methods);
-  if (m == NULL)
-    return;
-#endif
-
   import_array();
   import_astropy_wcs();
 
   Py_INCREF(&WCSMapType);
   PyModule_AddObject(m, "DefaultWCSMapping", (PyObject *)&WCSMapType);
 
-#if PY_MAJOR_VERSION >= 3
   return m;
-#endif
 }

--- a/tests/acs/test_unit.py
+++ b/tests/acs/test_unit.py
@@ -27,8 +27,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -70,8 +69,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -112,8 +110,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -155,8 +152,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -198,8 +194,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -241,8 +236,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -284,8 +278,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
         output_wcs = self.read_wcs(output_template)
 
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -324,8 +317,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
 
         output_wcs = self.read_wcs(output_template)
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')
@@ -360,8 +352,7 @@ class TestDriz(BaseUnit):
         inwht = np.ones(insci.shape,dtype=insci.dtype)
 
         output_wcs = self.read_wcs(output_template)
-        naxis1 = output_wcs._naxis1
-        naxis2 = output_wcs._naxis2
+        naxis1, naxis2 = output_wcs.pixel_shape
         outsci = np.zeros((naxis2, naxis1), dtype='float32')
         outwht = np.zeros((naxis2, naxis1), dtype='float32')
         outcon = np.zeros((1, naxis2, naxis1), dtype='i4')

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -1,6 +1,5 @@
 """HSTCAL regression test helpers."""
-from astropy.extern.six.moves import urllib
-
+import urllib
 import getpass
 import os
 import sys


### PR DESCRIPTION
This PR deals with three issues:

1. Fixes deprecation warnings due to deprecation of the `WCS._naxis1` - see https://github.com/spacetelescope/drizzlepac/issues/186

2. Remove support for Python 2.

3. Remove last dependency on `stsci.convolve`