### PR TITLE
Add partial clean

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+3.1.0 (unreleased)
+==================
+
+- Added new parameter 'keep_files' to AstroDrizzle function to control what
+  intermediate files are kept when 'clean=True'  [#301]
 
 3.0.2 (unreleased)
 ==================

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -57,7 +57,7 @@ log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
 def AstroDrizzle(input=None, mdriztab=False, editpars=False, configobj=None,
-                 wcsmap=None, keep_files=None, **input_dict):
+                 wcsmap=None, keep_files=[], **input_dict):
     """ AstroDrizzle command-line interface """
     # Support input of filenames from command-line without a parameter name
     # then copy this into input_dict for merging with TEAL ConfigObj
@@ -121,7 +121,7 @@ def AstroDrizzle(input=None, mdriztab=False, editpars=False, configobj=None,
 ##  Interfaces used by TEAL ##
 ##############################
 @util.with_logging
-def run(configobj, wcsmap=None, keep_files=None):
+def run(configobj, wcsmap=None, keep_files=[]):
     """
     Initial example by Nadia ran MD with configobj EPAR using:
     It can be run in one of two ways:

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -165,10 +165,7 @@ def run(configobj, wcsmap=None, keep_files=[]):
                     'outSContext','outSWeight','outSingle',
                     'outMedian','dqmask','tmpmask',
                     'skyMatchMask']
-    invalid_entries = []
-    for kfile in keep_files:
-        if kfile not in clean_files:
-            invalid_entries.append(kfile)
+    invalid_entries = set(keep_files).difference(clean_files)
     if invalid_entries:
         errmsg = "ERROR: These entries of the `keep_files` parameters "
         errmsg += "were invalid\n:    {}\n".format(invalid_entries)

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -128,7 +128,7 @@ class baseImageObject:
         # else:
         #     self._image.data= None # np.array(0,dtype=self.getNumpyType(self._image.header["BITPIX"]))
 
-    def clean(self):
+    def clean(self, keep_files=None):
         """ Deletes intermediate products generated for this imageObject.
         """
         clean_files = ['blotImage','crmaskImage','finalMask',
@@ -136,7 +136,14 @@ class baseImageObject:
                         'outSContext','outSWeight','outSingle',
                         'outMedian','dqmask','tmpmask',
                         'skyMatchMask']
-
+        if keep_files:
+            for kfile in keep_files:
+                if kfile in clean_files:
+                    clean_files.remove(kfile)
+                else:
+                    log.info("Did not find intermediate product type {} to keep.".format(kfile))
+                    log.info("Valid choices are: {}".format(clean_files))
+                    
         log.info('Removing intermediate files for %s' % self._filename)
         # We need to remove the combined products first; namely, median image
         util.removeFileSafely(self.outputNames['outMedian'])

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -128,7 +128,7 @@ class baseImageObject:
         # else:
         #     self._image.data= None # np.array(0,dtype=self.getNumpyType(self._image.header["BITPIX"]))
 
-    def clean(self, keep_files=None):
+    def clean(self, keep_files=[]):
         """ Deletes intermediate products generated for this imageObject.
         """
         clean_files = ['blotImage','crmaskImage','finalMask',
@@ -138,12 +138,8 @@ class baseImageObject:
                         'skyMatchMask']
         if keep_files:
             for kfile in keep_files:
-                if kfile in clean_files:
-                    clean_files.remove(kfile)
-                else:
-                    log.info("Did not find intermediate product type {} to keep.".format(kfile))
-                    log.info("Valid choices are: {}".format(clean_files))
-                    
+                clean_files.remove(kfile)
+
         log.info('Removing intermediate files for %s' % self._filename)
         # We need to remove the combined products first; namely, median image
         util.removeFileSafely(self.outputNames['outMedian'])


### PR DESCRIPTION
A new parameter was added that allows the user to control what intermediate files are not deleted when 'clean=True'.  The parameter was implemented independently of the configobj parameters since this capability really is only intended to support scripting use of Astrodrizzle which may require working with custom sets of the intermediate files (like HLA processing).  

This is intended to support creation of single visit mosaic products (v3.1.0), and NOT for initial use with astrometric updates to HST data.