### PR TITLE
JenkinsfileRT: Add ci-watson

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -46,6 +46,7 @@ bc.conda_packages = ['acstools',
                      'astropy',
                      'stsci.stimage',
                      'tweakwcs',
+		     'ci-watson',
                      'setuptools',
                      'pip',
                      'python=3.6']


### PR DESCRIPTION
Missed by #285 
Should fix failing `no argument: --bigdata`