### PR TITLE
handle astroquery import error and improve ASN interpretation

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -84,6 +84,7 @@ def check_and_get_data(input_list, **pars):
     candidate_list = []   # File names gathered from *_asn.fits file
     ipppssoot_list = []   # ipppssoot names used to avoid duplicate downloads
     total_input_list = []  # Output full filename list of data on disk
+    member_suffix = '_flc.fits'
 
     # Loop over the input_list to determine if the item in the input_list is a full association file
     # (*_asn.fits), a full individual image file (aka singleton, *_flt.fits), or a root name specification
@@ -115,7 +116,11 @@ def check_and_get_data(input_list, **pars):
                     if memname.find('_') != -1:
                         candidate_list.append(memname)
                     else:
-                        candidate_list.append(memname + '_flc.fits')
+                        # Define suffix for all members based on what files are present
+                        if not os.path.exists(memname + member_suffix):
+                            member_suffix = '_flt.fits'
+
+                        candidate_list.append(memname + member_suffix)
             elif suffix in ['flc', 'flt']:
                 if lc_input_item not in candidate_list:
                     candidate_list.append(lc_input_item)
@@ -382,7 +387,7 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
 
             # First ensure sources were found
 
-            if table is None or not table[1]: 
+            if table is None or not table[1]:
                 log.warning("No sources found in image {}".format(imgname))
                 filtered_table[:]['status'] = 1
                 filtered_table[:]['processMsg'] = "No sources found"

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -1,7 +1,10 @@
 """Wrappers for astroquery-related functionality"""
 import shutil
 import os
-from astroquery.mast import Observations
+try:
+    from astroquery.mast import Observations
+except FileExistsError:
+    Observations = None
 
 import sys
 from stsci.tools import logutil
@@ -43,6 +46,10 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
         List of filenames
     """
     local_files = []
+
+    if Observations is None:
+        log.warning("The astroquery package was not found.  No files retrieved!")
+        return local_files
 
     # Query MAST for the data with an observation type of either "science" or
     # "calibration"


### PR DESCRIPTION
Testing under HSTDP 2019.3a uncovered problems with using astroquery in parallel.  These changes recognize that specific exception case and silently trap it while setting up to warn the user if it ever happens interactively. 

The testing of this change also uncovered a limitation in the interpretation of the ASN files; namely, it only looked for _flc.fits files as members.  However, for WFC3/IR data, associations will only ever have _flt.fits files as members, something the original code did not recognize.  This code looks to see what type of file is present if no suffix is specified in the ASN file itself, and set the suffix to be that value.  