### PR TITLE
Fix step7 logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ of the list).
 3.0.2 (unreleased)
 ==================
 
+- Fix logic so that code no longer tries to update headers when no valid fit
+  could be determined. [#241] 
+
 - Updated code that relies on ``tweakwcs`` to use new API. [#234]
 
 - Fixed a bug in the computation of interpolated large scale flat field

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -459,7 +459,7 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
     startingDT = currentDT
     # 7: Write new fit solution to input image headers
     log.info("-------------------- STEP 7: Update image headers with new WCS information -----------------------------")
-    if best_fit_rms > 0 and update_hdr_wcs:
+    if (0 < best_fit_rms < 9999.) and update_hdr_wcs:
         headerlet_dict = update_image_wcs_info(imglist)
         for tableIndex in range(0,len(filteredTable)):
             filteredTable[tableIndex]['headerletFile'] = headerlet_dict[filteredTable[tableIndex]['imageName']]


### PR DESCRIPTION
Logic in alignimages allowed any solution with rms > 0 to be used to update the headers.  However, a default value of 1e+9 mas is used to flag fits which never get performed causing this logic to try to update the headers with invalid/non-existent fits.  

This simply change takes this into account when performing the check for running STEP 7.