### PR TITLE
Disable WFPC2 waiver tests

### DIFF
--- a/tests/wfpc2/test_wfpc2.py
+++ b/tests/wfpc2/test_wfpc2.py
@@ -9,6 +9,7 @@ from ..resources import BaseWFPC2
 
 class TestWFPC2(BaseWFPC2):
 
+    @pytest.mark.skip(reason="disable until truth files can be updated")
     def test_waiver_single(self):
         """ This test confirms that drizzlepac can correcly process .
         """
@@ -50,6 +51,7 @@ class TestWFPC2(BaseWFPC2):
         outputs = [(outfile, reffile)]
         self.compare_outputs(outputs)
 
+    @pytest.mark.skip(reason="disable until truth files can be updated")
     def test_waiver_asn(self):
         """ This test confirms that drizzlepac can correcly process input
         WFPC2 data stored in WAIVER fits format.


### PR DESCRIPTION
This disables WFPC2 waiver file format tests until the truth files can be updated in regression tests. See https://github.com/spacetelescope/drizzlepac/issues/338