### PR TITLE
Changed the nature of _random_select_from_csv() at this time.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,4 @@
 """Project default for pytest"""
-import os
-import pytest
 
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
@@ -8,3 +6,19 @@ from astropy.tests.helper import enable_deprecations_as_exceptions
 
 # Uncomment the following line to treat all DeprecationWarnings as exceptions
 enable_deprecations_as_exceptions()
+
+# Utilities to support command line passing of arguments to test_randomlist.py
+def pytest_addoption(parser):
+    """Support options for the pytest test_randomlist.py."""
+    parser.addoption("--start_row", action="store", default=0)
+    parser.addoption("--num_rows", action="store", default=50)
+
+def pytest_generate_tests(metafunc):
+    """Get the command line option."""
+    option_value1 = metafunc.config.option.start_row
+    if 'start_row' in metafunc.fixturenames and option_value1 is not None:
+        metafunc.parametrize("start_row", [option_value1])
+
+    option_value2 = metafunc.config.option.num_rows
+    if 'num_rows' in metafunc.fixturenames and option_value2 is not None:
+        metafunc.parametrize("num_rows", [option_value2])

--- a/tests/hla/process_randomlist.py
+++ b/tests/hla/process_randomlist.py
@@ -1,9 +1,9 @@
 """ This module processes a test on a list of input datasets to collect
     statistics on the quality of the alignment of each dataset to an
     astrometric catalog."""
-import os
 import datetime
 import time
+import os
 import random
 import numpy as np
 from astropy.table import Table, vstack
@@ -40,8 +40,8 @@ def _random_select_from_csv(table_name, num_entries, seed_value):
 
     Notes
     =====
-    The nature of this routine has changed to return an output table
-    culled sequentially from the input table.
+    This routine is for future use.
+
     """
     # Initialize the random number generator
     random.seed(seed_value)
@@ -49,10 +49,12 @@ def _random_select_from_csv(table_name, num_entries, seed_value):
     # Get the contents of the table
     data_table = Table.read(table_name, format='ascii.csv')
 
-    # Since the table is already randomized and to make it easier
-    # to start up new tests from the last dataset processed, just
-    # process the requested number of rows.
-    output_table = data_table[0:numEntries]
+    # Generate a sequence of integers the size of the table, and then
+    # obtain a random subset of the sequence with no duplicate selections
+    subset = random.sample(range(len(data_table)), num_entries)
+
+    # Extract the subset rows...
+    output_table = data_table[subset]
 
     # Returns the outputTable which is an Astropy Table object
     return output_table
@@ -62,7 +64,7 @@ class TestAlignMosaic(BaseHLATest):
         aligned to an astrometric standard.
     """
 
-    def test_align_randomfields(self):
+    def test_align_randomfields(self, start_row, num_rows):
         """ Wrapper to set up the test for aligning a large number of randomly
             selected fields (aka datasets) from a input ascii file (CSV).
 
@@ -73,23 +75,34 @@ class TestAlignMosaic(BaseHLATest):
 
         input_list_file = 'ACSWFC3List.csv'
 
-        # Desired number of random entries for testing
-        input_num_entries = 50
-
-        # Seed for random number generator
-        input_seed_value = 1
-
         # Obtain the full path to the file containing the dataset field names
         self.input_repo = 'hst-hla-pipeline'
         self.tree = 'dev'
         self.input_loc = 'master_lists'
         input_file_path = self.get_data(input_list_file)
 
+        # FOR FUTURE
+        # Desired number of random entries for testing
+        # num_rows = 50
+
+        # Seed for random number generator
+        # input_seed_value = 1
+
         # Randomly select a subset of field names (each field represented by a row) from
         # the master CSV file and return as an Astropy table
-        random_candidate_table = _random_select_from_csv(input_file_path[0],
-                                                              input_num_entries,
-                                                              input_seed_value)
+        # NOTE: Preserved for use in the future.
+        # random_candidate_table = _random_select_from_csv(input_file_path[0],
+        #                                                 num_rows,
+        #                                                 input_seed_value)
+
+        # Read a randomized table
+        data_table = Table.read(input_file_path[0], format='ascii.csv')
+
+        # Extract the subset rows
+        start_row = int(start_row)
+        end_row = start_row + int(num_rows)
+        print("\nTEST_RANDOM. Start row: {}   Number of rows to process: {}.".format(start_row, num_rows))
+        random_candidate_table = data_table[start_row:end_row]
 
         # Invoke the methods which will handle acquiring/downloading the data from
         # MAST and perform the alignment.  If an exception happens, just abort
@@ -168,7 +181,7 @@ class TestAlignMosaic(BaseHLATest):
                     dataset_table.write(output_name, format='ascii.ecsv')
 
                     # Successful datasets
-                    if fit_qual <= 2:
+                    if 0 < fit_qual <= 2:
                         print("TEST_RANDOM. Successful Dataset (fit_qual <= 2): ", dataset, "\n")
                         num_success += 1
                     elif 2 < fit_qual <= 4:

--- a/tests/hla/process_randomlist.py
+++ b/tests/hla/process_randomlist.py
@@ -37,6 +37,11 @@ def _random_select_from_csv(table_name, num_entries, seed_value):
     =======
     output_table : object
         Astropy Table object
+
+    Notes
+    =====
+    The nature of this routine has changed to return an output table
+    culled sequentially from the input table.
     """
     # Initialize the random number generator
     random.seed(seed_value)
@@ -44,16 +49,13 @@ def _random_select_from_csv(table_name, num_entries, seed_value):
     # Get the contents of the table
     data_table = Table.read(table_name, format='ascii.csv')
 
-    # Generate a sequence of integers the size of the table, and then
-    # obtain a random subset of the sequence with no duplicate selections
-    subset = random.sample(range(len(data_table)), num_entries)
-
-    # Extract the subset rows...
-    output_table = data_table[subset]
+    # Since the table is already randomized and to make it easier
+    # to start up new tests from the last dataset processed, just
+    # process the requested number of rows.
+    output_table = data_table[0:numEntries]
 
     # Returns the outputTable which is an Astropy Table object
     return output_table
-
 
 class TestAlignMosaic(BaseHLATest):
     """ Process a large sample of ACS and WFC3 datasets to determine if they can be
@@ -73,7 +75,6 @@ class TestAlignMosaic(BaseHLATest):
 
         # Desired number of random entries for testing
         input_num_entries = 50
-        input_num_entries = 2
 
         # Seed for random number generator
         input_seed_value = 1

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -7,7 +7,8 @@ from .process_randomlist import TestAlignMosaic
 @pytest.mark.bigdata
 @pytest.mark.xfail
 @pytest.mark.slow
-def test_randomlist(self):
+@pytest.mark.unit
+def test_randomlist(start_row, num_rows):
     """ Tests which validate whether mosaics can be aligned to an astrometric standard.
 
         Characteristics of these tests:
@@ -53,4 +54,4 @@ def test_randomlist(self):
     """
     run_random_test = TestAlignMosaic()
 
-    assert run_random_test.test_align_randomfields() > 0.7
+    assert run_random_test.test_align_randomfields(start_row, num_rows) > 0.7


### PR DESCRIPTION
In order to run this pytest on a large number of random datasets, the nature of the _random_select_from_csv() routine has been altered at this time to work on the input table in a sequential fashion.  In this case, the input list is actually already randomized.