### PR TITLE
Include wsctype in drz product headers

### DIFF
--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -11,18 +11,19 @@ from stsci.tools import fileutil, readgeis, logutil
 
 from . import wcs_functions
 from . import version
+from . import updatehdr
 
 from fitsblender import blendheaders
 
 yes = True
 no = False
 
-RESERVED_KEYS = ['NAXIS','BITPIX','DATE','IRAF-TLM','XTENSION','EXTNAME','EXTVER']
+RESERVED_KEYS = ['NAXIS', 'BITPIX', 'DATE', 'IRAF-TLM', 'XTENSION', 'EXTNAME',' EXTVER']
 
 EXTLIST = ('SCI', 'WHT', 'CTX')
 
-WCS_KEYWORDS=['CD1_1','CD1_2', 'CD2_1', 'CD2_2', 'CRPIX1',
-'CRPIX2','CRVAL1', 'CRVAL2', 'CTYPE1', 'CTYPE2','WCSNAME']
+WCS_KEYWORDS = ['CD1_1', 'CD1_2', 'CD2_1', 'CD2_2', 'CRPIX1',
+'CRPIX2', 'CRVAL1', 'CRVAL2', 'CTYPE1', 'CTYPE2', 'WCSNAME']
 
 # fits.CompImageHDU() crashes with default arguments.
 # Instead check that fits module has *attribute* 'CompImageHDU':
@@ -697,10 +698,12 @@ def addWCSKeywords(wcs,hdr,blot=False,single=False,after=None):
     """ Update input header 'hdr' with WCS keywords.
     """
     wname = wcs.wcs.name
+    wtype = updatehdr.interpret_wcsname_type(wname)
 
     # Update WCS Keywords based on PyDrizzle product's value
     # since 'drizzle' itself doesn't update that keyword.
     hdr['WCSNAME'] = wname
+    hdr['WCSTYPE'] = wtype
     hdr.set('VAFACTOR', value=1.0, after=after)
     hdr.set('ORIENTAT', value=wcs.orientat, after=after)
 

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -478,7 +478,7 @@ def update_wcs(image,extnum,new_wcs,wcsname="",reusename=False,verbose=False):
         idchdr = False
     # Open the file for updating the WCS
     try:
-        logstr = 'Updating header for %s[%s]'%(fimg.filename(),str(extnum))
+        logstr = 'Updating header for %s[%s]' % (fimg.filename(), str(extnum))
         if verbose:
             print(logstr)
         else:
@@ -508,15 +508,15 @@ def update_wcs(image,extnum,new_wcs,wcsname="",reusename=False,verbose=False):
         if fimg_update:
             if not reusename:
                 # Save the newly updated WCS as an alternate WCS as well
-                wkey = wcsutil.altwcs.next_wcskey(fimg,ext=extnum)
+                wkey = wcsutil.altwcs.next_wcskey(fimg, ext=extnum)
             else:
-                wkey = wcsutil.altwcs.getKeyFromName(hdr,wcsname)
+                wkey = wcsutil.altwcs.getKeyFromName(hdr, wcsname)
 
             # wcskey needs to be specified so that archiveWCS will create a
             # duplicate WCS with the same WCSNAME as the Primary WCS
-            wcsutil.altwcs.archiveWCS(fimg,[extnum],wcsname=wcsname,
+            wcsutil.altwcs.archiveWCS(fimg, [extnum], wcsname=wcsname,
                 wcskey=wkey, reusekey=reusename)
-            fimg[extnum].header['WCSTYPE'+wkey] = wcstype
+            fimg[extnum].header['WCSTYPE' + wkey] = wcstype
     finally:
         if fimg_open:
             # finish up by closing the file now


### PR DESCRIPTION
The WCSTYPE keyword was added to the HDRTAB table in #390, however, additional changes needed to be made to get the keyword added to the DRZ/DRC product science headers.  