### PR TITLE
Fix failing WFPC2 tests

### DIFF
--- a/tests/resources.py
+++ b/tests/resources.py
@@ -104,7 +104,7 @@ class BaseCal:
         downloaded, if necessary.
         """
         filename = self.get_data(*args)
-        ref_files = ref_from_image(filename, ['IDCTAB', 'OFFTAB', 'NPOLFILE', 'D2IMFILE'])
+        ref_files = ref_from_image(filename, ['IDCTAB', 'OFFTAB', 'NPOLFILE', 'D2IMFILE', 'DGEOFILE'])
         print("Looking for REF_FILES: {}".format(ref_files))
 
         for ref_file in ref_files:

--- a/tests/wfpc2/test_wfpc2.py
+++ b/tests/wfpc2/test_wfpc2.py
@@ -9,7 +9,6 @@ from ..resources import BaseWFPC2
 
 class TestWFPC2(BaseWFPC2):
 
-    @pytest.mark.skip(reason="FIXME: updatewcs fails")
     def test_waiver_single(self):
         """ This test confirms that drizzlepac can correcly process .
         """
@@ -88,7 +87,6 @@ class TestWFPC2(BaseWFPC2):
         outputs = [(outfile, reffile)]
         self.compare_outputs(outputs)
 
-    @pytest.mark.skip(reason="FIXME: updatewcs fails")
     def test_wfpc2_single(self):
         """ This test confirms that drizzlepac can correcly process single
         WFPC2 exposures.
@@ -127,7 +125,6 @@ class TestWFPC2(BaseWFPC2):
         outputs = [(outfile, reffile)]
         self.compare_outputs(outputs)
 
-    @pytest.mark.skip(reason="FIXME: updatewcs fails")
     def test_mef_asn(self):
         """ This test confirms that drizzlepac can correcly process input
         WFPC2 data stored in Multi-extensions FITS(MEF) format.


### PR DESCRIPTION
Added `DGEOFILE` to list passed to `ref_from_image`.

Thanks @stsci-hack 