### PR TITLE
Update headers to meet CAOM/Archive reqs

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -299,8 +299,6 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
         else:
             log.warning("WARNING: Unable to display Git repository revision information.")
 
-    log.info(input_list)
-
     try:
 
         # 1: Interpret input data and optional parameters
@@ -568,7 +566,7 @@ def run_align(input_list, archive=False, clobber=False, debug=False, update_hdr_
             # break out of outer fit algorithm loop
             # either with a fit_rms < 10 or a 'valid' relative fit
             if fit_quality == 1 or (0 < fit_quality < 5 and
-                "relative" in algorithm_name.__name__):  
+                "relative" in algorithm_name.__name__):
                 break
 
         # Reset imglist to point to best solution...

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -2,6 +2,8 @@
 
 """
 import sys
+import os
+import shutil
 
 import numpy as np
 
@@ -20,6 +22,18 @@ HAPCOLNAME = 'HAPEXPNAME'
 __taskname__ = 'processing_utils'
 
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
+
+def get_rules_file(product):
+    """Copies default HLA rules file to local directory."""
+    hdu, closefits = _process_input(product)
+    phdu = hdu[0].header
+    instrument = phdu['instrume']
+    code_dir = os.path.abspath(__file__)
+    base_dir = os.path.dirname(os.path.dirname(code_dir))
+    rules_name = "{}_header_hla.rules".format(instrument.lower())
+    rules_dir = os.path.join(base_dir, 'pars', rules_name)
+    if rules_name not in os.listdir('.'):
+        shutil.copy(rules_dir, os.getcwd())
 
 def refine_product_headers(product, obs_dict_info, level=None):
     """Refines output product headers to include values not available to AstroDrizzle.

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -96,7 +96,7 @@ def get_acs_filters(image, delimiter=';'):
         if 'clear' not in f.lower():
             acs_filters.append(f)
     if not acs_filters:
-        acs_filters = ['CLEAR']
+        acs_filters = ['clear']
     acs_filters = delimiter.join(acs_filters)
 
     return acs_filters

--- a/drizzlepac/pars/acs_header_hla.rules
+++ b/drizzlepac/pars/acs_header_hla.rules
@@ -342,6 +342,8 @@ WCSCDATE
 WFCMPRSD
 WRTERR
 XTENSION
+WCSNAME
+WCSTYPE
 #
 # WCS Related Keyword Rules
 #     These move any OPUS-generated WCS values to the table

--- a/drizzlepac/pars/wfc3_header_hla.rules
+++ b/drizzlepac/pars/wfc3_header_hla.rules
@@ -325,6 +325,8 @@ WCSAXES
 WCSCDATE
 ZOFFCORR
 ZSIGCORR
+WCSNAME
+WCSTYPE
 ################################################################################
 #
 # Header Keyword Rules REQUIRED for CAOM

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -489,7 +489,7 @@ def update_wcs(image,extnum,new_wcs,wcsname="",reusename=False,verbose=False):
         if verbose:
             log.info('    with WCS of')
             new_wcs.printwcs()
-            print("WCSNAME  : ",wcsname)
+            print("WCSNAME  : ", wcsname)
 
         # Insure that if a copy of the WCS has not been created yet, it will be now
         wcs_hdr = new_wcs.wcs2header(idc2hdr=idchdr, relax=True)
@@ -498,6 +498,8 @@ def update_wcs(image,extnum,new_wcs,wcsname="",reusename=False,verbose=False):
             hdr[key] = wcs_hdr[key]
         hdr['ORIENTAT'] = new_wcs.orientat
         hdr['WCSNAME'] = wcsname
+        wcstype = interpret_wcsname_type(wcsname)
+        hdr['WCSTYPE'] = wcstype
         util.updateNEXTENDKw(fimg)
 
         # Only if this image was opened in update mode should this
@@ -514,11 +516,40 @@ def update_wcs(image,extnum,new_wcs,wcsname="",reusename=False,verbose=False):
             # duplicate WCS with the same WCSNAME as the Primary WCS
             wcsutil.altwcs.archiveWCS(fimg,[extnum],wcsname=wcsname,
                 wcskey=wkey, reusekey=reusename)
+            fimg[extnum].header['WCSTYPE'+wkey] = wcstype
     finally:
         if fimg_open:
             # finish up by closing the file now
             fimg.close()
 
+def interpret_wcsname_type(wcsname):
+    """Interpret WCSNAME as a standardized human-understandable description """
+    wcstype = ''
+    fit_terms = {'REL': 'relatively aligned to {}',
+                 'IMG': 'aligned image-by-image to {}'}
+    post_fit = 'a posteriori solution '
+    default_fit = 'a priori solution based on {}'
+    base_terms = {'IDC': 'distortion-corrected ',
+                  'OPU': 'pipeline default '}
+    no_fit = 'not aligned'
+
+    wcsname_list = wcsname.split('-')
+
+    # Interpret base terms
+    wcstype += base_terms[wcsname_list[0][:3]]
+
+    # Interpret fit term (if any)
+    if len(wcsname_list) == 1:
+        wcstype += no_fit
+    else:
+        fit_term = wcsname_list[1]
+        if 'FIT' not in fit_term:
+            wcstype += default_fit.format(fit_term)
+        else:
+            wcstype += post_fit
+            postfit_type = fit_term.split('_')
+            wcstype += fit_terms[postfit_type[1]].format(postfit_type[2])
+    return wcstype
 
 def create_unique_wcsname(fimg, extnum, wcsname):
     """


### PR DESCRIPTION
Generating the sample datasets for pipeline testing revealed a number of problems with the headers and HDRTAB which prevented them from being ingested into the archive.  

(Most of?) These problems were addressed in this new version of `refine_product_headers`. 