### PR TITLE
Update runastrodriz to NOT overwrite hlet file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ of the list).
 
 3.0.2 (unreleased)
 ==================
+- Insure a posteriori headerlet does not get overwritten by runastrodriz, so that
+  info about fit is preserved. [#250]
+
 - Trap problems importing astroquery with any problems leading to not trying to
   get any remote data through astroquery. [#248]
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -448,14 +448,17 @@ def process(inFile,force=False,newpath=None, inmemory=False, num_cores=None,
         for fname in _calfiles:
             frootname = fileutil.buildNewRootname(fname)
             hname = "%s_flt_hlet.fits"%frootname
-            hlet_msg += "Created Headerlet file %s \n"%hname
-            try:
-                headerlet.write_headerlet(fname,'OPUS',output='flt', wcskey='PRIMARY',
-                    author="OPUS",descrip="Default WCS from Pipeline Calibration",
-                    attach=False,clobber=True,logging=False)
-            except ValueError:
-                hlet_msg += _timestamp("SKIPPED: Headerlet not created for %s \n"%fname)
-                # update trailer file to log creation of headerlet files
+            # Write out headerlet file used by astrodrizzle, however,
+            # do not overwrite any that was already written out by alignimages
+            if not os.path.exists(hname):
+                hlet_msg += "Created Headerlet file %s \n"%hname
+                try:
+                    headerlet.write_headerlet(fname,'OPUS',output='flt', wcskey='PRIMARY',
+                        author="OPUS",descrip="Default WCS from Pipeline Calibration",
+                        attach=False,clobber=True,logging=False)
+                except ValueError:
+                    hlet_msg += _timestamp("SKIPPED: Headerlet not created for %s \n"%fname)
+                    # update trailer file to log creation of headerlet files
         hlet_msg += _timestamp("Writing Headerlets completed")
         ftrl = open(_trlfile,'a')
         ftrl.write(hlet_msg)


### PR DESCRIPTION
This updates the `runastrodriz.py` wrapper to make sure that it does NOT overwrite any headerlet file already written out (with much more information) by alignimages (or any other code used).  This will insure that the ancillary information about the fit for each image gets retained in the hlet.fits files and archived properly.