### PR TITLE
Astroquery import error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ of the list).
 3.0.2 (unreleased)
 ==================
 - Trap problems importing astroquery with any problems leading to not trying to
-  get any remote data through astroquery. [#246]
+  get any remote data through astroquery. [#248]
 
 - Restore logic to flag failed fits with a fit quality of 5 in an except block. [#244]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ of the list).
 
 3.0.2 (unreleased)
 ==================
+- Trap problems importing astroquery with any problems leading to not trying to
+  get any remote data through astroquery. [#246]
+
 - Restore logic to flag failed fits with a fit quality of 5 in an except block. [#244]
 
 - Fix logic so that code no longer tries to update headers when no valid fit

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -89,7 +89,10 @@ def check_and_get_data(input_list,**pars):
     totalInputList = []
     retrieve_list = [] # list of already retrieved ASNs, only request each once
     for input_item in input_list:
-        filelist = aqutils.retrieve_observation(input_item,**pars)
+        try:
+            filelist = aqutils.retrieve_observation(input_item,**pars)
+        except Exception:
+            filelist = []
         if len(filelist) == 0:
             # look for local copy of the file
             input_rootname = input_item[:input_item.find('_')]
@@ -104,8 +107,11 @@ def check_and_get_data(input_list,**pars):
                 except KeyError:
                     asnid = None
                 if asnid and asnid not in retrieve_list:
-                    filelist = aqutils.retrieve_observation(asnid,**pars)
-                    retrieve_list.append(asnid) # record asn's already retrieved
+                    try:
+                        filelist = aqutils.retrieve_observation(asnid,**pars)
+                        retrieve_list.append(asnid) # record asn's already retrieved
+                    except Exception:
+                        filelist = []
 
         if len(filelist) > 0:
             totalInputList += filelist


### PR DESCRIPTION
Pipeline testing of HSTDP 2019.2 encountered errors which were triggered when alignimages tried to import astroquery.mast.  It is unclear why the pipeline would encounter this problem, and it is not something that has been reproduced locally.  A discussion with Clara (astroquery developer) did not provide any obvious reason for this behavior either.  

Therefore, these changes are being submitted in an attempt to make the use of astroquery effectively optional, with the code simply falling back to relying on what is already in the current directory in case of any problems with using astroquery.  

This PR should not be merged until the problem can be reproduced locally, or at least these changes are confirmed to actually work as intended when problems are forcibly created while also confirming that the code works normally when there are no problems.