### PR TITLE
Stop on valid relative alignment fit

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -565,7 +565,10 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
                         continue
                     if fit_quality == 1:  # break out of inner  astrometric catalog loop
                         break
-            if fit_quality == 1:  # break out of outer fit algorithm loop
+            # break out of outer fit algorithm loop
+            # either with a fit_rms < 10 or a 'valid' relative fit
+            if fit_quality == 1 or (fit_quality < 5 and
+                "relative" in algorithm_name.__name__):  
                 break
 
         # Reset imglist to point to best solution...


### PR DESCRIPTION
This change to the logic can have a big impact on the fit, as it will cause the code to **immediately stop** trying any additional solutions if a 'valid' relative fit has been determined.  

**We need to test extensively to insure that this will not have unexpected consequences for the solutions which our code can determine.**  