### PR TITLE
Fix incorrect log file name reported by WithLogging and return in finally

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ of the list).
 3.0.2 (unreleased)
 ==================
 
+- Fixed a bug in the ``util.WithLogging`` decorator due to which incorrect
+  log file was reported when user-supplied log file name does not have ``.log``
+  extension. [#365]
+
+- Fixed a bug introduced in #364 returning in ``finally`` block. [#365]
+
 - Improved ``util.WithLogging`` decorator to handle functions that return
   values. [#364]
 


### PR DESCRIPTION
This PR fixes a bug in `util.WithLogging` due to which the name of the log file reported by the decorator is incorrect when the log file name set by user does not have the `.log` extension.

This also fixes a bug introduced in #364 (`return` in `finally`) reported by @pllim .