### PR TITLE
Implement envvar control of alignment in runastrodriz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ of the list).
 
 3.0.2 (unreleased)
 ==================
+- Implement environment variable control, and command-line control, over running
+  alignment step in runastrodriz. [#251]
+  
 - Insure a posteriori headerlet does not get overwritten by runastrodriz, so that
   info about fit is preserved. [#250]
 


### PR DESCRIPTION
Control over operation of the a posteriori alignment has been added to 'runastrodriz' through use of a new environment variable as well as a new command-line switch.  This will allow the pipeline to turn this capability on/off at will without a new software delivery. 