### PR TITLE
Restore API for perform_align function

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -73,6 +73,7 @@ __version_date__ = '15-Feb-2019'
 
 # ----------------------------------------------------------------------------------------------------------------------
 
+
 def check_and_get_data(input_list,**pars):
     """Verify that all specified files are present. If not, retrieve them from MAST.
 
@@ -139,10 +140,7 @@ def convert_string_tf_to_boolean(invalue):
 
 
 # ----------------------------------------------------------------------------------------------------------------------
-
-@util.with_logging
-def perform_align(input_list, archive=False, clobber=False, debug=False, update_hdr_wcs=False, result=None, runfile=None,
-                  print_fit_parameters=True, print_git_info=False, output=False): # TODO: set 'debug' and 'output' back to 'False' before release.
+def perform_align(input_list, **kwargs):
     """Main calling function.
 
     Parameters
@@ -164,10 +162,6 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
     update_hdr_wcs : Boolean
         Write newly computed WCS information to image image headers?
 
-    result : Astropy Table
-        Write the contents of the filteredTable to the result so that it can be passed back to the calling routine
-        as a parameter versus a returned value as the @util.with_logging decorator does not allow returned values
-
     print_fit_parameters : Boolean
         Specify whether or not to print out FIT results for each chip.
 
@@ -185,6 +179,13 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         Table which contains processing information and alignment results for every raw image evaluated
 
     """
+    filteredTable = Table()
+    run_align(input_list, result=filteredTable, **kwargs)
+    return filteredTable
+
+@util.with_logging
+def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_wcs=False, result=None, runfile=None,
+                  print_fit_parameters=True, print_git_info=False, output=False):
 
     log.info("*** HLAPIPELINE Processing Version {!s} ({!s}) started at: {!s} ***\n".format(__version__, __version_date__, util._ptime()[0]))
 
@@ -393,6 +394,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                     filteredTable['status'][:] = 1
                     filteredTable['processMsg'][:] = "Fitting failure"
                     # It may be there are additional catalogs and algorithms to try, so keep going
+                    fitQual = 5 # Flag this fit with the 'bad' quality value
                     continue
 
                 if fitQual == 1:  # break out of inner fit algorithm loop

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -72,6 +72,8 @@ import numpy as np
 
 import math
 
+import math
+
 
 __taskname__ = "runastrodriz"
 
@@ -303,9 +305,9 @@ def process(inFile,force=False,newpath=None, inmemory=False, num_cores=None,
         _trlmsg = ""
 
         # Create an empty astropy table so it can be used as input/output for the perform_align function
-        align_table = Table()
+        #align_table = Table()
         try:
-            alignimages.perform_align(align_files,update_hdr_wcs=True,result=align_table, runfile=_alignlog)
+            align_table = alignimages.perform_align(align_files,update_hdr_wcs=True, runfile=_alignlog)
             for row in align_table:
                 if row['status'] == 0:
                     trlstr = "Successfully aligned {} to {} astrometric frame\n"
@@ -313,6 +315,7 @@ def process(inFile,force=False,newpath=None, inmemory=False, num_cores=None,
                 else:
                     trlstr = "Could not align {} to absolute astrometric frame\n"
                     _trlmsg += trlstr.format(row['imageName'])
+
         except Exception:
             # Something went wrong with alignment to GAIA, so report this in
             # trailer file

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -66,14 +66,7 @@ import time
 
 # THIRD-PARTY
 from astropy.io import fits
-from astropy.table import Table
 from stsci.tools import fileutil, asnutil
-import numpy as np
-
-import math
-
-import math
-
 
 __taskname__ = "runastrodriz"
 


### PR DESCRIPTION
The interface to perform_align() could not return any values when wrapped by the util.with_logging decorator.  However, the pipeline relies on the returned table to determine what to do next.  This set of changes restores the interface so that perform_align( ) once again returns the filteredTable.  