### PR TITLE
Ensure singletons do not use the match_relative_fit algorithm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,6 +90,8 @@ of the list).
 
 - Modified the check on the tweakwcs_output to be more robust[#260]
 
+- Ensure singletons do not use the match_relative_fit algorithm [#259]
+
 
 2.2.6 (02-Nov-2018)
 ===================

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -198,9 +198,6 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
     # Define astrometric catalog list in priority order
     catalogList = ['GAIADR2', 'GAIADR1']
 
-    # Define fitting algorithm list in priority order
-    fit_algorithm_list = [match_relative_fit,match_default_fit,match_2dhist_fit]
-
     # 0: print git info
     if print_git_info:
         log.info("-------------------- STEP 0: Display Git revision info  ------------------------------------------------")
@@ -248,6 +245,14 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
     processList = filteredTable['imageName'][np.where(filteredTable['doProcess'])]
     processList = list(processList) #Convert processList from numpy list to regular python list
     log.info("SUCCESS")
+
+    # Define fitting algorithm list in priority order
+    # The match_relative_fit algorithm must have more than one image as the first image is
+    # the reference for the remaining images.
+    if len(processList) > 1:
+        fit_algorithm_list=[match_relative_fit,match_2dhist_fit,match_default_fit]
+    else:
+        fit_algorithm_list=[match_2dhist_fit,match_default_fit]
 
     currentDT = datetime.datetime.now()
     deltaDT = (currentDT - startingDT).total_seconds()


### PR DESCRIPTION
Singletons cannot use the match_relative_fit algorithm because the algorithm requires at least two images - one which servers as the reference and the remaining image(s) are aligned to the reference.