### PR TITLE
Add archive hdrlet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ of the list).
 3.0.2 (unreleased)
 ==================
 - Insure new a posteriori solution gets appended to FLC file as well as FLT file
-  as a HDRLET extension. [#248]
+  as a HDRLET extension. [#249]
 
 - Restore logic to flag failed fits with a fit quality of 5 in an except block. [#244]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ of the list).
 
 3.0.2 (unreleased)
 ==================
+- Insure new a posteriori solution gets appended to FLC file as well as FLT file
+  as a HDRLET extension. [#248]
+
 - Restore logic to flag failed fits with a fit quality of 5 in an except block. [#244]
 
 - Fix logic so that code no longer tries to update headers when no valid fit

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -394,7 +394,7 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
                     # It may be there are additional catalogs and algorithms to try, so keep going
                     fitQual = 5 # Flag this fit with the 'bad' quality value
                     continue
-                
+
                 if fitQual == 1:  # break out of inner fit algorithm loop
                     break
         if fitQual == 1: #break out of outer astrometric catalog loop
@@ -909,6 +909,9 @@ def update_image_wcs_info(tweakwcs_output):
             out_headerlet.writeto(headerlet_filename, clobber=True)
             log.info("Wrote headerlet file {}.\n\n".format(headerlet_filename))
             out_headerlet_dict[imageName] = headerlet_filename
+
+            # Attach headerlet as HDRLET extension
+            headerlet.attach_headerlet(imageName, headerlet_filename)
 
         chipctr +=1
     return (out_headerlet_dict)


### PR DESCRIPTION
Evaluation of test results generated in testing HSTDP 2019.2 indicated that the new a posteriori solutions were NOT getting appended as HDRLET extensions to the original FLC files, where they were being attached to the FLT files.  

So, in order to keep the FLC and FLT files consistent with the same set of WCS solutions, this change explicitly attaches the newly created solution as a HDRLET extension to the image used to compute the solution (typically, the FLC file).  