### PR TITLE
Bugfix: Correct perform_align() subroutine call in alignimages.py

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -1110,6 +1110,8 @@ if __name__ == '__main__':
     output = convert_string_tf_to_boolean(ARGS.output)
 
     # Get to it!
-    return_value = perform_align(input_list,archive,clobber,debug,update_hdr_wcs,print_fit_parameters,print_git_info)
+    return_value = perform_align(input_list, archive=archive, clobber=clobber, debug=debug,
+                                 update_hdr_wcs=update_hdr_wcs, print_fit_parameters=print_fit_parameters,
+                                 print_git_info=print_git_info, output=output)
 
     log.info(return_value)


### PR DESCRIPTION
All changes were limited to the perform_align() subroutine call on line 1113 of alignimages.py.
The subroutine call had 2 issues that prevented alignimages.py from being successfully executed from the command line: 
1) The master version subroutine inputs were not formatted correctly.
2) The master version subroutine call was missing the final required input parameter "output".
