### PR TITLE
Allow HLA astrometric code to work with photutils 0.6

### DIFF
--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -428,7 +428,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
             # Define raw data from this slice
             detection_img = img[seg_slice]
             # zero out any pixels which do not have this segments label
-            detection_img[np.where(segm.data[seg_slice] == 0)] = 0
+            detection_img[segm.data[seg_slice] == 0] = 0
 
             # Detect sources in this specific segment
             seg_table = daofind.find_stars(detection_img)

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -424,7 +424,15 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
         # Identify nbrightest/largest sources
         if nlargest is not None:
             nlargest = min(nlargest, len(segm.labels))
-            large_labels = segm.labels[np.flip(np.argsort(segm.areas))[: nlargest]]
+            if LooseVersion(photutils.__version__) >= '0.7':
+                large_labels = segm.labels[
+                    np.flip(np.argsort(segm.areas))[: nlargest]]
+            else:
+                # for photutils < 0.7
+                areas = np.array([area for area in np.bincount(segm.data.ravel())[1:] if area != 0])
+                large_labels = segm.labels[
+                    np.flip(np.argsort(areas))[: nlargest]]
+
         log.info("Looking for sources in {} segments".format(len(segm.labels)))
 
         for segment in segm.segments:

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -408,12 +408,11 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
             # this is the photutils >= 0.7 fast code for removing labels
             segm.check_labels(bad_srcs)
             bad_srcs = np.atleast_1d(bad_srcs)
-            if len(bad_srcs) == 0:
-                return
-            idx = np.zeros(segm.max_label + 1, dtype=int)
-            idx[segm.labels] = segm.labels
-            idx[bad_srcs] = 0
-            segm.data = idx[segm.data]
+            if len(bad_srcs) != 0:
+                idx = np.zeros(segm.max_label + 1, dtype=int)
+                idx[segm.labels] = segm.labels
+                idx[bad_srcs] = 0
+                segm.data = idx[segm.data]
 
     # convert segm to mask for daofind
     if centering_mode == 'starfind':

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -402,7 +402,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
         # Remove likely cosmic-rays based on central_moments classification
         bad_srcs = np.where(classify_sources(cat) == 0)[0] + 1
 
-        if LooseVersion(photutils.__version__) >= 0.7:
+        if LooseVersion(photutils.__version__) >= '0.7':
             segm.remove_labels(bad_srcs)
         else:
             # this is the photutils >= 0.7 fast code for removing labels

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -414,6 +414,10 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
         log.info("Looking for sources in {} segments".format(len(segm.labels)))
 
         for segment in segm.segments:
+            # check needed for photutils <= 0.6; it can be removed when
+            # the drizzlepac depends on photutils >= 0.7
+            if segment is None:
+                continue
             if nlargest is not None and segment.label not in large_labels:
                 continue  # Move on to the next segment
             # Get slice definition for the segment with this label

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -385,6 +385,10 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
     kernel.normalize()
     segm = detect_sources(imgarr, threshold, npixels=source_box,
                           filter_kernel=kernel)
+    if segm is None:
+        log.info("No detected sources!")
+        return None, None
+
     if deblend:
         segm = deblend_sources(imgarr, segm, npixels=5,
                                filter_kernel=kernel, nlevels=16,
@@ -392,10 +396,9 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
     # If classify is turned on, it should modify the segmentation map
     if classify:
         cat = source_properties(imgarr, segm)
-        if len(cat) > 0:
-            # Remove likely cosmic-rays based on central_moments classification
-            bad_srcs = np.where(classify_sources(cat) == 0)[0] + 1
-            segm.remove_labels(bad_srcs)  # CAUTION: May be time-consuming!!!
+        # Remove likely cosmic-rays based on central_moments classification
+        bad_srcs = np.where(classify_sources(cat) == 0)[0] + 1
+        segm.remove_labels(bad_srcs)  # CAUTION: May be time-consuming!!!
 
     # convert segm to mask for daofind
     if centering_mode == 'starfind':

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -387,7 +387,8 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
     kernel.normalize()
     segm = detect_sources(imgarr, threshold, npixels=source_box,
                           filter_kernel=kernel)
-    if segm is None:
+    # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0
+    if segm is None or segm.nlabels == 0:
         log.info("No detected sources!")
         return None, None
 


### PR DESCRIPTION
This PR makes a few changes to allow the HLA astrometric code to work with `photutils 0.6` (latest stable release).  Once `drizzlepac` changes its minimal dependency to `photutils >= 0.7` some of this code can be removed.

CC: @stsci-hack 