### PR TITLE
Remove unnecessary PATH, HOME overrides

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -3,8 +3,6 @@ if (utils.scm_checkout()) return
 
 
 def test_env = [
-    'PATH=./miniconda/bin:$PATH',
-    'HOME=./',
     'TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory'
 ]
 
@@ -45,7 +43,7 @@ bc.conda_packages = ['numpy',
                      'stsci.stimage',
                      'setuptools',
                      'python=3.6']
-bc.build_cmds = ["conda install -q astropy stwcs -c http://ssb.stsci.edu/astroconda-dev",
+bc.build_cmds = ["./miniconda/bin/conda install -q astropy stwcs -c http://ssb.stsci.edu/astroconda-dev",
                  "python setup.py install"]
 bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
 bc.test_configs = [data_config]


### PR DESCRIPTION
and use relative path to invoke `conda` for installation of special-case development packages to prevent the erroneous use of the python interpreter in the base conda environment for execution of applicable `build_cmds` & `test_cmds`, rather than the interpreter provided in the custom environment created for hosting the build.