### PR TITLE
JenkinsfileRT: Use pip arguments that fit context

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -49,14 +49,14 @@ bc.conda_packages = ['acstools',
                      'setuptools',
                      'pip',
                      'python=3.6']
-bc.build_cmds = ["python setup.py install"]
+bc.build_cmds = ["pip install --no-deps -e ."]
 bc.test_cmds = ["pytest --basetemp=tests_output --junitxml results.xml --bigdata --remote-data=any"]
 bc.test_configs = [data_config]
 
 bc1 = utils.copy(bc)
 bc1.name = '3.6-dev'
 bc1.conda_channels = ['http://ssb.stsci.edu/conda-dev']
-bc1.build_cmds = ["pip install --no-deps -e ."]
+bc1.build_cmds = ["pip install --upgrade -e ."]
 
 // Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host (or workdir) for each combination and run in parallel.


### PR DESCRIPTION
RT job partially failing due to not compiling C extensions in-place