### PR TITLE
Initial version which calls alignimages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ of the list).
 DrizzlePac (DEVELOPMENT)
 ========================
 
+- Update runastrodriz to compute and apply absolute astrometric corrections to
+  GAIA (or related) frame to images where possible.
+
 - Add computation and reporting of the fit's
   `Root-Mean-Square Error (RMSE) <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_
   and `Mean Absolute Error (MAE) <https://en.wikipedia.org/wiki/Mean_absolute_error>`_.


### PR DESCRIPTION
These changes allow alignimages to be called from 'runastrodriz' so that the pipeline can align the images.  This initially expects alignimages to be in the HLAPipeline package. 

This requires [hlapipelne PR 72](https://github.com/spacetelescope/hlapipeline/pull/72) in order to work correctly.  
