### PR TITLE
Move keywords in HAP products to be consistent

### DIFF
--- a/drizzlepac/pars/acs_header_hla.rules
+++ b/drizzlepac/pars/acs_header_hla.rules
@@ -394,6 +394,8 @@ IMAGETYP  IMAGETYP  first
 OBSMODE   OBSMODE   multi
 OBSTYPE   OBSTYPE   first
 EQUINOX   EQUINOX   first
+REFFRAME  REFFRAME  multi
+MTFLAG    MTFLAG    first
 ################################################################################
 #
 # Header Keyword Rules for remaining keywords


### PR DESCRIPTION
These changes move keywords around to insure they are always in the same extension regardless of instrument or detector.  This includes updating the rules to make sure a couple of keywords are kept in the product header that were originally missing (for ACS, that is).  

The HAPEXPNAME value was also updated to report the 'exposure name' instead of the full filename, upon request of the archive and CAOM.  