### PR TITLE
Make WithLogging decorator handle functions that return values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ of the list).
 3.0.2 (unreleased)
 ==================
 
+- Improved ``util.WithLogging`` decorator to handle functions that return
+  values. [#364]
+
 - Fixed a bug in the automatic computation of the IVM weights when IVM
   was not provided by the user. [#320]
 

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -208,10 +208,10 @@ class WithLogging:
                         logfile = kwargs.get('runfile', None)
                         if logfile:
                             filename = logfile
-                        verbose_level = logging.INFO  # Default level 
+                        verbose_level = logging.INFO  # Default level
                         # If either `debug` or `verbose` are set to True in kwargs
                         # set logging level to DEBUG
-                        debug = kwargs.get('debug',False)   
+                        debug = kwargs.get('debug',False)
                         verbose = kwargs.get('verbose', False)
                         if debug or verbose:
                             verbose_level = logging.DEBUG
@@ -228,10 +228,12 @@ class WithLogging:
             # under it, Python discards the sys.exc_info() data by the time the
             # finally clause is reached.
             try:
-                func(*args, **kwargs)
+                result = func(*args, **kwargs)
             except Exception as e:
                 errorobj = e
+                result = None
                 raise
+
             finally:
                 self.depth -= 1
                 if self.depth == 0:
@@ -240,6 +242,7 @@ class WithLogging:
                     # (hope that end_logging didn't change the last exception raised)
                     if errorobj:
                         raise errorobj
+                return result
 
         return wrapper
 


### PR DESCRIPTION
This should fix the issue described in https://github.com/spacetelescope/drizzlepac/pull/360#issuecomment-489739047. Specifically, it appears that `util.WithLogging` was designed for the original `astrodrizzle` and `tweakreg`' `run()` functions that do not return values. As designed, `util.WithLogging` cannot handle the case of functions returning values as used in https://github.com/spacetelescope/drizzlepac/pull/360/files#diff-7e71c64f2a6349beb1e22b3761bb8e81R192

This PR expands `util.WithLogging` to make the decorated function return the original function return value.