### PR TITLE
Make skytopix work in Python 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ of the list).
 3.0.2 (unreleased)
 ==================
 
+- Fixed a compatibility issue in ``tweakutils`` that would result in crash in
+  ``skytopix`` when converting coordinates in ``hms`` format. [#385]
+
 - Fixed a bug in the ``astrodrizzle.sky`` module due to which sky matching
   fails with "Keyword 'MDRIZSKY' not found" error when some of the
   input images do not overlap at all with the other images. [#380]

--- a/drizzlepac/tweakutils.py
+++ b/drizzlepac/tweakutils.py
@@ -6,6 +6,7 @@
 """
 import string
 import os
+import sys
 
 import numpy as np
 from scipy import signal, ndimage
@@ -31,6 +32,8 @@ __all__ = [
     'build_xy_zeropoint', 'build_pos_grid'
 ]
 
+_ASCII_LETTERS = string.ascii_letters
+_NASCII = len(string.ascii_letters)
 
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
@@ -231,8 +234,10 @@ def radec_hmstodd(ra, dec):
         astropy.coordinates
 
     """
-    hmstrans = string.maketrans(string.ascii_letters,
-                                ' ' * len(string.ascii_letters))
+    if sys.hexversion >= 196864:
+        hmstrans = str.maketrans(_ASCII_LETTERS, _NASCII * ' ')
+    else:
+        hmstrans = string.maketrans(_ASCII_LETTERS, _NASCII * ' ')
 
     if isinstance(ra, list):
         rastr = ':'.join(ra)


### PR DESCRIPTION
Fixes a compatibility issue with Python 3 when using `drizzlepac.skytopix.rd2xy` with world coordinates in `hms` format. Reported in helpdesk.