### PR TITLE
Stop overwriting WCSNAME in drz products

### DIFF
--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -697,8 +697,6 @@ def addWCSKeywords(wcs,hdr,blot=False,single=False,after=None):
     """ Update input header 'hdr' with WCS keywords.
     """
     wname = wcs.wcs.name
-    if not single:
-        wname = 'DRZWCS'
 
     # Update WCS Keywords based on PyDrizzle product's value
     # since 'drizzle' itself doesn't update that keyword.


### PR DESCRIPTION
This simple change insures that the WCSNAME header keyword gets populated based on the input WCSNAME values.  It also works in concert with [FITSBLENDER PR 25](https://github.com/spacetelescope/fitsblender/pull/25) to add WCSNAME to the HDRTAB extension of the drz products and has the WCSNAME keyword in the SCI header.