### PR TITLE
Add computation and reporting of the RMSE and MAE of the fit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ of the list).
 DrizzlePac (DEVELOPMENT)
 ========================
 
+- Add computation and reporting of the fit's Root-Mean-Square Error (RMSE) and
+  Mean Absolute Error (MAE). [#208]
+
 - Replaced the use of ``WCS._naxis1`` and ``WCS._naxis2`` with
   ``WCS.pixel_shape`` [#207]
 

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -696,8 +696,10 @@ class Image(object):
                 else:
                     assert(False)
 
-                print('XRMS: %.2g    YRMS: %.2g\n'%(
-                        self.fit['rms'][0],self.fit['rms'][1]))
+                print('FIT XRMS: {:<7.2g}    FIT YRMS: {:<7.2g}'
+                      .format(*self.fit['rms']))
+                print('FIT RMSE: {:<7.2g}    FIT MAE: {:<7.2g}\n'
+                      .format(self.fit['rmse'], self.fit['mae']))
                 print('RMS_RA: %.2g (deg)   RMS_DEC: %.2g (deg)\n'%(
                         self.fit['rms_keys']['RMS_RA'],
                         self.fit['rms_keys']['RMS_DEC']))

--- a/drizzlepac/linearfit.py
+++ b/drizzlepac/linearfit.py
@@ -210,9 +210,10 @@ def fit_shifts(xy, uv):
 
     fit = build_fit(Pcoeffs, Qcoeffs, 'shift')
     resids = diff_pts - fit['offset']
-    rms = [resids[:,0].std(),resids[:,1].std()]
     fit['resids'] = resids
-    fit['rms'] = rms
+    fit['rms'] = resids.std(axis=0)
+    fit['rmse'] = float(np.sqrt(np.mean(2 * resids**2)))
+    fit['mae'] = float(np.mean(np.linalg.norm(resids, axis=1)))
 
     return fit
 
@@ -268,9 +269,10 @@ def fit_general(xy, uv):
     # Return the shift, rotation, and scale changes
     result = build_fit(P, Q, 'general')
     resids = xy - np.dot(uv, result['fit_matrix']) - result['offset']
-    rms = [resids[:,0].std(), resids[:,1].std()]
-    result['rms'] = rms
+    result['rms'] = resids.std(axis=0)
     result['resids'] = resids
+    result['rmse'] = float(np.sqrt(np.mean(2 * resids**2)))
+    result['mae'] = float(np.mean(np.linalg.norm(resids, axis=1)))
 
     return result
 
@@ -561,8 +563,9 @@ def geomap_rscale(xyin,xyref,center=None):
     # Return the shift, rotation, and scale changes
     result = build_fit(P, Q, fitgeom='rscale')
     resids = xyin - np.dot((xyref), result['fit_matrix']) - result['offset']
-    rms = [resids[:,0].std(), resids[:,1].std()]
-    result['rms'] = rms
+    result['rms'] = resids.std(axis=0)
     result['resids'] = resids
+    result['rmse'] = float(np.sqrt(np.mean(2 * resids**2)))
+    result['mae'] = float(np.mean(np.linalg.norm(resids, axis=1)))
 
     return result


### PR DESCRIPTION
This PR adds computation and reporting of the fit's `RMSE` and `MAE` errors. This addresses https://github.com/spacetelescope/drizzlepac/issues/206 without removing `RMSX` and `RMSY` for backward compatibility purposes.