### PR TITLE
Increased search radius for alignment algorithms

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -61,8 +61,10 @@ detector_specific_params = {"acs": {"hrc": {"fwhmpsf": 0.152,  # 0.073
                                               "classify": True,
                                               "threshold": None}}}
 
-SEARCH_RELATIVE = {'radius': 250, 'tolerance': 2.0, 'separation':0.1, 'use2dhist':True}
-SEARCH_2DHIST = {'radius': 250, 'tolerance': 2.0, 'separation':0.1, 'use2dhist':True}
+SEARCH_RELATIVE = {'radius':75, 'blind_radius': 250, 'tolerance': 2.0, 
+                   'separation':0.1, 'use2dhist':True}
+SEARCH_2DHIST = {'radius':75, 'blind_radius': 250, 'tolerance': 2.0, 
+                 'separation':0.1, 'use2dhist':True}
 SEARCH_TOLERANCE = {'radius': 250, 'tolerance': 100.0, 'separation':0.1, 'use2dhist':False}
 
 log = logutil.create_logger('alignimages', level=logutil.logging.INFO, stream=sys.stdout)
@@ -703,10 +705,20 @@ def match_relative_fit(imglist, reference_catalog):
 
     """
     log.info("{} STEP 5b: (match_relative_fit) Cross matching and fitting {}".format("-" * 20, "-" * 27))
+    # Find out what WCS we are starting with...
+    wcsname = imglist[0].wcs.wcs.name
+    # Determine search radius to use based on initial WCS 
+    if '-' in wcsname:
+        # WCS updated with a priori or a posteriori solution
+        radius = SEARCH_RELATIVE['radius']
+    else:
+        # WCS is pipeline default with unknown pedigree, look for larger offsets
+        radius = SEARCH_RELATIVE['blind_radius']
+  
     # 0: Specify matching algorithm to use
-    match = tweakwcs.TPMatch(searchrad=SEARCH_RELATIVE['radius'], 
-                            separation=SEARCH_RELATIVE['separation'],  # 0.1, 
-                             tolerance=SEARCH_RELATIVE['tolerance'],  # 2,
+    match = tweakwcs.TPMatch(searchrad=radius, 
+                            separation=SEARCH_RELATIVE['separation'],
+                             tolerance=SEARCH_RELATIVE['tolerance'],
                              use2dhist=SEARCH_RELATIVE['use2dhist'])
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
     #                          tolerance=100, use2dhist=False)
@@ -787,10 +799,20 @@ def match_2dhist_fit(imglist, reference_catalog):
         List of input image `~tweakwcs.tpwcs.FITSWCS` objects with metadata and source catalogs
 
     """
+    # Find out what WCS we are starting with...
+    wcsname = imglist[0].wcs.wcs.name
+    # Determine search radius to use based on initial WCS 
+    if '-' in wcsname:
+        # WCS updated with a priori or a posteriori solution
+        radius = SEARCH_2DHIST['radius']
+    else:
+        # WCS is pipeline default with unknown pedigree, look for larger offsets
+        radius = SEARCH_2DHIST['blind_radius']
+
     log.info("{} STEP 5b: (match_2dhist_fit) Cross matching and fitting "
              "{}".format("-" * 20, "-" * 28))
     # Specify matching algorithm to use
-    match = tweakwcs.TPMatch(searchrad=SEARCH_2DHIST['radius'],
+    match = tweakwcs.TPMatch(searchrad=radius,
                              separation=SEARCH_2DHIST['separation'],
                              tolerance=SEARCH_2DHIST['tolerance'], 
                              use2dhist=SEARCH_2DHIST['use2dhist'])

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -61,6 +61,10 @@ detector_specific_params = {"acs": {"hrc": {"fwhmpsf": 0.152,  # 0.073
                                               "classify": True,
                                               "threshold": None}}}
 
+SEARCH_RELATIVE = {'radius': 250, 'tolerance': 2.0, 'separation':0.1, 'use2dhist':True}
+SEARCH_2DHIST = {'radius': 250, 'tolerance': 2.0, 'separation':0.1, 'use2dhist':True}
+SEARCH_TOLERANCE = {'radius': 250, 'tolerance': 100.0, 'separation':0.1, 'use2dhist':False}
+
 log = logutil.create_logger('alignimages', level=logutil.logging.INFO, stream=sys.stdout)
 
 __version__ = 0.1
@@ -700,7 +704,10 @@ def match_relative_fit(imglist, reference_catalog):
     """
     log.info("{} STEP 5b: (match_relative_fit) Cross matching and fitting {}".format("-" * 20, "-" * 27))
     # 0: Specify matching algorithm to use
-    match = tweakwcs.TPMatch(searchrad=75, separation=0.1, tolerance=2, use2dhist=True)
+    match = tweakwcs.TPMatch(searchrad=SEARCH_RELATIVE['radius'], 
+                            separation=SEARCH_RELATIVE['separation'],  # 0.1, 
+                             tolerance=SEARCH_RELATIVE['tolerance'],  # 2,
+                             use2dhist=SEARCH_RELATIVE['use2dhist'])
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
     #                          tolerance=100, use2dhist=False)
 
@@ -747,8 +754,10 @@ def match_default_fit(imglist, reference_catalog):
     log.info("{} STEP 5b: (match_default_fit) Cross matching and fitting "
              "{}".format("-" * 20, "-" * 27))
     # Specify matching algorithm to use
-    match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
-                             tolerance=100, use2dhist=False)
+    match = tweakwcs.TPMatch(searchrad=SEARCH_TOLERANCE['radius'], 
+                             separation=SEARCH_TOLERANCE['separation'],
+                             tolerance=SEARCH_TOLERANCE['tolerance'], 
+                             use2dhist=SEARCH_TOLERANCE['use2dhist'])
     # Align images and correct WCS
     tweakwcs.align_wcs(imglist, reference_catalog, match=match, expand_refcat=False)
 
@@ -781,7 +790,10 @@ def match_2dhist_fit(imglist, reference_catalog):
     log.info("{} STEP 5b: (match_2dhist_fit) Cross matching and fitting "
              "{}".format("-" * 20, "-" * 28))
     # Specify matching algorithm to use
-    match = tweakwcs.TPMatch(searchrad=75, separation=0.1, tolerance=2.0, use2dhist=True)
+    match = tweakwcs.TPMatch(searchrad=SEARCH_2DHIST['radius'],
+                             separation=SEARCH_2DHIST['separation'],
+                             tolerance=SEARCH_2DHIST['tolerance'], 
+                             use2dhist=SEARCH_2DHIST['use2dhist'])
     # Align images and correct WCS
     tweakwcs.align_wcs(imglist, reference_catalog, match=match, expand_refcat=False)
 
@@ -896,7 +908,7 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, print_fit
 
         # Execute checks
         nmatches_check = False
-        if num_xmatches > 4:
+        if num_xmatches > 5:
             nmatches_check = True
 
         radial_offset_check = False


### PR DESCRIPTION
A couple of problems arose with trying to align `J8C601040` and any observations like it; namely, the offset was larger than what our search algorithms were set up to find.  However, other problems stem from blindly trying too large of a search radius.  So, this version of the alignment code recognizes both a `blind_radius` as well as a tighter search `radius`.  The 'blind_radius' value will be used with only the default pipeline WCS has been defined, whereas the tighter `radius` will be used when the input WCS has been corrected by either an a priori or a posteriori solution.  The `blind_radius` has been increased to 250, while keeping the tighter 'radius' at 75 pixels as we used before.  

In addition, the parameters used for controlling the search are now dicts at the top of the module to allow for easier management, instead of being 'magic numbers' hard-coded in each function. 