### PR TITLE
Mods to add/update regression tests for alignment code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,6 +97,9 @@ of the list).
   to the associated regression tests migrated from the original hlapipeline
   package [#283].
 
+- Fixed improper logic caused by nested if statements in analyze.py found
+  when testing [#283].
+
 
 2.2.6 (02-Nov-2018)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -92,6 +92,11 @@ of the list).
 
 - Ensure singletons do not use the match_relative_fit algorithm [#259]
 
+- Entirely re-wrote check_and_get_data function in alignimages.py.
+  Updates to the overall hlapipeline alignment code and updates/clean-up 
+  to the associated regression tests migrated from the original hlapipeline
+  package [#283].
+
 
 2.2.6 (02-Nov-2018)
 ===================

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -103,10 +103,11 @@ def check_and_get_data(input_list,**pars):
 
     # If the regression test flag is True, a regression test has been invoked where the input_list 
     # actually contains the full filename(s) (e.g., *_flt.fits).  Note that not all regression tests use 
-    # this functionality as Artifactory is accessed for the data source with the use of this flag.
+    # this functionality as Artifactory is accessed for the data source with the use of this flag.  Some
+    # regression tests use astroquery to connect to MAST. This regression testing code is not a scalable
+    # solution, but it is necessary for the alignment portion of the drizzle software.
     if pars['regtest'] == True:
         # Artifactory root name and test folder containing the data
-        remote_root=os.environ['TEST_BIGDATA']
         data_path = pars['test_data_path']
         from ci_watson.artifactory_helpers import get_bigdata
         for infile in input_list:
@@ -119,7 +120,6 @@ def check_and_get_data(input_list,**pars):
         for input_item in input_list:
             try:
                 filelist = aqutils.retrieve_observation(input_item,archive=archive,clobber=clobber)
-                #filelist = aqutils.retrieve_observation(input_item)
             except Exception:
                 filelist = []
             if len(filelist) == 0:

--- a/drizzlepac/hlautils/analyze.py
+++ b/drizzlepac/hlautils/analyze.py
@@ -196,20 +196,6 @@ def analyze_data(inputFileList, **kwargs):
             noProcKey   = SCNKEY
             noProcValue = scan_typ
 
-        # Filter which does not begin with: 'F'(F###), 'C'(CLEAR), 'N'(N/A), and is not blank
-        # The sfilter variable may be the concatenation of two filters (F160_CLEAR)
-        elif sfilter and not sfilter.startswith(('F', 'C', 'N')):
-            noProcKey   = FILKEY
-            noProcValue = sfilter
-
-        elif '_' in sfilter:
-            pos = sfilter.index('_')
-            pos += 1
-
-            if sfilter[pos] != 'F' and sfilter[pos] != '' and sfilter[pos] != 'C' and sfilter[pos] != 'N':
-                noProcKey   = FILKEY
-                noProcValue = sfilter
-
         # Ramp, polarizer, grism, or prism
         elif any (x in aperture for x in ['RAMP', 'POL', 'GRISM', '-REF', 'PRISM']):
             noProcKey   = APKEY
@@ -235,6 +221,20 @@ def analyze_data(inputFileList, **kwargs):
             noProcKey   = CHINKEY
             noProcValue = chinject
 
+        # Filter which does not begin with: 'F'(F###), 'C'(CLEAR), 'N'(N/A), and is not blank
+        # The sfilter variable may be the concatenation of two filters (F160_CLEAR)
+        elif sfilter and not sfilter.startswith(('F', 'C', 'N')):
+            noProcKey   = FILKEY
+            noProcValue = sfilter
+
+        elif '_' in sfilter:
+            pos = sfilter.index('_')
+            pos += 1
+
+            if sfilter[pos] != 'F' and sfilter[pos] != '' and sfilter[pos] != 'C' and sfilter[pos] != 'N':
+                noProcKey   = FILKEY
+                noProcValue = sfilter
+
         # If noProcKey is set to a keyword, then this image has been found to not be viable for
         # alignment purposes.
         if (noProcKey is not None):
@@ -258,6 +258,7 @@ def analyze_data(inputFileList, **kwargs):
                              offset_x, offset_y, rot, scale, rms_x, rms_y,
                              rms_ra, rms_dec, completed, fit_rms, total_rms, datasetKey,
                              status, fit_qual, headerletFile])
+        processMsg = None
     #outputTable.pprint(max_width=-1)
 
     return(outputTable)

--- a/tests/hla/base_classes.py
+++ b/tests/hla/base_classes.py
@@ -12,6 +12,7 @@ from drizzlepac.hlautils.astroquery_utils import retrieve_observation
 
 # Base classes for actual tests.
 # NOTE: Named in a way so pytest will not pick them up here.
+@pytest.mark.bigdata
 class BaseTest(object):
     prevdir = os.getcwd()
     use_ftp_crds = True

--- a/tests/hla/base_classes.py
+++ b/tests/hla/base_classes.py
@@ -1,0 +1,178 @@
+"""Regression test helpers."""
+import os
+
+import pytest
+from astropy.io import fits
+from astropy.utils.data import conf
+
+from ci_watson.artifactory_helpers import get_bigdata
+from ci_watson.artifactory_helpers import compare_outputs
+
+from drizzlepac.hlautils.astroquery_utils import retrieve_observation
+
+# Base classes for actual tests.
+# NOTE: Named in a way so pytest will not pick them up here.
+class BaseTest(object):
+    prevdir = os.getcwd()
+    use_ftp_crds = True
+    timeout = 30  # seconds
+    tree = 'dev'
+    docopy = False
+
+    # Numpy default for allclose comparison
+    rtol = 1e-6
+    atol = 0
+
+    # To be defined by instrument/test
+    input_repo = ''  # e.g., 'drizzlepac' or 'jwst-pipeline'
+    results_root = None  # e.g., 'drizzlepac-results'
+    input_loc = ''  # root directory for 'input' files
+    ref_loc = []    # root path for 'truth' files: ['test1','truth'] or ['test3']
+    ignore_keywords = []
+    ignore_table_keywords = []
+    ignore_fields = []
+    ignore_hdus = []
+
+    # To be defined by individual test
+    subdir = ''
+    curdir = ''
+
+    @pytest.fixture(autouse=True)
+    def setup_class(self, tmpdir, envopt):
+        """
+        Run test in own dir so we can keep results separate from
+        other tests.
+        """
+        # create working directory specified for the test
+        if not tmpdir.ensure(self.subdir, dir=True):
+            curdir = tmpdir.mkdir(self.subdir).strpath
+        else:
+            curdir = tmpdir.join(self.subdir).strpath
+        os.chdir(curdir)
+        self.curdir = curdir
+
+        # This controls astropy.io.fits timeout
+        conf.remote_timeout = self.timeout
+
+        # Update tree to point to correct environment
+        self.tree = envopt
+
+        # Configure environment for tests
+        self.set_environ()
+
+    def teardown_class(self):
+        """Reset path and variables."""
+        conf.reset('remote_timeout')
+        os.chdir(self.prevdir)
+        if self.use_ftp_crds and self.prevref is not None:
+            os.environ[self.refstr] = self.prevref
+
+    def set_environ(self):
+        """Set environment variables for test environment to be used
+
+           Each class/test will define what needs to be set, if anything.
+           For example, control use of Astrometry updates for HST with:
+               os.environ['ASTROMETRY_STEP_CONTROL'] = 'OFF'
+        """
+        pass
+
+    def get_input_path(self):
+        """
+        Return path within repository to remote source of input data
+        """
+        path = [self.input_repo, self.tree, self.input_loc]
+
+        return path
+
+    def get_data(self, *args, **kwargs):
+        """
+        Download `filename` into working directory using
+        `artifactory_helpers/get_bigdata()` or 
+        `astroquery_utils.retrieve_observation`.  Use of `astroquery_utils`
+	will allow getting data directly from MAST via astroquery.
+
+        Returns
+        --------
+        local_files : list
+            This will return a list of all the files downloaded with 
+            the full path to the local copy of the file.
+        """
+        if len(args[0]) == 9: # Only a rootname provided
+            local_files = retrieve_observation(args[0])
+        else:
+            # If user has specified action for no_copy, apply it with
+            # default behavior being whatever was defined in the base class.
+            docopy = kwargs.get('docopy', self.docopy)
+            local_files = get_bigdata(*self.get_input_path(),
+                                     *args,
+                                     docopy=docopy)
+            local_files = [local_files]
+
+        return local_files
+
+    def raw_from_asn(self, asn_file):
+        """
+        Return the list of  member exposures specified in the
+        association file.
+
+        .. WARNING::
+        This method needs to be defined by each subclass.
+        """
+        msg = "Sub-class needs to define this method."
+        raise NotImplementedError(msg)
+
+
+    def get_input_file(self, *args, refsep='$', **kwargs):
+        """
+        Download or copy input file (e.g., RAW) into the working directory.
+        Can be differentiated from 'get_data' by overloading with version for
+        the test that performs additional steps, such as identifying and
+        downloading calibration ref files from CRDS (HST does not do this
+        automatically).
+        """
+        # If user has specified action for no_copy, apply it with
+        # default behavior being whatever was defined in the base class.
+        docopy = kwargs.get('docopy', self.docopy)
+
+        self.get_data(*args, docopy=docopy)
+
+    def compare_outputs(self, outputs, raise_error=True, **kwargs):
+
+        # Parse any user-specified kwargs
+        ignore_keywords = kwargs.get('ignore_keywords', self.ignore_keywords)
+        ignore_hdus = kwargs.get('ignore_hdus', self.ignore_hdus)
+        ignore_fields = kwargs.get('ignore_fields', self.ignore_fields)
+        rtol = kwargs.get('rtol', self.rtol)
+        atol = kwargs.get('atol', self.atol)
+
+        compare_kws = dict(ignore_fields=ignore_fields, ignore_hdus=ignore_hdus,
+                        ignore_keywords=ignore_keywords,
+                        rtol=rtol, atol=atol)
+
+        input_path = [self.input_repo, self.tree, self.input_loc, *self.ref_loc]
+
+        return compare_outputs(outputs, raise_error=True,
+                               input_path=input_path,
+                               docopy = self.docopy,
+                               results_root = self.results_root,
+                               **compare_kws)
+
+def get_hdu(filename):
+    """Return the HDU for the file and extension specified in the filename.
+
+       This routine expects the filename to be of the format:
+           <filename>.fits[extn]
+
+        For example, "jw99999-a3001_t1_nircam_f140m-maskbar_i2d.fits[hdrtab]"
+    """
+    froot, fextn = filename.split('[')
+    fextn = fextn.replace(']','')
+    fits_file = fits.open(froot)
+    return fits_file[fextn]
+
+def build_hdulist(filename, extn_list):
+    """Create a new HDUList object based on extensions specified in extn_list"""
+    f = fits.open(filename)
+    fhdu = [f[extn] for extn in extn_list]
+
+    return fhdu

--- a/tests/hla/base_classes.py
+++ b/tests/hla/base_classes.py
@@ -172,8 +172,8 @@ def get_hdu(filename):
     return fits_file[fextn]
 
 def build_hdulist(filename, extn_list):
-    """Create a new HDUList object based on extensions specified in extn_list"""
-    f = fits.open(filename)
-    fhdu = [f[extn] for extn in extn_list]
+    """Create a new list object based on extensions specified in extn_list"""
+    with fits.open(filename) as f:
+        fhdu = [f[extn] for extn in extn_list]
 
     return fhdu

--- a/tests/hla/base_test.py
+++ b/tests/hla/base_test.py
@@ -1,0 +1,405 @@
+import os
+import pytest
+import math
+
+from astropy.io import fits
+from astropy.table import Table
+
+import numpy as np
+import stwcs
+from stwcs import updatewcs
+from stsci.tools import fileutil
+
+from ci_watson.artifactory_helpers import get_bigdata_root
+from ci_watson.hst_helpers import raw_from_asn, ref_from_image, download_crds
+try:
+    from ci_watson.artifactory_helpers import check_url
+except ImportError:
+    from ci_watson.artifactory_helpers import _is_url as check_url
+
+from .base_classes import BaseTest
+
+__all__ = ['BaseHLATest', 'BaseHLAParTest', 'centroid_compare', 'BaseUnit']
+
+@pytest.mark.usefixtures('_jail')
+class BaseHLATest(BaseTest):
+    ignore_hdus = []
+    input_repo = 'hst-hla-pipeline'
+    results_root = 'hst-hla-pipeline-results'
+    output_shift_file = None
+    fit_limit = 0.010 # 10 milli-arcseconds
+    
+    docopy = False  # Do not make additional copy by default
+    rtol = 1e-6
+
+    refstr = 'jref'
+    prevref = os.environ.get(refstr)
+
+    ignore_keywords = ['origin', 'filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'upwtim', 'wcscdate', 'upwcsver', 'pywcsver',
+                       'history', 'prod_ver', 'rulefile']
+
+    reffile_lookup = ['IDCTAB', 'OFFTAB', 'NPOLFILE', 'D2IMFILE', 'DGEOFILE']
+
+    def set_environ(self):
+        # Enforce copies of data when TEST_BIGDATA is URL
+        input_dir = get_bigdata_root()
+
+        if input_dir and check_url(input_dir):
+            self.docopy = True
+
+        # NOTE: This could be explicitly controlled using pytest fixture
+        #       but too many ways to do the same thing would be confusing.
+        #       Refine this logic if using pytest fixture.
+        # HSTCAL cannot open remote CRDS on FTP but central storage is okay.
+        # So use central storage if available to avoid FTP.
+        if self.prevref is None or self.prevref.startswith(('ftp', 'http')):
+            os.environ[self.refstr] = self.curdir + os.sep
+            self.use_ftp_crds = True
+
+        # Turn off Astrometry updates
+        os.environ['ASTROMETRY_STEP_CONTROL'] = 'OFF'
+
+    def raw_from_asn(self, asn_file, suffix='_flt.fits'):
+        return raw_from_asn(asn_file, suffix='_flt.fits')
+
+    def get_input_file(self, *args, refsep='$', **kwargs):
+
+        # If user has specified action for docopy, apply it with
+        # default behavior being whatever was defined in the base class.
+        docopy = kwargs.get('docopy', self.docopy)
+
+#        Download or copy input file (e.g., RAW) into the working directory.
+#        The associated CRDS reference files in ``refstr`` are also
+#        downloaded, if necessary.
+        curdir = os.getcwd()
+        filenames = self.get_data(*args, docopy=docopy)
+        for filename in filenames:
+            ref_files = ref_from_image(filename, reffile_lookup=self.reffile_lookup)
+            print("Looking for {} REF_FILES: {}".format(filename, ref_files))
+
+            for ref_file in ref_files:
+                if ref_file.strip() == '':
+                    continue
+                if refsep not in ref_file:  # Local file
+                    self.get_data('customRef', ref_file, docopy=docopy)
+                else:
+                    # Start by checking to see whether IRAF variable *ref/*tab
+                    # has been added to os.environ
+                    refdir, refname = ref_file.split(refsep)
+                    refdir_parent = os.path.split(refdir)[0]
+                    # Define refdir to point to current directory if:
+                    #   i. refdir is not defined in environment already
+                    #  ii. refdir in os.environ points to another test directory
+                    # This logic should leave refdir unchanged if it already
+                    # points to a globally defined directory.
+                    if refdir not in os.environ or refdir_parent in curdir:
+                        os.environ[refdir] = curdir + os.sep
+
+                    # Download from FTP, if applicable
+                    if self.use_ftp_crds:
+                        download_crds(ref_file, timeout=self.timeout)
+        return filenames
+
+# Pytest function to support the parameterization of these classes
+def pytest_generate_tests(metafunc):
+    # called once per each test function
+    funcarglist = metafunc.cls.params[metafunc.function.__name__]
+    argnames = sorted(funcarglist[0])
+    idlist = [funcargs['id'] for funcargs in funcarglist]
+    del argnames[argnames.index('id')]
+    metafunc.parametrize(argnames, [[funcargs[name] for name in argnames]
+            for funcargs in funcarglist], ids=idlist)
+
+
+@pytest.mark.usefixtures('_jail')
+class BaseHLAParTest(BaseHLATest):
+
+    params = {'test_modes':[dict(input="",
+                                 test_dir=None,
+                                 step_class=None,
+                                 step_pars=dict(),
+                                 output_truth="",
+                                 output_hdus=[])
+                            ]
+             }
+
+    def test_modes(self, input, test_dir, step_class, step_pars,
+                   output_truth, output_hdus):
+        """
+        Template method for parameterizing some tests based on JWST code.
+        """
+        if test_dir is None:
+            return
+
+        self.test_dir = test_dir
+        self.ref_loc = [self.test_dir, 'truth']
+
+        # can be removed once all truth files have been updated
+        self.ignore_keywords += ['FILENAME']
+
+        input_file = self.get_data(self.test_dir, input)
+
+        result = step_class.call(input_file, **step_pars)
+
+        output_file = result.meta.filename
+        result.save(output_file)
+        result.close()
+
+        output_pars = None
+        if isinstance(output_truth, tuple):
+            output_pars = output_truth[1]
+            output_truth = output_truth[0]
+
+        if not output_pars:
+            if output_hdus:
+                output_spec = (output_file, output_truth, output_hdus)
+            else:
+                output_spec = (output_file, output_truth)
+        else:
+            output_spec = {'files':(output_file, output_truth),
+                           'pars':output_pars}
+        outputs = [output_spec]
+        self.compare_outputs(outputs)
+
+
+def centroid_compare(centroid):
+    return centroid[1]
+
+class BaseUnit(BaseHLATest):
+    buff = 0
+    refstr = 'jref'
+    prevref = os.environ.get(refstr)
+    input_loc = 'acs'
+    ref_loc = 'acs'
+    ignore_keywords = ['origin', 'filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'upwtim', 'wcscdate', 'upwcsver', 'pywcsver',
+                       'history', 'prod_ver', 'rulefile']
+    atol = 1.0e-5
+
+    def bound_image(self, image):
+        """
+        Compute region where image is non-zero
+        """
+        coords = np.nonzero(image)
+        ymin = coords[0].min()
+        ymax = coords[0].max()
+        xmin = coords[1].min()
+        xmax = coords[1].max()
+        return (ymin, ymax, xmin, xmax)
+
+    def centroid(self, image, size, center):
+        """
+        Compute the centroid of a rectangular area
+        """
+        ylo = int(center[0]) - size // 2
+        yhi = min(ylo + size, image.shape[0])
+        xlo = int(center[1]) - size // 2
+        xhi = min(xlo + size, image.shape[1])
+
+        center = [0.0, 0.0, 0.0]
+        for y in range(ylo, yhi):
+            for x in range(xlo, xhi):
+                center[0] += y * image[y,x]
+                center[1] += x * image[y,x]
+                center[2] += image[y,x]
+
+        if center[2] == 0.0: return None
+
+        center[0] /= center[2]
+        center[1] /= center[2]
+        return center
+
+    def centroid_close(self, list_of_centroids, size, point):
+        """
+        Find if any centroid is close to a point
+        """
+        for i in range(len(list_of_centroids)-1, -1, -1):
+            if (abs(list_of_centroids[i][0] - point[0]) < size / 2 and
+                abs(list_of_centroids[i][1] - point[1]) < size / 2):
+                return 1
+
+        return 0
+
+    def centroid_distances(self, image1, image2, amp, size):
+        """
+        Compute a list of centroids and the distances between them in two images
+        """
+        distances = []
+        list_of_centroids, lst_pts = self.centroid_list(image2, amp, size)
+
+        for center2, pt in zip(list_of_centroids, lst_pts):
+            center1 = self.centroid(image1, size, pt)
+            if center1 is None: continue
+
+            disty = center2[0] - center1[0]
+            distx = center2[1] - center1[1]
+            dist = math.sqrt(disty * disty + distx * distx)
+            dflux = abs(center2[2] - center1[2])
+            distances.append([dist, dflux, center1, center2])
+
+        distances.sort(key=centroid_compare)
+        return distances
+
+    def centroid_list(self, image, amp, size):
+        """
+        Find the next centroid
+        """
+        list_of_centroids = []
+        list_of_points = []
+        points = np.transpose(np.nonzero(image > amp))
+
+        for point in points:
+            if not self.centroid_close(list_of_centroids, size, point):
+                center = self.centroid(image, size, point)
+                list_of_centroids.append(center)
+                list_of_points.append(point)
+
+        return list_of_centroids, list_of_points
+
+    def centroid_statistics(self, title, fname, image1, image2, amp, size):
+        """
+        write centroid statistics to compare differences btw two images
+        """
+        stats = ("minimum", "median", "maximum")
+        images = (None, None, image1, image2)
+        im_type = ("", "", "test", "reference")
+
+        diff = []
+        distances = self.centroid_distances(image1, image2, amp, size)
+        indexes = (0, len(distances)//2, len(distances)-1)
+        fd = open(fname, 'w')
+        fd.write("*** %s ***\n" % title)
+
+        if len(distances) == 0:
+            diff = [0.0, 0.0, 0.0]
+            fd.write("No matches!!\n")
+
+        elif len(distances) == 1:
+            diff = [distances[0][0], distances[0][0], distances[0][0]]
+
+            fd.write("1 match\n")
+            fd.write("distance = %f flux difference = %f\n" % (distances[0][0], distances[0][1]))
+
+            for j in range(2, 4):
+                ylo = int(distances[0][j][0]) - (1+self.buff)
+                yhi = int(distances[0][j][0]) + (2+self.buff)
+                xlo = int(distances[0][j][1]) - (1+self.buff)
+                xhi = int(distances[0][j][1]) + (2+self.buff)
+                subimage = images[j][ylo:yhi,xlo:xhi]
+                fd.write("\n%s image centroid = (%f,%f) image flux = %f\n" %
+                         (im_type[j], distances[0][j][0], distances[0][j][1], distances[0][j][2]))
+                fd.write(str(subimage) + "\n")
+
+        else:
+            fd.write("%d matches\n" % len(distances))
+
+            for k in range(0,3):
+                i = indexes[k]
+                diff.append(distances[i][0])
+                fd.write("\n%s distance = %f flux difference = %f\n" % (stats[k], distances[i][0], distances[i][1]))
+
+                for j in range(2, 4):
+                    ylo = int(distances[i][j][0]) - (1+self.buff)
+                    yhi = int(distances[i][j][0]) + (2+self.buff)
+                    xlo = int(distances[i][j][1]) - (1+self.buff)
+                    xhi = int(distances[i][j][1]) + (2+self.buff)
+                    subimage = images[j][ylo:yhi,xlo:xhi]
+                    fd.write("\n%s %s image centroid = (%f,%f) image flux = %f\n" %
+                             (stats[k], im_type[j], distances[i][j][0], distances[i][j][1], distances[i][j][2]))
+                    fd.write(str(subimage) + "\n")
+
+        fd.close()
+        return tuple(diff)
+
+    def make_point_image(self, input_image, point, value):
+        """
+        Create an image with a single point set
+        """
+        output_image = np.zeros(input_image.shape, dtype=input_image.dtype)
+        output_image[point] = value
+        return output_image
+
+    def make_grid_image(self, input_image, spacing, value):
+        """
+        Create an image with points on a grid set
+        """
+        output_image = np.zeros(input_image.shape, dtype=input_image.dtype)
+
+        shape = output_image.shape
+        for y in range(spacing//2, shape[0], spacing):
+            for x in range(spacing//2, shape[1], spacing):
+                output_image[y,x] = value
+
+        return output_image
+
+    def print_wcs(self, title, wcs):
+        """
+        Print the wcs header cards
+        """
+        print("=== %s ===" % title)
+        print(wcs.to_header_string())
+
+
+    def read_image(self, filename):
+        """
+        Read the image from a fits file
+        """
+        hdu = fits.open(filename)
+
+        image = hdu[1].data
+        hdu.close()
+        return image
+
+    def read_wcs(self, filename):
+        """
+        Read the wcs of a fits file
+        """
+        hdu = fits.open(filename)
+
+        wcs = stwcs.wcsutil.HSTWCS(hdu, 1)
+        hdu.close()
+        return wcs
+
+    def write_wcs(self, hdu, image_wcs):
+        """
+        Update header with WCS keywords
+        """
+        hdu.header['ORIENTAT'] = image_wcs.orientat
+        hdu.header['CD1_1'] = image_wcs.wcs.cd[0][0]
+        hdu.header['CD1_2'] = image_wcs.wcs.cd[0][1]
+        hdu.header['CD2_1'] = image_wcs.wcs.cd[1][0]
+        hdu.header['CD2_2'] = image_wcs.wcs.cd[1][1]
+        hdu.header['CRVAL1'] = image_wcs.wcs.crval[0]
+        hdu.header['CRVAL2'] = image_wcs.wcs.crval[1]
+        hdu.header['CRPIX1'] = image_wcs.wcs.crpix[0]
+        hdu.header['CRPIX2'] = image_wcs.wcs.crpix[1]
+        hdu.header['CTYPE1'] = image_wcs.wcs.ctype[0]
+        hdu.header['CTYPE2'] = image_wcs.wcs.ctype[1]
+        hdu.header['VAFACTOR'] = 1.0
+
+    def write_image(self, filename, wcs, *args):
+        """
+        Read the image from a fits file
+        """
+        extarray = ['SCI', 'WHT', 'CTX']
+
+        pimg = fits.HDUList()
+        phdu = fits.PrimaryHDU()
+        phdu.header['NDRIZIM'] = 1
+        phdu.header['ROOTNAME'] = filename
+        pimg.append(phdu)
+
+        for img in args:
+            # Create a MEF file with the specified extname
+            extn = extarray.pop(0)
+            extname = fileutil.parseExtn(extn)
+
+            ehdu = fits.ImageHDU(data=img)
+            ehdu.header['EXTNAME'] = extname[0]
+            ehdu.header['EXTVER'] = extname[1]
+            self.write_wcs(ehdu, wcs)
+            pimg.append(ehdu)
+
+        pimg.writeto(filename)
+        del pimg

--- a/tests/hla/test_align.py
+++ b/tests/hla/test_align.py
@@ -72,7 +72,7 @@ class TestAlignMosaic(BaseHLATest):
         # Since these are full file names (*_flc.fits) which cannot be obtained via astroquery from
         # MAST, get the data now using ci_watson.
         for input_file in input_filenames:
-            abs_path = get_bigdata('hst-hla-pipeline','dev','mosaic_ngc188',input_file)
+            get_bigdata('hst-hla-pipeline','dev','mosaic_ngc188',input_file)
 
         try:
             datasetTable = alignimages.perform_align(input_filenames,archive=False,clobber=False,debug=False,
@@ -109,7 +109,7 @@ class TestAlignMosaic(BaseHLATest):
         # Since these are full file names (*_flc.fits) which cannot be obtained via astroquery from
         # MAST, get the data now using ci_watson.
         for input_file in input_filenames:
-            abs_path = get_bigdata('hst-hla-pipeline','dev','mosaic_47tuc',input_file)
+            get_bigdata('hst-hla-pipeline','dev','mosaic_47tuc',input_file)
 
         try:
             datasetTable = alignimages.perform_align(input_filenames,archive=False,clobber=False,debug=False,
@@ -182,7 +182,7 @@ class TestAlignMosaic(BaseHLATest):
         # Since these are full file names (*_flc.fits) which cannot be obtained via astroquery from
         # MAST, get the data now using ci_watson.
         for input_file in input_filenames:
-            abs_path = get_bigdata('hst-hla-pipeline','dev','base_tests',input_file)
+            get_bigdata('hst-hla-pipeline','dev','base_tests',input_file)
 
         try:
             datasetTable = alignimages.perform_align(input_filenames,archive=False,clobber=False,debug=False,

--- a/tests/hla/test_align.py
+++ b/tests/hla/test_align.py
@@ -1,0 +1,213 @@
+import sys
+import traceback
+import os
+import datetime
+import pytest
+import numpy as np
+from astropy.table import Table
+
+from stwcs import updatewcs
+
+from .base_test import BaseHLATest
+from drizzlepac import alignimages
+import drizzlepac.hlautils.astrometric_utils as amutils
+from ci_watson.artifactory_helpers import get_bigdata
+
+# Nominal acceptable RMS limit for a good solution (IMPROVE THIS)
+RMS_LIMIT = 10.0 
+
+@pytest.mark.bigdata
+class TestAlignMosaic(BaseHLATest):
+    """ Tests which validate whether mosaics can be aligned to an astrometric standard.
+
+        Characeteristics of these tests:
+          * A single astrometric catalog was obtained with both GAIA and non-GAIA
+            (PanSTARRS?) sources for the entire combined field-of-view using the GSSS
+            server.
+              * These tests assume combined input exposures for each test have enough
+                astrometric sources from the external catalog to perform a high quality
+                fit.
+          * This test only determines the fit between sources
+            extracted from the images by Tweakreg and the source positions included in
+            the astrometric catalog.
+          * The WCS information for the input exposures do not get updated in this test.
+          * No mosaic gets generated.
+
+        Success Criteria:
+          * Success criteria hard-coded for this test represents 10mas RMS for the
+            WFC3 images based on the fit of source positions to the astrometric catalog
+            source positions.
+              * RMS values are extracted from optional shiftfile output from `tweakreg`
+              * Number of stars used for the fit and other information is not available
+                with the current version of `tweakreg`.
+
+        The environment variable needs to be set in the following manner:
+            export TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/
+     
+        This test file can be executed in the following manner:
+            $ pytest -s --bigdata test_align.py >& test_align_output.txt &
+            $ tail -f test_align_output.txt
+
+    """
+
+    ref_loc = ['truth']
+
+    def test_align_ngc188(self):
+        """ Verify whether NGC188 exposures can be aligned to an astrometric standard.
+
+        Characeteristics of this test:
+          * Input exposures include both ACS and WFC3 images of the same general field-of-view
+            of NGC188 suitable for creating a combined mosaic using both instruments.
+        """
+        self.input_repo = 'hst-hla-pipeline'
+        self.input_loc = 'mosaic_ngc188'
+        totalRMS = 0.0
+        input_filenames = ['iaal01hxq_flc.fits', 'iaala3btq_flc.fits',
+                            'iaal01hyq_flc.fits', 'iaala3bsq_flc.fits',
+                            'j8boa1m8q_flc.fits', 'j8boa1m4q_flc.fits',
+                            'j8boa1maq_flc.fits', 'j8boa1m6q_flc.fits']
+
+        data_path = ['hst-hla-pipeline','dev','mosaic_ngc188']
+        try:
+            datasetTable = alignimages.perform_align(input_filenames,archive=False,clobber=True,debug=False,
+                update_hdr_wcs=False,print_fit_parameters=True,print_git_info=False,output=False,regtest=True,
+                test_data_path=data_path)
+
+            # Examine the output table to extract the RMS for the entire fit and the compromised information
+            if (datasetTable):
+                totalRMS = datasetTable['total_rms'][0]
+
+        except Exception:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
+
+        # Perform some clean up
+        #if os.path.exists('ref_cat.ecsv'): os.remove('ref_cat.ecsv')
+        #if os.path.exists('refcatalog.cat'): os.remove('refcatalog.cat')
+        #for filename in os.listdir():
+        #    if filename.endswith('flt.fits') or filename.endswith('flc.fits'):
+
+        #reference_wcs = amutils.build_reference_wcs(input_filenames)
+        #test_limit = self.fit_limit / reference_wcs.pscale
+        assert (0.0 < totalRMS <= RMS_LIMIT)
+
+    def test_align_47tuc(self):
+        """ Verify whether 47Tuc exposures can be aligned to an astrometric standard.
+
+        Characeteristics of this test:
+          * Input exposures include both ACS and WFC3 images of the same general field-of-view
+            of 47Tuc suitable for creating a combined mosaic using both instruments.
+        """
+        self.input_loc = 'mosaic_47tuc'
+        totalRMS = 0.0
+        input_filenames = ['ib6v06c4q_flc.fits','ib6v06c7q_flc.fits',
+                                'ib6v25aqq_flc.fits','ib6v25atq_flc.fits',
+                                'jddh02gjq_flc.fits','jddh02glq_flc.fits',
+                                'jddh02goq_flc.fits']
+        data_path = ['hst-hla-pipeline','dev','mosaic_47tuc']
+        try:
+            datasetTable = alignimages.perform_align(input_filenames,archive=False,clobber=True,debug=False,
+                update_hdr_wcs=False,print_fit_parameters=True,print_git_info=False,output=False,regtest=True,
+                test_data_path=data_path)
+
+            # Examine the output table to extract the RMS for the entire fit and the compromised information
+            if (datasetTable):
+                totalRMS = datasetTable['total_rms'][0]
+
+        except Exception:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
+
+        assert (0.0 < totalRMS <= RMS_LIMIT)
+
+    @pytest.mark.xfail
+    @pytest.mark.parametrize("input_filenames", [['j8ura1j1q_flt.fits','j8ura1j2q_flt.fits',
+                                                  'j8ura1j4q_flt.fits','j8ura1j6q_flt.fits',
+                                                  'j8ura1j7q_flt.fits','j8ura1j8q_flt.fits',
+                                                  'j8ura1j9q_flt.fits','j8ura1jaq_flt.fits',
+                                                  'j8ura1jbq_flt.fits','j8ura1jcq_flt.fits',
+                                                  'j8ura1jdq_flt.fits','j8ura1jeq_flt.fits',
+                                                  'j8ura1jfq_flt.fits','j8ura1jgq_flt.fits',
+                                                  'j8ura1jhq_flt.fits','j8ura1jiq_flt.fits',
+                                                  'j8ura1jjq_flt.fits','j8ura1jkq_flt.fits'],
+                                                 ['j92c01b4q_flc.fits','j92c01b5q_flc.fits',
+                                                  'j92c01b7q_flc.fits','j92c01b9q_flc.fits'],
+                                                 ['jbqf02gzq_flc.fits', 'jbqf02h5q_flc.fits',
+                                                  'jbqf02h7q_flc.fits', 'jbqf02hdq_flc.fits',
+                                                  'jbqf02hjq_flc.fits', 'jbqf02hoq_flc.fits',
+                                                  'jbqf02hqq_flc.fits', 'jbqf02hxq_flc.fits',
+                                                  'jbqf02i3q_flc.fits', 'jbqf02i8q_flc.fits',
+                                                  'jbqf02iaq_flc.fits'],
+                                                 ['ib2u12kaq_flt.fits', 'ib2u12keq_flt.fits',
+                                                  'ib2u12kiq_flt.fits', 'ib2u12klq_flt.fits'],
+                                                 ['ibjt01a1q_flc.fits', 'ibjt01a8q_flc.fits',
+                                                  'ibjt01aiq_flt.fits', 'ibjt01amq_flt.fits',
+                                                  'ibjt01aqq_flt.fits', 'ibjt01auq_flt.fits',
+                                                  'ibjt01yqq_flc.fits', 'ibjt01z0q_flc.fits',
+                                                  'ibjt01zwq_flc.fits', 'ibjt01a4q_flc.fits',
+                                                  'ibjt01acq_flc.fits', 'ibjt01akq_flt.fits',
+                                                  'ibjt01aoq_flt.fits', 'ibjt01asq_flt.fits',
+                                                  'ibjt01avq_flt.fits', 'ibjt01yuq_flc.fits',
+                                                  'ibjt01ztq_flc.fits'],
+                                                 ['ibnh02coq_flc.fits','ibnh02cmq_flc.fits',
+                                                  'ibnh02c7q_flc.fits','ibnh02c5q_flc.fits',
+                                                  'ibnh02cpq_flc.fits','ibnh02c9q_flc.fits',
+                                                  'ibnh02bfq_flc.fits','ibnh02beq_flc.fits']])
+    def test_align_single_visits(self,input_filenames):
+        """ Verify whether single-visit exposures can be aligned to an astrometric standard.
+
+        Characteristics of these tests:
+          * Input exposures include exposures from a number of single visit datasets to explore what impact differing
+            observing modes (differing instruments, detectors, filters, subarray size, etc.) have on astrometry.
+
+        The following datasets are used in these tests:
+
+            * ACS dataset 10048_a1: 2x F344N, 1x F435W, 1x F475W, 2x F502N, 2x F550M, 1x F555W, 1x F606W, 1x F625W,
+              2x F658N, 1x F775W, 1x F814W, 1x F850LP, and 2x F892N ACS/HRC images
+            * ACS dataset 10265_01: 4x F606W full-frame ACS/WFC images
+            * ACS dataset 12580_02: 5x F475W & 6x F814W ACS/WFC images
+            * WFC3 dataset 11663_12: 4x F160W full-frame WFC3/IR images
+            * WFC3 dataset 12219_01: 8x F160W full-frame WFC3/IR images, 9x F336W full-frame WFC3/UVIS images
+            * WFC3 dataset 12379_02: 4X F606W, 4x F502N full-frame WFC3/UVIS images
+
+        """
+        self.input_loc = 'base_tests'
+        self.curdir = os.getcwd()
+        totalRMS = 0.0
+        data_path = ['hst-hla-pipeline','dev','base_tests']
+        try:
+            datasetTable = alignimages.perform_align(input_filenames,archive=False,clobber=True,debug=False,
+                update_hdr_wcs=False,print_fit_parameters=True,print_git_info=False,output=False,regtest=True,
+                test_data_path=data_path)
+
+            # Examine the output table to extract the RMS for the entire fit and the compromised information
+            if (datasetTable):
+                totalRMS = datasetTable['total_rms'][0]
+
+        except Exception:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
+
+        assert (0.0 < totalRMS <= RMS_LIMIT)
+
+    def test_astroquery(self):
+        """Verify that new astroquery interface will work"""
+        #self.curdir = os.getcwd()
+        #self.input_loc = ''
+
+        totalRMS = 0.0
+        try:
+            datasetTable = alignimages.perform_align(['IB6V06060'],archive=False,clobber=True,debug=False,
+                update_hdr_wcs=False,print_fit_parameters=True,print_git_info=False,output=False,regtest=False,
+                test_data_path=None)
+
+            # Examine the output table to extract the RMS for the entire fit and the compromised information
+            if (datasetTable):
+                totalRMS = datasetTable['total_rms'][0]
+
+        except Exception:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
+            sys.exit()
+
+        assert (0.0 < totalRMS <= RMS_LIMIT)

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -63,7 +63,6 @@ class TestAlignMosaic(BaseHLATest):
             of the test.
         """
 
-        #inputListFiles = ['ACSList50R_v2.csv', 'WFC3List50R_v2.csv']
         inputListFile = 'ACSWFC3List.csv'
 
         # Desired number of random entries for testing

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -1,0 +1,224 @@
+import sys
+import traceback
+import os
+import datetime
+import pytest
+import numpy as np
+from astropy.table import Table, vstack
+from astropy.io import ascii
+
+from .base_test import BaseHLATest
+from drizzlepac import alignimages
+import drizzlepac.hlautils.catalog_utils as catutils
+import drizzlepac.hlautils.astrometric_utils as amutils
+
+@pytest.mark.bigdata
+class TestAlignMosaic(BaseHLATest):
+    """ Tests which validate whether mosaics can be aligned to an astrometric standard.
+
+        Characeteristics of these tests:
+          * A single astrometric catalog was obtained with both GAIA and non-GAIA
+            (PanSTARRS?) sources for the entire combined field-of-view using the GSSS
+            server.
+              * These tests assume combined input exposures for each test have enough
+                astrometric sources from the external catalog to perform a high quality
+                fit.
+          * This test only determines the fit between sources
+            extracted from the images by Tweakreg and the source positions included in
+            the astrometric catalog.
+          * The WCS information for the input exposures do not get updated in this test.
+          * No mosaic gets generated.
+
+        Success Criteria:
+          * Success criteria hard-coded for this test represents 10mas RMS for the
+            WFC3 images based on the fit of source positions to the astrometric catalog
+            source positions.
+              * RMS values are extracted from optional shiftfile output from `tweakreg`
+              * Number of stars used for the fit and other information is not available
+                with the current version of `tweakreg`.
+
+    """
+
+    ref_loc = ['truth']
+
+    @pytest.mark.xfail
+    #@pytest.mark.slow
+    def test_align_randomFields(self):
+        """ Wrapper to set up the test for aligning a large number of randomly
+            selected fields (aka datasets) from a input ascii file (CSV).
+
+            The wrapper provides the parameter settings for the underlying test,
+            as well as implements the criterion for the overall success or failure
+            of the test.
+        """
+
+        #inputListFiles = ['ACSList50R_v2.csv', 'WFC3List50R_v2.csv']
+        inputListFile = 'ACSWFC3List.csv'
+
+        # Desired number of random entries for testing
+        #inputNumEntries = 50
+        inputNumEntries = 4
+
+        # Seed for random number generator
+        inputSeedValue = 1
+
+        # Obtain the full path to the file containing the dataset field names
+        self.input_loc  = 'master_lists'
+        self.curdir     = os.getcwd()
+        input_file_path = self.get_data(inputListFile)
+
+        # Randomly select a subset of field names (each field represented by a row) from
+        # the master CSV file and return as an Astropy table
+        randomCandidateTable = catutils.randomSelectFromCSV(input_file_path[0],
+            inputNumEntries, inputSeedValue)
+
+        # Invoke the methods which will handle acquiring/downloading the data from
+        # MAST and perform the alignment
+        percentSuccess = 0.0
+        try:
+            percentSuccess = self.align_randomFields (randomCandidateTable)
+        except Exception:
+            pass
+
+        assert(percentSuccess >= 0.70)
+
+    def align_randomFields(self, randomTable):
+        """ Process randomly selected fields (aka datasets) stored in an Astropy table.
+
+            Each field is used as input to determine if it can be aligned to an
+            astrometric standard.  The success or fail status for each test is retained
+            as the overall success or fail statistic is the necessary output from
+            this test.
+        """
+
+        numSuccess = 0
+        numUnsuccessful = 0
+        numException = 0
+        numProcessedDatasets = 0
+
+        # Read the table and extract a list of each dataset name in IPPSSOOT format
+        # which is either an association ID or an individual filename
+        dataset_list = get_dataset_list(randomTable)
+
+        numProcessedDatasets = len(dataset_list)
+        numStartTests  = numProcessedDatasets
+
+        # Process the dataset names in the list
+        #
+        # If the dataset name represents an association ID, the multiplicity
+        # of images within the association need to be processed.  Otherwise,
+        # the dataset is a single image.
+        #
+        # If the "alignment" of a field/dataset fails for any reason, trap
+        # the exception and keep going.
+        allDatasetTable = Table()
+        datasetKey = -1
+        print("TEST_RANDOM. Dataset List: ", dataset_list)
+        for dataset in dataset_list:
+            datasetKey += 1
+            outputName = dataset + '.ecsv'
+
+            print("TEST_RANDOM. Dataset: ", dataset)
+            currentDT = datetime.datetime.now()
+            print(str(currentDT))
+            
+            try:
+                
+                datasetTable = alignimages.perform_align([dataset],archive=False,clobber=True,debug=False,
+                    update_hdr_wcs=False,print_fit_parameters=True,print_git_info=False,output=False)
+
+                # Filtered datasets
+                if datasetTable['doProcess'].sum() == 0:
+                    print("TEST_RANDOM. Filtered Dataset: ", dataset, "\n")
+                    numProcessedDatasets -= 1;
+                # Datasets to process
+                elif datasetTable['doProcess'].sum() > 0:
+                    # Determine images in dataset to be processed and the number of images
+                    # This is in case an image was filtered out (e.g., expotime = 0)
+                    index = np.where(datasetTable['doProcess']==1)[0]
+                    sumOfStatus = datasetTable['status'][index].sum()
+
+                    # Update the table with the datasetKey which is really just a counter
+                    datasetTable['datasetKey'][:] = datasetKey
+                    datasetTable['completed'][:] = True
+                    datasetTable.write(outputName, format='ascii.ecsv')
+                    #datasetTable.pprint(max_width=-1)
+   
+                    # Successful datasets
+                    if (sumOfStatus == 0):
+                        print("TEST_RANDOM. Successful Dataset: ", dataset, "\n")
+                        numSuccess += 1
+                    # Unsuccessful datasets
+                    else:
+                        print("TEST_RANDOM. Unsuccessful Dataset: ", dataset, "\n")
+                        numUnsuccessful += 1
+
+                # Append the latest dataset table to the summary table 
+                allDatasetTable = vstack([allDatasetTable, datasetTable])
+
+            # Catch anything that happens as this dataset will be considered a failure, but
+            # the processing of datasets should continue.  Generate sufficient output exception
+            # information so problems can be addressed.
+            except Exception:
+           
+                exc_type, exc_value, exc_tb = sys.exc_info()
+                traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
+                print("TEST_RANDOM. Exception Dataset: ", dataset, "\n")
+                numException += 1
+                continue
+
+        # Perform some clean up
+        if os.path.exists('ref_cat.ecsv'): os.remove('ref_cat.ecsv')
+        if os.path.exists('refcatalog.cat'): os.remove('refcatalog.cat')
+        for filename in os.listdir():
+            if filename.endswith('flt.fits') or filename.endswith('flc.fits'):
+                os.unlink(filename)
+
+        # Write out the table
+        allDatasetTable.write('resultsBigTest.ecsv', format='ascii.ecsv')
+
+        # Determine the percent success over all datasets processed
+        percentSuccess = numSuccess/numProcessedDatasets
+        print('TEST_RANDOM. Number of tests started: ', numStartTests)
+        print('TEST_RANDOM. Number of tests (excluding filtered): ', numProcessedDatasets)
+        print('TEST_RANDOM. Number of successful tests: ', numSuccess)
+        print('TEST_RANDOM. Number of unsuccessful tests: ', numUnsuccessful)
+        print('TEST_RANDOM. Number of exception tests: ', numException)
+        print('TEST_RANDOM. Percentage success/numberOfTests: ', numSuccess/numProcessedDatasets*100.0)
+ 
+        return percentSuccess
+
+def get_dataset_list(tableName):
+    """ Standalone function to read the Astropy table and get the dataset names
+
+    Parameters
+    ==========
+    tableName : str
+        Filename of the input master CSV file containing individual
+        images or association names, as well as observational
+        information regarding the images
+
+    Returns
+    =======
+    datasetNames: list
+        List of individual image or association base (IPPSSOOT) names
+    """
+
+    #dataFromTable = Table.read(filename, format='ascii')
+    datasetIDs = tableName['observationID']
+    asnIDs     = tableName['asnID']
+
+    datasetNames = []
+
+    # Determine if the data is part of an association or is an individual image
+    for imgid,asnid in zip(datasetIDs,asnIDs):
+
+        # If the asnID is the string NONE, this is an individual image,
+        # and it is necessary to get the individual image dataset name.
+        # Otherwise, this is an association dataset, so just add the asnID.
+        if (asnid.upper() == "NONE"):
+            datasetNames.append(imgid)
+        else:
+            datasetNames.append(asnid)
+
+    return datasetNames

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -178,9 +178,9 @@ class TestAlignMosaic(BaseHLATest):
                 continue
 
         # Perform some clean up
-        if os.path.exists('ref_cat.ecsv'): 
+        if os.path.isfile('ref_cat.ecsv'): 
             os.remove('ref_cat.ecsv')
-        if os.path.exists('refcatalog.cat'):  
+        if os.path.isfile('refcatalog.cat'):  
             os.remove('refcatalog.cat')
         for filename in os.listdir():
             if filename.endswith('flt.fits') or filename.endswith('flc.fits'):

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -52,7 +52,7 @@ class TestAlignMosaic(BaseHLATest):
             $ tail -f test_random_output.txt
     """
 
-    #@pytest.mark.xfail
+    @pytest.mark.xfail
     @pytest.mark.slow
     def test_align_randomFields(self):
         """ Wrapper to set up the test for aligning a large number of randomly

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -10,7 +10,6 @@ from astropy.io import ascii
 from .base_test import BaseHLATest
 from drizzlepac import alignimages
 import drizzlepac.hlautils.catalog_utils as catutils
-import drizzlepac.hlautils.astrometric_utils as amutils
 
 @pytest.mark.bigdata
 class TestAlignMosaic(BaseHLATest):
@@ -37,12 +36,24 @@ class TestAlignMosaic(BaseHLATest):
               * Number of stars used for the fit and other information is not available
                 with the current version of `tweakreg`.
 
+        The environment variable needs to be set in the following manner:
+            export TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/
+            OR
+            export TEST_BIGDATA=/Users/YourNameHere/TestDataDirectory/
+
+        For this test, the TEST_BIGDATA defines the root of the location  where the CSV 
+        file is stored.  The full path is TEST_BIGDATA/self.input_repo/self.tree/self.input_loc.
+        The CSV is output from a database and lists associations and singletons for ACS 
+        and WFC3 instruments randomly sorted.  The actual data files are downloaded from MAST
+        via astroquery.
+     
+        This test file can be executed in the following manner:
+            $ pytest -s --bigdata test_randomlist.py >& test_random_output.txt &
+            $ tail -f test_random_output.txt
     """
 
-    ref_loc = ['truth']
-
-    @pytest.mark.xfail
-    #@pytest.mark.slow
+    #@pytest.mark.xfail
+    @pytest.mark.slow
     def test_align_randomFields(self):
         """ Wrapper to set up the test for aligning a large number of randomly
             selected fields (aka datasets) from a input ascii file (CSV).
@@ -56,15 +67,15 @@ class TestAlignMosaic(BaseHLATest):
         inputListFile = 'ACSWFC3List.csv'
 
         # Desired number of random entries for testing
-        #inputNumEntries = 50
-        inputNumEntries = 4
+        inputNumEntries = 50
 
         # Seed for random number generator
         inputSeedValue = 1
 
         # Obtain the full path to the file containing the dataset field names
-        self.input_loc  = 'master_lists'
-        self.curdir     = os.getcwd()
+        self.input_repo = 'hst-hla-pipeline'
+        self.tree = 'dev'
+        self.input_loc = 'master_lists'
         input_file_path = self.get_data(inputListFile)
 
         # Randomly select a subset of field names (each field represented by a row) from
@@ -168,8 +179,10 @@ class TestAlignMosaic(BaseHLATest):
                 continue
 
         # Perform some clean up
-        if os.path.exists('ref_cat.ecsv'): os.remove('ref_cat.ecsv')
-        if os.path.exists('refcatalog.cat'): os.remove('refcatalog.cat')
+        if os.path.exists('ref_cat.ecsv'): 
+            os.remove('ref_cat.ecsv')
+        if os.path.exists('refcatalog.cat'):  
+            os.remove('refcatalog.cat')
         for filename in os.listdir():
             if filename.endswith('flt.fits') or filename.endswith('flc.fits'):
                 os.unlink(filename)


### PR DESCRIPTION
Added the regression tests for the alignment code to the drizzlepac package.  Modified the alignment tests to use the updated output (astropy table) from the alignment code (alignimages.py/perform_align()) to determine the processing state.  Currently, the output states are: Successful, Unsuccessful, Filtered, and Exception.  These tests were written to satisfy the criterion of 0 < total_RMS < 10 mas, so they are not true regression tests.  One routine, test_extract.py, has not been updated pending information needed from the originator of the test.

An update was required in the alignment code itself to accommodate these tests to (1) resolve issues where full filenames (e.g., *_flt.fits) are used for files which are part of associations, but they are to be used as singletons so they cannot be acquired from MAST, and (2) the tests run in the Pytest context which creates its processing directory on-the-fly.  Artifactory is used to store the input files.

Finally, only a few files (after backing out larger number of changes) in support of the original drizzlepac regression test code were modified to avoid name conflicts between ci_watson regression test helper code and home-grown drizzlepac regression test helpers.