### PR TITLE
Implemented parallel testing with user input file list

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,4 @@
 """Project default for pytest"""
-
-from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 
@@ -13,13 +11,3 @@ def pytest_addoption(parser):
     parser.addoption("--start_row", action="store", default=0)
     parser.addoption("--num_rows", action="store", default=50)
     parser.addoption("--master_list", action="store", default="Masterlist.csv")
-
-def pytest_generate_tests(metafunc):
-    """Get the command line option."""
-    option_value1 = metafunc.config.option.start_row
-    if 'start_row' in metafunc.fixturenames and option_value1 is not None:
-        metafunc.parametrize("start_row", [option_value1])
-
-    option_value2 = metafunc.config.option.num_rows
-    if 'num_rows' in metafunc.fixturenames and option_value2 is not None:
-        metafunc.parametrize("num_rows", [option_value2])

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ def pytest_addoption(parser):
     """Support options for the pytest test_randomlist.py."""
     parser.addoption("--start_row", action="store", default=0)
     parser.addoption("--num_rows", action="store", default=50)
+    parser.addoption("--master_list", action="store", default="Masterlist.csv")
 
 def pytest_generate_tests(metafunc):
     """Get the command line option."""

--- a/tests/hla/test_randomlist.py
+++ b/tests/hla/test_randomlist.py
@@ -1,14 +1,37 @@
 """ This module is the high-level wrapper for running a test on a list of input
     datasets in order to collect statistics on alignment of each dataset to an
     astrometric catalog."""
+import datetime
+import os
+import numpy as np
+from astropy.table import Table
 import pytest
-from .process_randomlist import TestAlignMosaic
+
+from drizzlepac import alignimages
+
+def pytest_generate_tests(metafunc):
+    """Get the command line option."""
+    start_row = metafunc.config.option.start_row
+    num_rows = metafunc.config.option.num_rows
+    master_list = metafunc.config.option.master_list
+
+    # Read a randomized table
+    data_table = Table.read(master_list, format='ascii.csv')
+
+    # Extract the subset rows
+    start_row = int(start_row)
+    end_row = start_row + int(num_rows)
+    print("\nTEST_RANDOM. Start row: {}   Number of rows to process: {}.".format(start_row, num_rows))
+    print("MASTER_TABLE: {}".format(master_list))
+    random_candidate_table = data_table[start_row:end_row]['observationID'].tolist()
+    print(random_candidate_table)
+    metafunc.parametrize('dataset', random_candidate_table)
+
 
 @pytest.mark.bigdata
-@pytest.mark.xfail
 @pytest.mark.slow
 @pytest.mark.unit
-def test_randomlist(start_row, num_rows):
+def test_randomlist(dataset):
     """ Tests which validate whether mosaics can be aligned to an astrometric standard.
 
         Characteristics of these tests:
@@ -35,23 +58,68 @@ def test_randomlist(start_row, num_rows):
             statistical sample (70%) of ACS and WFC3 datasets were able to be
             aligned to within 10mas RMS.
               * RMS values are extracted from the table output from `perform_align`
+              * This criterion will need to be determined by the user after the test has been run based
+                on how many datasets were run and skipped.
 
-        The environment variable needs to be set in the following manner:
-            export TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory/
-            OR
-            export TEST_BIGDATA=/Users/YourNameHere/TestDataDirectory/
-
-        For this test, the TEST_BIGDATA defines the root of the location where
-        the CSV file is stored.  The full path is
-        TEST_BIGDATA/self.input_repo/self.tree/self.input_loc.  The CSV is
+        The input master_list CSV file is
         output from a database and lists associations and singletons for ACS
         and WFC3 instruments randomly sorted.  The actual data files are
         downloaded from MAST via astroquery.
 
         This test file can be executed in the following manner:
-            $ pytest -s --bigdata test_randomlist.py >& test_random_output.txt &
+            $ pytest -s --basetemp=/internal/pytest-processing --bigdata --slow --master_list ACSWFC3List.csv --start_row 0 --num_rows 50 test_randomlist.py >& test_random_output.txt &
             $ tail -f test_random_output.txt
-    """
-    run_random_test = TestAlignMosaic()
+        The `-n` option can be used to run tests in parallel if `pytest-xdist` has been installed.
 
-    assert run_random_test.test_align_randomfields(start_row, num_rows) > 0.7
+    """
+    print("TEST_RANDOM. Dataset: ", dataset)
+    output_name = dataset + '.ecsv'
+
+    current_dt = datetime.datetime.now()
+    print(str(current_dt))
+
+    try:
+
+        dataset_table = alignimages.perform_align([dataset], archive=False,
+                                                  clobber=True, debug=False,
+                                                  update_hdr_wcs=False,
+                                                  print_fit_parameters=True,
+                                                  print_git_info=False,
+                                                  output=False)
+
+        # Filtered datasets
+        if dataset_table['doProcess'].sum() == 0:
+            pytest.skip("TEST_RANDOM. Filtered Dataset: {}".format(dataset))
+        # Datasets to process
+        elif dataset_table['doProcess'].sum() > 0:
+            # Determine images in dataset to be processed and the number of images
+            # This is in case an image was filtered out (e.g., expotime = 0)
+            index = np.where(dataset_table['doProcess'] == 1)[0]
+            fit_qual = dataset_table['fit_qual'][index[0]]
+
+            # Update the table with the dataset_key which is really just a counter
+            dataset_table['completed'][:] = True
+            dataset_table.write(output_name, format='ascii.ecsv')
+
+            if fit_qual > 4:
+                pytest.fail("TEST_RANDOM. Unsuccessful Dataset (fit_qual = 5): ".format(dataset))
+            else:
+                assert fit_qual <= 4
+
+    # Catch anything that happens as this dataset will be considered a failure, but
+    # the processing of datasets should continue.  This is meant to catch
+    # unexpected errors and generate sufficient output exception
+    # information so algorithmic problems can be addressed.
+    except Exception as except_details:
+        print(except_details)
+        pytest.fail("TEST_RANDOM. Exception Dataset: {}", dataset, "\n")
+
+    finally:
+        # Perform some clean up
+        if os.path.isfile('ref_cat.ecsv'):
+            os.remove('ref_cat.ecsv')
+        if os.path.isfile('refcatalog.cat'):
+            os.remove('refcatalog.cat')
+        for filename in os.listdir():
+            if filename.endswith('flt.fits') or filename.endswith('flc.fits'):
+                os.remove(filename)


### PR DESCRIPTION
This shows how testing of multiple datasets can be performed in parallel with the user providing the master list on input.  It relies on pytest to report failures and skips rather than computing the 70% pass/fail criteria itself.