### PR TITLE
Fix setuptools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ for (numpy_ver in matrix_numpy) {
     bc.conda_packages += ["astropy${astropy_ver}",
                           "numpy${numpy_ver}",
                           "python=${python_ver}"]
-    bc.build_cmds = ["python setup.py install"]
+    bc.build_cmds = ["pip install ."]
     bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
     bc.test_configs = [data_config]
     matrix += bc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ for (numpy_ver in matrix_numpy) {
     bc.conda_packages += ["astropy${astropy_ver}",
                           "numpy${numpy_ver}",
                           "python=${python_ver}"]
-    bc.build_cmds = ["pip install ."]
+    bc.build_cmds = ["pip install -e ."]
     bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
     bc.test_configs = [data_config]
     matrix += bc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,9 @@
+[build-system]
+requires = [
+    "setuptools>=38.2.5",
+    "wheel",
+    "numpy",
+]
+
 [tool.stsci-bot]
 check_milestone = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=38.2.5",
     "wheel",
     "numpy",
+    "astropy"
 ]
 
 [tool.stsci-bot]


### PR DESCRIPTION
Latest `setuptools` produces the following error during build:
```        
from setuptools import setup, find_packages, Extension, _install_setup_requires
ImportError: cannot import name '_install_setup_requires'
```

This implements `pyproject.toml` (PEP517) as a replacement.