### PR TITLE
CRITICAL FIX for WCS update with best solution

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -549,8 +549,7 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
                                         best_fit_qual = fit_quality
                             else:  # new solution has worse fit_quality. discard and continue looping.
                                 continue
-                            # preserve best fit solution so that it can be inserted into a reinitialized imglist next time through.
-                            best_imglist = copy.deepcopy(imglist)
+
                     except Exception:
                         exc_type, exc_value, exc_tb = sys.exc_info()
                         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)


### PR DESCRIPTION
This set of changes fixes a problem identified in the original code where the 'best fit' WCS is NOT being used to update the science data, where instead the last solution was being used.  This fix also removes the check for the ratio of the rms_RA and rms_DEC, since it is no longer needed with this fixing the underlying problem.  

The fix was to eliminate the use of 'best_meta' and replace it with a full copy of the 'best' imglist.

This needs to be included immediately in the pending, being tested, release.