### PR TITLE
Treat too few sources in match as invalid

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -935,7 +935,7 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, print_fit
             fit_status_dict[dict_key]['compromised'] = False
             fit_status_dict[dict_key]['reason'] = "Radial offset value too large!"
         elif not nmatches_check:  # Too few matches
-            fit_status_dict[dict_key]['valid'] = True
+            fit_status_dict[dict_key]['valid'] = False
             fit_status_dict[dict_key]['compromised'] = True
             fit_status_dict[dict_key]['reason'] = "Too few matches!"
         else:  # all checks passed. Valid solution.


### PR DESCRIPTION
Any fit which is based on only 3 matched sources will always come out with an RMS very near zero, yet it may not be correct (due to cross-matching) or the most reliable compared to another fit with many times more matched sources and a still valid RMS.  So, this simple change will instead treat those solutions as completely invalid, until more refined logic can be determined to deal with the situations where another solution has a significant number of matches.

