### PR TITLE
Add PA_V3 to ACS HAP rules to insure consistency for HAP products

### DIFF
--- a/drizzlepac/pars/acs_header_hla.rules
+++ b/drizzlepac/pars/acs_header_hla.rules
@@ -417,6 +417,7 @@ SNRMAX    SNRMAX    max
 SNRMEAN   SNRMEAN   mean
 SNRMIN    SNRMIN    min
 TELESCOP  TELESCOP  first
+PA_V3     PA_V3     first
 ### rules below were added 05Jun2012,in response to Dorothy Fraquelli guidance re: DADS
 ATODCORR  ATODCORR  multi
 ATODGNA   ATODGNA   first


### PR DESCRIPTION
This change insures that all HAP products include the PA_V3 keyword in the header of the products. 