### PR TITLE
Ensure run_align() always passes back the filteredTable contents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -100,6 +100,9 @@ of the list).
 - Fixed improper logic caused by nested if statements in analyze.py found
   when testing [#283].
 
+- Fixed a logic bug in alignimages.py to force the run_align() function
+  to always return the filtered table contents. [#302]
+
 
 2.2.6 (02-Nov-2018)
 ===================


### PR DESCRIPTION
Fixed a bug by adding a try/finally to the run_align() method as the "result" argument must always return the filtered table values.  The run_align() method was created in order to use the logutil functionality and not have the output table "swallowed" by the drizzlepac WithLogging support class.  This is why the perform_align() function is a thin wrapper around run_align().  The perform_align() function returns a table to any higher level calling utilities (e.g. runastrodriz.py or test_randomlist.py).

Add the try/finally blocks and changed `return(filteredTable)` to `return`.

Because of this problem, a Pytest test can fail if the dataset being processed returns prematurely as would be true in the cases of: filtered out dataset (e.g., spectroscopic), not enough sources found, not enough cross matches found, etc.