### PR TITLE
Add headerlet docs

### DIFF
--- a/doc/source/astrometry.rst
+++ b/doc/source/astrometry.rst
@@ -46,7 +46,7 @@ The use of headerlets extends this standard by allowing each new WCS, specified 
    20  HDRLET        5 HeaderletHDU     26   ()
    21  HDRLET        6 HeaderletHDU     26   ()
 
-In this example, extensions 16 through 21 contain headerlets each of which specifies different astrometric alignment (each may potentially be based on a different distortion model) and each has been assigned a unique name given by the **WCSNAME** keyword.  A quick listing of the names of all these WCSs can be obtained using the Python library STWCS ::
+In this example, extensions 16 through 21 contain headerlets each of which specifies different astrometric alignment (each may potentially be based on a different distortion model) and each has been assigned a unique name given by the **WCSNAME** keyword.  A quick listing of the names of all these WCSs can be obtained using the Python library STWCS:
 
 .. code-block:: python
 

--- a/doc/source/astrometry.rst
+++ b/doc/source/astrometry.rst
@@ -65,6 +65,8 @@ The first WCS solution listed, OPUS, corresponds to the default WCS defined by t
 
 Additional WCS solutions will then be based on either the original **OPUS** WCS or the distortion-corrected **IDC_** WCS solutions.  Two types of solutions can be defined for images; namely, *a priori* and *a posteriori* solutions.
 
+a priori solutions
+^^^^^^^^^^^^^^^^^^
 The *a priori* solutions have been determined for **ALL HST data** by correcting the coordinates of the guide stars that were used from the originally specified coordinates to the coordinates of those guide stars as determined by GAIA.  The naming convention for these *a priori* solutions are::
 
   <Starting WCS>-<Astrometric Catalog>
@@ -74,7 +76,9 @@ The *a priori* solutions have been determined for **ALL HST data** by correcting
 
 where the *Astrometric Catalog* refers the exact astrometric catalog used to correct the guide star positions.
 
-The *a posteriori*, on the other hand, gets determined from measuring sources in each image, finding overlapping sources from an astrometric catalog, identifying and cross-matching image sources with sources from the astrometric catalog and performing a fit to correct the WCS.  These type of solutions can not be determined for all datasets due to a number of reasons, such as lack of sources in the image and/or lack of overlapping sources from an astrometric catalog.  When these solutions can be determined for an observation, they are given a name which follows the convention::
+a posteriori solutions
+^^^^^^^^^^^^^^^^^^^^^^^
+The *a posteriori* solutions, on the other hand, get determined from measuring sources in each image, finding overlapping sources from an astrometric catalog, identifying and cross-matching image sources with sources from the astrometric catalog and performing a fit to correct the WCS.  These type of solutions can not be determined for all datasets due to a number of reasons, such as lack of sources in the image and/or lack of overlapping sources from an astrometric catalog.  When these solutions can be determined for an observation, they are given a name which follows the convention::
 
   <Starting WCS>-FIT_<Astrometric Catalog>
 

--- a/doc/source/astrometry.rst
+++ b/doc/source/astrometry.rst
@@ -1,0 +1,174 @@
+.. _astrometry:
+
+===================================================
+Headerlets and You: Astrometry in Drizzle Products
+===================================================
+
+The astrometry for any given observation relies upon accurate pointing information from the telescope.   However, HST has evolved over time since it was put into orbit, with the focus changing over time as the telescope desorbs.  The instruments have also changed positions over time relative to the FGS guides, and the coordinates for the guide stars were orginally determined using ground-based information.  All this has limited the calculation of the pointing of any given observation on the sky (absolute astrometry) to no better than 1-2 arc-seconds.
+
+Calibration of the distortion model for each instrument has been done well enough to allow observations to be combined (relative astrometry) with an accuracy of better than 5 milli-arcseconds.  This has made the absolute astrometry inaccuracy stand out even more, making it more difficult to compare observations taken at different times or to compare HST data with observations from other telescopes (like Chandra).
+
+Therefore, multiple efforts have been undertaken to improve the absolute astrometry to match the accuracy of the relative astrometry.  These efforts have resulted in multiple new world coordinate systems (WCS) solutions to be developed for HST observations, starting with ACS, WFC3, and WFPC2.
+
+Each solution has its own advantages and errors, making some good for one use but inadequate for others.  As a result,  all new WCS solutions which are approved by STScI are being offered with HST data provided by MAST with headerlets serving as the mechanism for providing and applying all WCS solutions.
+
+
+Where are all the WCS solutions?
+================================
+
+All calibrated HST products delivered by the Barbara A. Mikulski Archive for Space Telescopes (MAST) contain the best available WCS solutions available at the time the data was last processed.  Unfortunately, only 1 WCS can be used at a time to transform the position in the image to an undistorted position on the sky.  The FITS Standard, however, describes how multiple WCS solutions can be defined for an image in `FITS Paper I (Greisen, E. W., and Calabretta, M. R., Astronomy & Astrophysics, 395, 1061-1075, 2002) <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2002A%26A...395.1061G&db_key=AST&high=3db47576cf06933>`_.
+
+This standard defines a keyword, WCSNAME, which serves as the label for the WCS specified in the header of the observation.  It also defines additional keywords, WCSNAME[A-Z], that represent additional WCS solutions which are specified as alternate WCS solutions in the same header as the active WCS associated with WCSNAME.  Headerlets rely on the use of the WCSNAME keyword to manage the multiple solutions that may be defined for a given observation, with each WCS having it's own unique WCSNAME value.  Headerlets also build the HDRNAME keyword which specifies the exposure name as well WCS to insure that this WCS will only ever be applied to this exposure and no other.
+
+The use of headerlets extends this standard by allowing each new WCS, specified using the FITS Paper I standards along with the SIP convention, to be stored separately as a new extension at the end of the image's FITS file.  This can be seen in the extensions listed by astropy.fits for a sample ACS/WFC image which includes 6 additional WCS solutions from the astrometry database.::
+
+  No.    Name      Ver    Type      Cards   Dimensions   Format
+    0  PRIMARY       1 PrimaryHDU     279   ()
+    1  SCI           1 ImageHDU       201   (4096, 2048)   float32
+    2  ERR           1 ImageHDU        57   (4096, 2048)   float32
+    3  DQ            1 ImageHDU        49   (4096, 2048)   int16
+    4  SCI           2 ImageHDU       199   (4096, 2048)   float32
+    5  ERR           2 ImageHDU        57   (4096, 2048)   float32
+    6  DQ            2 ImageHDU        49   (4096, 2048)   int16
+    7  D2IMARR       1 ImageHDU        15   (64, 32)   float32
+    8  D2IMARR       2 ImageHDU        15   (64, 32)   float32
+    9  D2IMARR       3 ImageHDU        15   (64, 32)   float32
+   10  D2IMARR       4 ImageHDU        15   (64, 32)   float32
+   11  WCSDVARR      1 ImageHDU        15   (64, 32)   float32
+   12  WCSDVARR      2 ImageHDU        15   (64, 32)   float32
+   13  WCSDVARR      3 ImageHDU        15   (64, 32)   float32
+   14  WCSDVARR      4 ImageHDU        15   (64, 32)   float32
+   15  WCSCORR       1 BinTableHDU     59   14R x 24C   [40A, I, A, 24A, 24A, 24A, 24A, D, D, D, D, D, D, D, D, 24A, 24A, D, D, D, D, J, 40A, 128A]
+   16  HDRLET        1 HeaderletHDU     22   ()
+   17  HDRLET        2 HeaderletHDU     22   ()
+   18  HDRLET        3 HeaderletHDU     26   ()
+   19  HDRLET        4 HeaderletHDU     26   ()
+   20  HDRLET        5 HeaderletHDU     26   ()
+   21  HDRLET        6 HeaderletHDU     26   ()
+
+In this example, extensions 16 through 21 contain headerlets each of which specifies different astrometric alignment (each may potentially be based on a different distortion model) and each has been assigned a unique name given by the **WCSNAME** keyword.  A quick listing of the names of all these WCSs can be obtained using the Python library STWCS ::
+
+.. code-block:: python
+
+    from stwcs.wcsutil import headerlet
+    headerlet.get_headerlet_kw_names("j95y04hq_flc.fits", kw='WCSNAME')
+    ['OPUS',
+    'IDC_0461802ej',
+    'OPUS-GSC240',
+    'IDC_0461802ej-GSC240',
+    'OPUS-HSC30',
+    'IDC_0461802ej-HSC30']
+
+Interpreting WCS names
+-----------------------
+The first WCS solution listed, OPUS, corresponds to the default WCS defined by the HST calibration pipeline based on original telemetry and only a first-order distortion model. Solutions which contain **IDC_** are based on the distortion model based on the reference data associated with the **IDCTAB** reference file whose rootname is specified in the WCSNAME.  For example, **IDC_0461802ej** refers to a WCS solution based on the **IDCTAB** reference file 0461802ej_idc.fits along with all the associated secondary distortion reference files given by **DGEOFILE**, **NPOLFILE** and, for WFPC2, **OFFTAB** and **DXYFILE**.
+
+Additional WCS solutions will then be based on either the original **OPUS** WCS or the distortion-corrected **IDC_** WCS solutions.  Two types of solutions can be defined for images; namely, *a priori* and *a posteriori* solutions.
+
+The *a priori* solutions have been determined for **ALL HST data** by correcting the coordinates of the guide stars that were used from the originally specified coordinates to the coordinates of those guide stars as determined by GAIA.  The naming convention for these *a priori* solutions are::
+
+  <Starting WCS>-<Astrometric Catalog>
+
+  For example,
+  'IDC_0461802ej-GSC240'
+
+where the *Astrometric Catalog* refers the exact astrometric catalog used to correct the guide star positions.
+
+The *a posteriori*, on the other hand, gets determined from measuring sources in each image, finding overlapping sources from an astrometric catalog, identifying and cross-matching image sources with sources from the astrometric catalog and performing a fit to correct the WCS.  These type of solutions can not be determined for all datasets due to a number of reasons, such as lack of sources in the image and/or lack of overlapping sources from an astrometric catalog.  When these solutions can be determined for an observation, they are given a name which follows the convention::
+
+  <Starting WCS>-FIT_<Astrometric Catalog>
+
+  For example,
+  'IDC_0461802ej-FIT_GAIADR2'
+
+
+Choosing a WCS
+---------------
+The **only** WCS solution that gets used to perform coordinate transformations on the pixel values will be the 'active' or 'primary' WCS associated with the WCSNAME keyword.  The pipeline generated products will include an active WCS which the pipeline specifies as the *best* available WCS as the 'active' given the information used at the time of processing.  However, this default 'active' WCS may not be appropriate for all science, so this WCS may need to be replaced by one of the other WCSs instead to best support the analysis necessary for the research.
+
+Dependent Packages
+^^^^^^^^^^^^^^^^^^^^
+Working with the WCS solutions and headerlets gets performed using `STWCS package <https://stwcs.readthedocs.io/en/latest/>`_.  Examples of how to work with this package will assume that the user has already installed this package into their working Python environment and have started a python shell.  In addition, the following example relies on the Astropy IO package to work with the FITS headers and extensions.
+
+Finally, the example described here will rely on additional functionality included in the V3.2.0 or later of the Drizzlepac package.  These new functions support the generation of drizzle combined products which have been aligned to an astrometric standard catalog such as GAIA DR2.
+
+Sample Session
+^^^^^^^^^^^^^^^
+This example will work with 4 exposures taken using ACS/WFC as the association *j95y04010*, with most of the example being performed on the single exposure *j95y04hpq_flc.fits*.
+
+All the necessary libraries for working on this example can be imported using:
+
+.. code-block:: python
+
+    from drizzlepac.hlautils import astroquery_utils as aqutils
+    from drizzlepac.hlautils import astrometric_utils as amutils
+    from astropy.io import fits
+    from stwcs.wcsutil import headerlet
+
+The data can be obtained from MAST with `astroquery <https://astroquery.readthedocs.io/en/latest/>`_ using a simplified interface developed in **drizzlepac** using the commands:
+
+.. code-block:: python
+
+    filenames = aqutils.retrieve_observation('j95y04010')
+    # filenames = ['j95y04hpq_flc.fits', 'j95y04hqq_flc.fits',
+    #              'j95y04hsq_flc.fits', 'j95y04huq_flc.fits']
+
+The default 'active' WCS can be determined using:
+
+.. code-block:: python
+
+    default_wcsname = fits.getval(filenames[0], 'wcsname', ext=1)
+
+For this example, we find that **default_wcsname='IDC_0461802ej'**, or as noted earlier, the default distortion correction based WCS provided by the pipeline with no correction for any astrometric catalogs, has been designated by the pipeline as the 'active' WCS.
+
+All available WCSs provided by the astrometry database and attached as headerlet extensions can be queried to find the WCSNAMEs for all the new WCSs using:
+
+.. code-block:: python
+
+    new_wcsnames = headerlet.get_headerlet_kw_names(filenames[0], kw='WCSNAME')
+
+These will be the same ones listed earlier.  For this example, we decide we would like to have this observation aligned using the guide stars corrected to GAIA DR1 through the use of the GSC240-based WCS; specifically, **IDC_0461802ej-GSC240**.  We can replace the 'active' WCS with this new one using:
+
+.. code-block:: python
+
+    new_hdrnames = headerlet.get_headerlet_kw_names(filenames[0])
+    # identify hdrname that corresponds with desired WCS with name of IDC_041802ej-GSC240
+    new_wcs = new_hdrnames[new_wcsnames.index('IDC_0416802ej-GSC240')]
+    headerlet.restore_from_headerlet(filenames[0], hdrname=new_wcs, force=True)
+    # confirm new WCS is now 'active'
+    fits.getval(filenames[0], 'wcsname', ext=1)
+
+At this point, the exposure has been updated to perform all coordinate transformations with the new GAIA DR1-based WCS as if the guide stars used for taking the observation has GAIA DR1 coordinates in the first place.  This will not mean it will align perfectly with GAIA, but should be within 0.5 arcseconds due to drift in the telescope field-of-view for each of the instruments relative to the FGSs.
+
+
+Headerlet Primer
+=================
+
+The headerlet file itself conforms to FITS standards with the PRIMARY header containing global information about the WCS solution and how it was determined.  Separate extensions in the headerlet then contain the header keywords for specifying the WCS for each chip in the exposure or for the distortion information necessary to correct the pixel positions from the image to the un-distorted position on the sky.  These solutions rely on calibration reference data that describe the distortion observed in each instrument to better than 0.1 pixels in each detector.  Instead of having to retrieve separate files with this distortion information, that distortion information has been folded into the header of each WFC3, ACS and WFPC2 dataset.
+
+Headerlet File Structure
+-------------------------
+This new object complete with the NPOLFILE and the D2IMFILE extensions
+derived from the full FITS file fully describes the WCS of each chip
+and serves without further modification as the definition of the
+`headerlet`. The listing of the FITS extensions for a `headerlet` for
+the sample ACS/WFC exposure after writing it out to a file would then be::
+
+    EXT#  FITSNAME      FILENAME              EXTVE DIMENS       BITPI OBJECT
+
+    0     j8hw27c4q     j8hw27c4q_hdr.fits                       16
+    1       IMAGE       D2IMARR               1     4096         -32
+    2       IMAGE       WCSDVARR              1     64x32        -32
+    3       IMAGE       WCSDVARR              2     64x32        -32
+    4       IMAGE       WCSDVARR              3     64x32        -32
+    5       IMAGE       WCSDVARR              4     64x32        -32
+    6       IMAGE       SIPWCS                1                  8
+    7       IMAGE       SIPWCS                2                  8
+
+Detailed Description of headerlet
+----------------------------------
+The full details on the headerlet, it's required set of keywords, and how the distortion models get described in the headerlet can be found in the `Technical Report on headerlets <https://stwcs.readthedocs.io/en/latest/headerlet_tsr/source/index.html>`_.
+
+Code Interface to headerlets
+-----------------------------
+The `STWCS package <https://stwcs.readthedocs.io/en/latest/>`_ provides the code used to work with headerlets and WCS solutions.

--- a/doc/source/astrometry_api.rst
+++ b/doc/source/astrometry_api.rst
@@ -1,0 +1,30 @@
+.. _astrometry_api:
+
+Generating Astrometrically Aligned products
+============================================
+The code described here gets used in the automated HST calibration pipeline to align images to an absolute astrometric standard using a number of methods.
+
+
+.. automodule:: drizzlepac.alignimages
+  :members:
+  :undoc-members:
+
+.. automodule:: drizzlepac.hlautils.astrometric_utils
+  :members:
+  :undoc-members:
+
+.. automodule:: drizzlepac.hlautils.astroquery_utils
+  :members:
+  :undoc-members:
+
+.. automodule:: drizzlepac.hlautils.catalog_utils
+  :members:
+  :undoc-members:
+
+.. automodule:: drizzlepac.hlautils.analyze
+  :members:
+  :undoc-members:
+
+.. automodule:: drizzlepac.hlautils.testutils
+  :members:
+  :undoc-members:

--- a/doc/source/astrometry_api.rst
+++ b/doc/source/astrometry_api.rst
@@ -1,30 +1,30 @@
-.. _astrometry_api:
+.. _enhanced_products:
 
-Generating Astrometrically Aligned products
-============================================
-The code described here gets used in the automated HST calibration pipeline to align images to an absolute astrometric standard using a number of methods.
-
+Enhanced Pipeline Products code API
+-------------------------------------
 
 .. automodule:: drizzlepac.alignimages
-  :members:
-  :undoc-members:
+.. autofunction:: drizzlepac.alignimages.perform_align
+.. autofunction:: drizzlepac.alignimages.generate_source_catalogs
+
 
 .. automodule:: drizzlepac.hlautils.astrometric_utils
-  :members:
-  :undoc-members:
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.create_astrometric_catalog
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.get_catalog
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.find_gsc_offset
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.extract_sources
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.classify_sources
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.generate_source_catalog
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.generate_sky_catalog
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.compute_photometry
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.filter_catalog
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.build_self_reference
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.within_footprint
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.find_hist2d_offset
+.. autofunction:: drizzlepac.hlautils.astrometric_utils.build_wcscat
 
 .. automodule:: drizzlepac.hlautils.astroquery_utils
-  :members:
-  :undoc-members:
-
-.. automodule:: drizzlepac.hlautils.catalog_utils
-  :members:
-  :undoc-members:
-
-.. automodule:: drizzlepac.hlautils.analyze
-  :members:
-  :undoc-members:
+.. autofunction:: drizzlepac.hlautils.astroquery_utils.retrieve_observation
 
 .. automodule:: drizzlepac.hlautils.testutils
-  :members:
-  :undoc-members:
+.. autofunction:: drizzlepac.hlautils.testutils.compare_wcs_alignment

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -117,12 +117,18 @@ The task 'runastrodriz' can be used to reproduce the same Drizzle processing tha
 
    Running Astrodriz <runastrodriz.rst>
 
-Enhanced Pipeline Products API
-------------------------------
+Astrometry and Enhanced Pipeline Products
+------------------------------------------
+The `drizzlepac` package can be used for many purposes, all related to aligning and combining images to create products which can provide the deepest available views of the data.  Combining the data with `drizzlepac` relies on the WCS solution specified in the input image headers.  These WCS solutions are expected to align the images to each other (relative astrometry) as well as align the image to the correct position on the sky (absolute astrometry).  The telemetry from HST allows the relative astrometry to be known extremely accurately (sub-milli-arcsecond level) when all images use the same guide stars and when the images were taken in the same visit.  However, data taken at different times using different guide stars have historically had errors in the alignment with a sigma of 1 arc-second (or more).  As a result, corrections to the alignment need to be made in order to successfully combine the images.
+
+The code being used in the automated HST calibration pipeline, used to generate the products served by the HST Archive through the MAST Portal, uses multiple methods to do the best job possible in aligning and combining data regardless of whether they came from the same visit (or instrument) or not.
+
 .. toctree::
    :maxdepth: 2
 
-   hla
+   Astrometry and Headerlets <astrometry.rst>
+   astrometry_api.rst
+
 
 Indices and tables
 ==================
@@ -130,6 +136,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-
-

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -6,7 +6,7 @@ should fall within the field-of-view of all the input images.
 
 This module relies on the definition of an environment variable to specify
 the URL of the astrometric catalog to use for generating this
-reference catalog.
+reference catalog. ::
 
     ASTROMETRIC_CATALOG_URL  -- URL of web service that can be queried to
                                 obtain listing of astrometric sources,
@@ -58,6 +58,7 @@ __taskname__ = 'astrometric_utils'
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
 
 
+
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = 'http://gsss.stsci.edu/webservices'
 
@@ -68,7 +69,7 @@ else:
 
 MODULE_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
 VEGASPEC = os.path.join(os.path.dirname(MODULE_PATH),
-                        'data', 'alpha_lyr_stis_008.fits')
+                        'data','alpha_lyr_stis_008.fits')
 
 __all__ = ['create_astrometric_catalog', 'compute_radius', 'find_gsc_offset',
            'extract_sources', 'find_hist2d_offset', 'generate_source_catalog',
@@ -77,7 +78,7 @@ __all__ = ['create_astrometric_catalog', 'compute_radius', 'find_gsc_offset',
 
 def buildRotMatrix(theta):
     _theta = np.deg2rad(theta)
-    _mrot = np.zeros(shape=(2, 2), dtype=np.float64)
+    _mrot = np.zeros(shape=(2,2), dtype=np.float64)
     _mrot[0] = (np.cos(_theta), np.sin(_theta))
     _mrot[1] = (-np.sin(_theta), np.cos(_theta))
 
@@ -89,8 +90,6 @@ def buildRotMatrix(theta):
 Primary function for creating an astrometric reference catalog.
 
 """
-
-
 def create_astrometric_catalog(inputs, **pars):
     """Create an astrometric catalog that covers the inputs' field-of-view.
 
@@ -148,7 +147,7 @@ def create_astrometric_catalog(inputs, **pars):
 
     # perform query for this field-of-view
     ref_dict = get_catalog(ra, dec, sr=radius, catalog=catalog)
-    colnames = ('ra', 'dec', 'mag', 'objID', 'GaiaID')
+    colnames = ('ra','dec', 'mag', 'objID', 'GaiaID')
     col_types = ('f8', 'f8', 'f4', 'U25', 'U25')
     ref_table = Table(names=colnames, dtype=col_types)
 
@@ -183,7 +182,6 @@ def create_astrometric_catalog(inputs, **pars):
 
     return ref_table
 
-
 def build_reference_wcs(inputs, sciname='sci'):
     """Create the reference WCS based on all the inputs for a field"""
     # start by creating a composite field-of-view for all inputs
@@ -207,7 +205,6 @@ def build_reference_wcs(inputs, sciname='sci'):
     outwcs = utils.output_wcs(wcslist)
 
     return outwcs
-
 
 def get_catalog(ra, dec, sr=0.1, fmt='CSV', catalog='GSC241'):
     """ Extract catalog from VO web service.
@@ -243,7 +240,7 @@ def get_catalog(ra, dec, sr=0.1, fmt='CSV', catalog='GSC241'):
     headers = {'Content-Type': 'text/csv'}
 
     spec = spec_str.format(ra, dec, sr, fmt, catalog)
-    serviceUrl = '{}/{}?{}'.format(SERVICELOCATION, serviceType, spec)
+    serviceUrl = '{}/{}?{}'.format(SERVICELOCATION, serviceType,spec)
     rawcat = requests.get(serviceUrl, headers=headers)
     r_contents = rawcat.content.decode()  # convert from bytes to a String
     rstr = r_contents.split('\r\n')
@@ -266,7 +263,6 @@ def compute_radius(wcs):
     radius = img_center.separation(img_corners).max().value
 
     return radius
-
 
 def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
     """Find the GSC to GAIA offset based on guide star coordinates
@@ -291,7 +287,7 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
         ippssoot = fu.buildNewRootname(image).upper()
 
     spec = spec_str.format(input_catalog, output_catalog, ippssoot)
-    serviceUrl = "{}/{}?{}".format(SERVICELOCATION, serviceType, spec)
+    serviceUrl = "{}/{}?{}".format(SERVICELOCATION, serviceType,spec)
     rawcat = requests.get(serviceUrl)
     if not rawcat.ok:
         log.info("Problem accessing service with:\n{{}".format(serviceUrl))
@@ -299,13 +295,13 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
 
     delta_ra = delta_dec = None
     tree = BytesIO(rawcat.content)
-    for _, element in etree.iterparse(tree):
+    for _,element in etree.iterparse(tree):
         if element.tag == 'deltaRA':
             delta_ra = float(element.text)
         elif element.tag == 'deltaDEC':
             delta_dec = float(element.text)
 
-    return delta_ra, delta_dec
+    return delta_ra,delta_dec
 
 
 def extract_sources(img, **pars):
@@ -357,8 +353,8 @@ def extract_sources(img, **pars):
         If plotting the sources, scale the image to this maximum value.
 
     """
-    fwhm = pars.get('fwhm', 3.0)
-    threshold = pars.get('threshold', None)
+    fwhm= pars.get('fwhm', 3.0)
+    threshold= pars.get('threshold', None)
     source_box = pars.get('source_box', 7)
     classify = pars.get('classify', True)
     output = pars.get('output', None)
@@ -366,7 +362,7 @@ def extract_sources(img, **pars):
     vmax = pars.get('vmax', None)
     centering_mode = pars.get('centering_mode', 'starfind')
     deblend = pars.get('deblend', False)
-    dqmask = pars.get('dqmask', None)
+    dqmask = pars.get('dqmask',None)
     nlargest = pars.get('nlargest', None)
     # apply any provided dqmask for segmentation only
     if dqmask is not None:
@@ -382,8 +378,8 @@ def extract_sources(img, **pars):
     for percentile in exclude_percentiles:
         try:
             bkg = Background2D(imgarr, (50, 50), filter_size=(3, 3),
-                               bkg_estimator=bkg_estimator,
-                               exclude_percentile=percentile)
+                           bkg_estimator=bkg_estimator,
+                           exclude_percentile=percentile)
             # If it succeeds, stop and use that value
             bkg_rms = (5. * bkg.background_rms)
             bkg_rms_mean = bkg.background.mean() + 5. * bkg_rms.std()
@@ -416,8 +412,8 @@ def extract_sources(img, **pars):
                           filter_kernel=kernel)
     if deblend:
         segm = deblend_sources(imgarr, segm, npixels=5,
-                               filter_kernel=kernel, nlevels=16,
-                               contrast=0.01)
+                           filter_kernel=kernel, nlevels=16,
+                           contrast=0.01)
     # If classify is turned on, it should modify the segmentation map
     if classify:
         cat = source_properties(imgarr, segm)
@@ -426,10 +422,11 @@ def extract_sources(img, **pars):
             bad_srcs = np.where(classify_sources(cat) == 0)[0] + 1
             segm.remove_labels(bad_srcs)  # CAUTION: May be time-consuming!!!
 
+
     # convert segm to mask for daofind
     if centering_mode == 'starfind':
         src_table = None
-        # daofind = IRAFStarFinder(fwhm=fwhm, threshold=5.*bkg.background_rms_median)
+        #daofind = IRAFStarFinder(fwhm=fwhm, threshold=5.*bkg.background_rms_median)
         log.info("Setting up DAOStarFinder with: \n    fwhm={}  threshold={}".format(fwhm, bkg_rms_mean))
         daofind = DAOStarFinder(fwhm=fwhm, threshold=bkg_rms_mean)
         # Identify nbrightest/largest sources
@@ -441,13 +438,13 @@ def extract_sources(img, **pars):
 
         for label in segm.labels:
             if nlargest is not None and label not in large_labels:
-                continue  # Move on to the next segment
+                continue # Move on to the next segment
             # Get slice definition for the segment with this label
             seg_slice = segm.segments[label - 1].slices
             seg_yoffset = seg_slice[0].start
             seg_xoffset = seg_slice[1].start
 
-            # Define raw data from this slice
+            #Define raw data from this slice
             detection_img = img[seg_slice]
             # zero out any pixels which do not have this segments label
             detection_img[np.where(segm.data[seg_slice] == 0)] = 0
@@ -509,7 +506,6 @@ def extract_sources(img, **pars):
             ax[1][1].imshow(threshold, origin='lower')
     return tbl, segm
 
-
 def classify_sources(catalog, sources=None):
     """ Convert moments_central attribute for source catalog into star/cr flag.
 
@@ -535,21 +531,20 @@ def classify_sources(catalog, sources=None):
     """
     moments = catalog.moments_central
     if sources is None:
-        sources = (0, len(moments))
+        sources = (0,len(moments))
     num_sources = sources[1] - sources[0]
-    srctype = np.zeros((num_sources,), np.int32)
-    for src in range(sources[0], sources[1]):
+    srctype = np.zeros((num_sources,),np.int32)
+    for src in range(sources[0],sources[1]):
         # Protect against spurious detections
         src_x = catalog[src].xcentroid
         src_y = catalog[src].ycentroid
         if np.isnan(src_x) or np.isnan(src_y):
             continue
-        x, y = np.where(moments[src] == moments[src].max())
+        x,y = np.where(moments[src] == moments[src].max())
         if (x[0] > 1) and (y[0] > 1):
             srctype[src] = 1
 
     return srctype
-
 
 def generate_source_catalog(image, **kwargs):
     """ Build source catalogs for each chip using photutils.
@@ -596,8 +591,8 @@ def generate_source_catalog(image, **kwargs):
     """
     if not isinstance(image, pf.HDUList):
         raise ValueError("Input {} not fits.HDUList object".format(image))
-    dqname = kwargs.get('dqname', 'DQ')
-    output = kwargs.get('output', None)
+    dqname = kwargs.get('dqname','DQ')
+    output = kwargs.get('output',None)
     # Build source catalog for entire image
     source_cats = {}
     numSci = countExtn(image, extname='SCI')
@@ -609,12 +604,12 @@ def generate_source_catalog(image, **kwargs):
             rootname = image[0].header['rootname']
             outroot = '{}_sci{}_src'.format(rootname, chip)
             kwargs['output'] = outroot
-        imgarr = image['sci', chip].data
+        imgarr = image['sci',chip].data
 
         # apply any DQ array, if available
         dqmask = None
         if image.index_of(dqname):
-            dqarr = image[dqname, chip].data
+            dqarr = image[dqname,chip].data
 
             # "grow out" regions in DQ mask flagged as saturated by several
             # pixels in every direction to prevent the
@@ -709,10 +704,10 @@ def generate_sky_catalog(image, refwcs, **kwargs):
         if seg_tab_phot is None:
             continue
         # Convert pixel coordinates from this chip to sky coordinates
-        chip_wcs = wcsutil.HSTWCS(image, ext=('sci', chip))
-        seg_ra, seg_dec = chip_wcs.all_pix2world(seg_tab_phot['xcentroid'], seg_tab_phot['ycentroid'], 1)
+        chip_wcs = wcsutil.HSTWCS(image,ext=('sci',chip))
+        seg_ra,seg_dec = chip_wcs.all_pix2world(seg_tab_phot['xcentroid'],seg_tab_phot['ycentroid'],1)
         # Convert sky positions to pixel positions in the reference WCS frame
-        seg_xy_out = refwcs.all_world2pix(seg_ra, seg_dec, 1)
+        seg_xy_out = refwcs.all_world2pix(seg_ra,seg_dec,1)
         seg_tab_phot['xcentroid'] = seg_xy_out[0]
         seg_tab_phot['ycentroid'] = seg_xy_out[1]
         if master_cat is None:
@@ -721,7 +716,6 @@ def generate_sky_catalog(image, refwcs, **kwargs):
             master_cat = vstack([master_cat, seg_tab_phot])
 
     return master_cat
-
 
 def compute_photometry(catalog, photmode):
     """ Compute magnitudes for sources from catalog based on observations photmode.
@@ -757,7 +751,6 @@ def compute_photometry(catalog, photmode):
 
     return catalog
 
-
 def filter_catalog(catalog, **kwargs):
     """ Create a new catalog selected from input based on photometry.
 
@@ -782,10 +775,10 @@ def filter_catalog(catalog, **kwargs):
         New table which only has the sources that meet the selection criteria.
     """
     # interpret input pars
-    bright_limit = kwargs.get('bright_limit', 1.00)
-    max_bright = kwargs.get('max_bright', None)
-    min_bright = kwargs.get('min_bright', 20)
-    colname = kwargs.get('colname', 'vegamag')
+    bright_limit = kwargs.get('bright_limit',1.00)
+    max_bright = kwargs.get('max_bright',None)
+    min_bright = kwargs.get('min_bright',20)
+    colname = kwargs.get('colname','vegamag')
 
     # sort by magnitude
     phot_column = catalog[colname]
@@ -802,6 +795,7 @@ def filter_catalog(catalog, **kwargs):
     new_catalog = catalog[sort_indx[:limit_num]]
 
     return new_catalog
+
 
 
 def build_self_reference(filename, clean_wcs=False):
@@ -847,13 +841,10 @@ def build_self_reference(filename, clean_wcs=False):
 
     if clean_wcs:
         wcsbase = wcslin.wcs
-        customwcs = build_hstwcs(wcsbase.crval[0], wcsbase.crval[1], wcsbase.crpix[0],
-                                 wcsbase.crpix[1], wcslin._naxis1, wcslin._naxis2,
-                                 wcslin.pscale, wcslin.orientat)
+        customwcs = build_hstwcs(wcsbase.crval[0],wcsbase.crval[1],wcsbase.crpix[0],wcsbase.crpix[1],wcslin._naxis1,wcslin._naxis2,wcslin.pscale,wcslin.orientat)
     else:
         customwcs = wcslin
     return customwcs
-
 
 def read_hlet_wcs(filename, ext):
     """Insure `stwcs.wcsutil.HSTWCS` includes all attributes of a full image WCS.
@@ -874,8 +865,8 @@ def build_hstwcs(crval1, crval2, crpix1, crpix2, naxis1, naxis2, pscale, orienta
     distortion based on user provided parameter values.
     """
     wcsout = wcsutil.HSTWCS()
-    wcsout.wcs.crval = np.array([crval1, crval2])
-    wcsout.wcs.crpix = np.array([crpix1, crpix2])
+    wcsout.wcs.crval = np.array([crval1,crval2])
+    wcsout.wcs.crpix = np.array([crpix1,crpix2])
     wcsout.naxis1 = naxis1
     wcsout.naxis2 = naxis2
     wcsout.wcs.cd = buildRotMatrix(orientat) * [-1, 1] * pscale / 3600.0
@@ -883,10 +874,9 @@ def build_hstwcs(crval1, crval2, crpix1, crpix2, naxis1, naxis2, pscale, orienta
     wcsout.wcs.set()
     wcsout.setPscale()
     wcsout.setOrient()
-    wcsout.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcsout.wcs.ctype = ['RA---TAN','DEC--TAN']
 
     return wcsout
-
 
 def within_footprint(img, wcs, x, y):
     """Determine whether input x, y fall in the science area of the image.
@@ -926,11 +916,10 @@ def within_footprint(img, wcs, x, y):
 
     # Now, confirm that these points fall within actual science area of WCS
     img_mask = create_image_footprint(img, wcs, border=1.0)
-    inmask = np.where(img_mask[y.astype(np.int32), x.astype(np.int32)])[0]
+    inmask = np.where(img_mask[y.astype(np.int32),x.astype(np.int32)])[0]
     x = x[inmask]
     y = y[inmask]
-    return x, y
-
+    return x,y
 
 def create_image_footprint(image, refwcs, border=0.):
     """ Create the footprint of the image in the reference WCS frame.
@@ -958,7 +947,7 @@ def create_image_footprint(image, refwcs, border=0.):
     # convert border value into pixels
     border_pixels = int(border / refwcs.pscale)
 
-    mask_arr = np.zeros((ref_y, ref_x), dtype=int)
+    mask_arr = np.zeros((ref_y,ref_x),dtype=int)
 
     for chip in range(numSci):
         chip += 1
@@ -976,7 +965,7 @@ def create_image_footprint(image, refwcs, border=0.):
         mask_arr[edge_y_out, edge_x_out] = 1
 
     # Fill in outline of each chip
-    mask_arr = ndimage.binary_fill_holes(ndimage.binary_dilation(mask_arr, iterations=2))
+    mask_arr = ndimage.binary_fill_holes(ndimage.binary_dilation(mask_arr,iterations=2))
 
     if border > 0.:
         mask_arr = ndimage.binary_erosion(mask_arr, iterations=border_pixels)
@@ -1075,8 +1064,8 @@ def find_hist2d_offset(filename, reference, refwcs=None, refnames=['ra', 'dec'],
 
     # Build source catalog for entire image
     img_cat = generate_source_catalog(image, refwcs, output=chip_catalog, classify=classify)
-    img_cat.write(filename.replace(".fits", "_xy.cat"), format='ascii.no_header',
-                  overwrite=True)
+    img_cat.write(filename.replace(".fits","_xy.cat"), format='ascii.no_header',
+                    overwrite=True)
 
     # Retrieve source XY positions in reference frame
     seg_xy = np.column_stack((img_cat['xcentroid'], img_cat['ycentroid']))
@@ -1093,8 +1082,8 @@ def find_hist2d_offset(filename, reference, refwcs=None, refnames=['ra', 'dec'],
 
     # write out astrometric reference catalog that was actually used
     ref_ra_img, ref_dec_img = refwcs.all_pix2world(xref, yref, 1)
-    ref_tab = Table([ref_ra_img, ref_dec_img, xref, yref], names=['ra', 'dec', 'x', 'y'])
-    ref_tab.write(reference.replace('.cat', '_{}.cat'.format(rootname)),
+    ref_tab = Table([ref_ra_img,ref_dec_img, xref, yref],names=['ra','dec', 'x', 'y'])
+    ref_tab.write(reference.replace('.cat','_{}.cat'.format(rootname)),
                   format='ascii.fast_commented_header', overwrite=True)
     searchrad = search_radius / refwcs.pscale
 

--- a/drizzlepac/hlautils/testutils.py
+++ b/drizzlepac/hlautils/testutils.py
@@ -35,6 +35,7 @@ def compare_wcs_alignment(dataset, force=False):
         results : dict
             A dictionary whose keys are the WCS's found and fit to GAIA.
             Each WCS has entries for:
+            
                 * imageName - filenames of input exposures included in the fit
                 * offset_x - offset in X (pixels)
                 * offset_y - offset in X (pixels)


### PR DESCRIPTION
A first draft of some documentation on the new astrometric solutions and headerlets has been added to this package's doc directory for inclusion in the readthedocs output.   A new section was added at the top level labelled "Astrometry and Drizzle Products" which introduces and points to the new documentation.  The new docs are split into 2 components: end-user directed explanations and examples in the first section, and the usual API for all the new HLA-based alignment code based on the code's docstrings.   

This documentation also needs to be reviewed by INS in order to get their approval for the contents prior to merging.   

The intent is to have this as part of this initial public release, even if incomplete.  We can then update it further as we prepare the code to become operational.  