### PR TITLE
Enforce pixtopix verbose setting when not run as a script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ of the list).
   ``pixtopix.tran()`` function. [#406]
 
 - Modified the behavior of the ``verbose`` parameter in ``pixtopix.tran()``
-  to not print coordinates when not run as a script when ``output``
+  to not print coordinates when not run as a script and when ``output``
   is `None`. [#406]
 
 - Fixed a compatibility issue in ``tweakutils`` that would result in crash in

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,13 @@ of the list).
 3.0.2 (unreleased)
 ==================
 
+- Removed deprecated parameter ``coords`` from the parameter list of
+  ``pixtopix.tran()`` function. [#406]
+
+- Modified the behavior of the ``verbose`` parameter in ``pixtopix.tran()``
+  to not print coordinates when not run as a script when ``output``
+  is `None`. [#406]
+
 - Fixed a compatibility issue in ``tweakutils`` that would result in crash in
   ``skytopix`` when converting coordinates in ``hms`` format. [#385]
 

--- a/drizzlepac/pixtopix.help
+++ b/drizzlepac/pixtopix.help
@@ -1,4 +1,4 @@
-`pixtopix` transforms pixel positions given as X,Y values into
+``pixtopix`` transforms pixel positions given as X,Y values into
 positions in another WCS frame based on the WCS information and any
 recognized distortion keywords from the input image header.
 

--- a/drizzlepac/pixtopix.py
+++ b/drizzlepac/pixtopix.py
@@ -1,4 +1,4 @@
-""" pixtosky - A module to perform coordinate transformation from pixel
+""" pixtopix - A module to perform coordinate transformation from pixel
     coordinates in one image to pixel coordinates in another frame
 
     :Authors: Warren Hack

--- a/drizzlepac/pixtopix.py
+++ b/drizzlepac/pixtopix.py
@@ -240,8 +240,6 @@ def help(file=None):
         print(helpstr)
 
     else:
-        if os.path.exists(file):
-            os.remove(file)
         with open(file, mode='w') as f:
             f.write(helpstr)
 

--- a/drizzlepac/pixtopix.py
+++ b/drizzlepac/pixtopix.py
@@ -1,5 +1,5 @@
-""" pixtosky - A module to perform coordinate transformation from pixel coordinates
-                in one image to pixel coordinates in another frame
+""" pixtosky - A module to perform coordinate transformation from pixel
+    coordinates in one image to pixel coordinates in another frame
 
     :Authors: Warren Hack
 
@@ -8,20 +8,21 @@
     PARAMETERS
     ----------
     inimage : str
-        full filename with path of input image, an extension name ['sci',1] should be
-        provided if input is a multi-extension FITS file
+        full filename with path of input image, an extension name ``['sci',1]``
+        should be provided if input is a multi-extension FITS file.
+
     outimage : str, optional
-        full filename with path of output image, an extension name ['sci',1] should be
-        provided if output is a multi-extension FITS file. If no image gets
-        specified, the input image will be used to generate a default output
-        WCS using stwcs.distortion.util.output_wcs().
+        full filename with path of output image, an extension name ``['sci',1]``
+        should be provided if output is a multi-extension FITS file.
+        If no image gets  specified, the input image will be used to generate a
+        default output WCS using ``stwcs.distortion.util.output_wcs()``.
+
     direction : str
         Direction of transform (forward or backward). The 'forward' transform
-        takes the pixel positions (assumed to be from the 'input' image) and determines
-        their position in the 'output' image. The 'backward' transform converts
-        the pixel positions (assumed to be from the 'output' image) into pixel
-        positions in the 'input' image.
-
+        takes the pixel positions (assumed to be from the 'input' image) and
+        determines their position in the 'output' image. The 'backward'
+        transform converts the pixel positions (assumed to be from the
+        'output' image) into pixel positions in the 'input' image.
 
     Optional Parameters
     -------------------
@@ -29,10 +30,6 @@
         X position from image
     y : float, optional
         Y position from image
-    coords : str, deprecated
-        [DEPRECATED] full filename with path of file with x,y coordinates
-        Filename given here will be *ignored* if a file has been specified
-        in `coordfile` parameter.
     coordfile : str, optional
         full filename with path of file with starting x,y coordinates
     colnames : str, optional
@@ -75,77 +72,55 @@
     EXAMPLES
     --------
 
-    1. The following command will transform the position 256,256 from
+    1.  The following command will transform the position 256,256 from
         'input_flt.fits[sci,1]' into a position on the output image
         'output_drz.fits[sci,1]' using::
 
-            >>> from drizzlepac import pixtopix
-            >>> outx,outy = pixtopix.tran("input_file_flt.fits[sci,1]",
-                        "output_drz.fits[sci,1],"forward", 256,256)
+        >>> from drizzlepac import pixtopix
+        >>> outx,outy = pixtopix.tran("input_file_flt.fits[sci,1]",
+                    "output_drz.fits[sci,1],"forward", 256,256)
 
 
-    2. The set of X,Y positions from 'output_drz.fits[sci,1]' stored as
+    2.  The set of X,Y positions from 'output_drz.fits[sci,1]' stored as
         the 3rd and 4th columns from the ASCII file 'xy_sci1.dat'
         will be transformed into pixel positions from 'input_flt.fits[sci,1]'
         and written out to 'xy_flt1.dat' using::
 
-            >>> from drizzlepac import pixtopix
-            >>> x,y = pixtopix.tran("input_flt.fits[sci,1]", "output_drz.fits[sci,1]",
-                    "backward", coordfile='xy_sci1.dat', colnames=['c3','c4'],
-                    output="xy_flt1.dat")
+        >>> from drizzlepac import pixtopix
+        >>> x,y = pixtopix.tran("input_flt.fits[sci,1]", "output_drz.fits[sci,1]",
+                "backward", coordfile='xy_sci1.dat', colnames=['c3','c4'],
+                output="xy_flt1.dat")
 
 """
-import os,copy
-import warnings
+import os
 import numpy as np
 
 from stsci.tools import fileutil, teal
+from stwcs import wcsutil, distortion
 from . import wcs_functions
 from . import util
-from stwcs import wcsutil, distortion
 
 # This is specifically NOT intended to match the package-wide version information.
-__version__ = '0.1'
-__version_date__ = '1-Mar-2011'
+__version__ = '0.2'
+__version_date__ = '19-Mar-2019'
 
 __taskname__ = 'pixtopix'
 
-def tran(inimage,outimage,direction='forward',x=None,y=None,
-        coords=None, coordfile=None,colnames=None,separator=None,
-        precision=6, output=None,verbose=True):
+
+def tran(inimage, outimage, direction='forward', x=None, y=None,
+         coordfile=None, colnames=None, separator=None,
+         precision=6, output=None, verbose=True):
     """ Primary interface to perform coordinate transformations in pixel
         coordinates between 2 images using STWCS and full distortion models
         read from each image's header.
     """
     single_coord = False
 
-    # Only use value provided in `coords` if nothing has been specified for coordfile
-    if coords is not None and coordfile is None:
-        coordfile = coords
-        warnings.simplefilter('always',DeprecationWarning)
-        warnings.warn("Please update calling code to pass in `coordfile` instead of `coords`.",
-            category=DeprecationWarning)
-        warnings.simplefilter('default',DeprecationWarning)
-
-    if coordfile is not None:
-        if colnames in util.blank_list:
-            colnames = ['c1','c2']
-        # Determine columns which contain pixel positions
-        cols = util.parse_colnames(colnames,coordfile)
-        # read in columns from input coordinates file
-        xyvals = np.loadtxt(coordfile,usecols=cols,delimiter=separator)
-        if xyvals.ndim == 1: # only 1 entry in coordfile
-            xlist = [xyvals[0].copy()]
-            ylist = [xyvals[1].copy()]
-        else:
-            xlist = xyvals[:,0].copy()
-            ylist = xyvals[:,1].copy()
-        del xyvals
-    else:
-        if isinstance(x,np.ndarray):
+    if coordfile is None:
+        if isinstance(x, np.ndarray):
             xlist = x.tolist()
             ylist = y.tolist()
-        elif not isinstance(x,list):
+        elif not isinstance(x, list):
             xlist = [x]
             ylist = [y]
             single_coord = True
@@ -153,88 +128,99 @@ def tran(inimage,outimage,direction='forward',x=None,y=None,
             xlist = x
             ylist = y
 
+    else:
+        if colnames in util.blank_list:
+            colnames = ['c1', 'c2']
+
+        # Determine columns which contain pixel positions
+        cols = util.parse_colnames(colnames, coordfile)
+        # read in columns from input coordinates file
+        xyvals = np.loadtxt(coordfile, usecols=cols, delimiter=separator)
+
+        if xyvals.ndim == 1:  # only 1 entry in coordfile
+            xlist = [xyvals[0].copy()]
+            ylist = [xyvals[1].copy()]
+        else:
+            xlist = xyvals[:, 0].copy()
+            ylist = xyvals[:, 1].copy()
+
     # start by reading in WCS+distortion info for each image
     im1wcs = wcsutil.HSTWCS(inimage)
     if im1wcs.wcs.is_unity():
-        print("####\nNo valid input WCS found in {}.\n  Results may be invalid.\n####\n".format(inimage))
+        print("####\nNo valid input WCS found in '{}'."
+              "\n  Results may be invalid.\n####\n".format(inimage))
 
     if util.is_blank(outimage):
-        fname,fextn = fileutil.parseFilename(inimage)
+        fname, fextn = fileutil.parseFilename(inimage)
         numsci = fileutil.countExtn(fname)
-        chips = []
-        for e in range(1,numsci+1):
-            chips.append(wcsutil.HSTWCS(fname,ext=('sci',e)))
+        chips = [wcsutil.HSTWCS(fname, ext=('sci', e + 1)) for e in range(numsci)]
         if len(chips) == 0:
             chips = [im1wcs]
         im2wcs = distortion.utils.output_wcs(chips)
+
     else:
         im2wcs = wcsutil.HSTWCS(outimage)
 
     if im2wcs.wcs.is_unity():
-        print("####\nNo valid output WCS found in {}.\n  Results may be invalid.\n####\n".format(outimage))
+        print("####\nNo valid output WCS found in '{}'."
+              "\n  Results may be invalid.\n####\n".format(outimage))
 
     # Setup the transformation
-    p2p = wcs_functions.WCSMap(im1wcs,im2wcs)
+    p2p = wcs_functions.WCSMap(im1wcs, im2wcs)
 
     if direction[0].lower() == 'f':
-        outx,outy = p2p.forward(xlist,ylist)
+        outx, outy = p2p.forward(xlist, ylist)
     else:
-        outx,outy = p2p.backward(xlist,ylist)
+        outx, outy = p2p.backward(xlist, ylist)
 
-    if isinstance(outx,np.ndarray):
+    if isinstance(outx, np.ndarray):
         outx = outx.tolist()
         outy = outy.tolist()
 
     # add formatting based on precision here...
     xstr = []
     ystr = []
-    fmt = "%."+repr(precision)+"f"
-    for ox,oy in zip(outx,outy):
-        xstr.append(fmt%ox)
-        ystr.append(fmt%oy)
+    for ox, oy in zip(outx, outy):
+        xstr.append('{0:.{1}f}'.format(ox, precision))
+        ystr.append('{0:.{1}f}'.format(oy, precision))
 
-    if verbose or (not verbose and util.is_blank(output)):
-        print('# Coordinate transformations for ',inimage)
+    if verbose:
+        print('# Coordinate transformations for ', inimage)
         print('# X(in)      Y(in)             X(out)         Y(out)\n')
-        for xs,ys,a,b in zip(xlist,ylist,xstr,ystr):
-            print("%.4f  %.4f    %s  %s"%(xs,ys,a,b))
+        for xs, ys, a, b in zip(xlist, ylist, xstr, ystr):
+            print("%.4f  %.4f    %s  %s" % (xs, ys, a, b))
 
     # Create output file, if specified
     if output:
-        f = open(output,mode='w')
-        f.write("# Coordinates converted from %s\n"%inimage)
-        for xs,ys in zip(xstr,ystr):
-            f.write('%s    %s\n'%(xs,ys))
-        f.close()
-        print('Wrote out results to: ',output)
+        with open(output, mode='w') as f:
+            f.write("# Coordinates converted from %s\n" % inimage)
+            for xs, ys in zip(xstr, ystr):
+                f.write('%s    %s\n' % (xs, ys))
+        print('Wrote out results to: ', output)
 
     if single_coord:
         outx = outx[0]
         outy = outy[0]
-    return outx,outy
+
+    return outx, outy
 
 
-#--------------------------
+# --------------------------
 # TEAL Interface functions
-#--------------------------
+# --------------------------
 def run(configObj):
-
-    if 'coords' in configObj:
-        coords = util.check_blank(configObj['coords'])
-    else:
-        coords = None
-
     coordfile = util.check_blank(configObj['coordfile'])
     colnames = util.check_blank(configObj['colnames'])
     sep = util.check_blank(configObj['separator'])
     outfile = util.check_blank(configObj['output'])
-
     outimage = util.check_blank(configObj['outimage'])
-    tran(configObj['inimage'], outimage,direction=configObj['direction'],
-            x = configObj['x'], y = configObj['y'], coords=coords,
-            coordfile = coordfile, colnames = colnames,
-            separator= sep, precision= configObj['precision'],
-            output= outfile, verbose = configObj['verbose'])
+
+    verbose = configObj['verbose'] or outfile is None
+
+    tran(configObj['inimage'], outimage, direction=configObj['direction'],
+         x=configObj['x'], y=configObj['y'], coordfile=coordfile,
+         colnames=colnames, separator=sep, precision=configObj['precision'],
+         output=outfile, verbose=configObj['verbose'])
 
 
 def help(file=None):
@@ -249,17 +235,18 @@ def help(file=None):
         writing out the help.
 
     """
-    helpstr = getHelpAsString(docstring=True, show_ver = True)
+    helpstr = getHelpAsString(docstring=True, show_ver=True)
     if file is None:
         print(helpstr)
+
     else:
-        if os.path.exists(file): os.remove(file)
-        f = open(file, mode = 'w')
-        f.write(helpstr)
-        f.close()
+        if os.path.exists(file):
+            os.remove(file)
+        with open(file, mode='w') as f:
+            f.write(helpstr)
 
 
-def getHelpAsString(docstring = False, show_ver = True):
+def getHelpAsString(docstring=False, show_ver=True):
     """
     return useful help from a file in the script directory called
     __taskname__.help
@@ -272,19 +259,20 @@ def getHelpAsString(docstring = False, show_ver = True):
 
     if docstring or (not docstring and not os.path.exists(htmlfile)):
         if show_ver:
-            helpString = os.linesep + \
-                ' '.join([__taskname__, 'Version', __version__,
-                ' updated on ', __version_date__]) + 2*os.linesep
+            helpString = '\n' + ' '.join(
+                [__taskname__, 'Version', __version__,
+                 ' updated on ', __version_date__]) + '\n\n'
         else:
             helpString = ''
         if os.path.exists(helpfile):
             helpString += teal.getHelpFileAsString(taskname, __file__)
         else:
             if __doc__ is not None:
-                helpString += __doc__ + os.linesep
+                helpString += __doc__ + '\n'
     else:
         helpString = 'file://' + htmlfile
 
     return helpString
 
-__doc__ = getHelpAsString(docstring = True, show_ver = False)
+
+__doc__ = getHelpAsString(docstring=True, show_ver=False)

--- a/drizzlepac/pixtosky.help
+++ b/drizzlepac/pixtosky.help
@@ -22,22 +22,17 @@ Optional Parameters
     y : float, optional
         Y position from input image
 
-    coords : str, deprecated
-        [DEPRECATED] full filename with path of file with x,y coordinates
-        Filename given here will be *ignored* if a file has been specified
-        in `coordfile` parameter.
-
     coordfile : str, optional
-        full filename with path of file with x,y coordinates
+        full filename with path of file with x, y coordinates
 
     colnames : str, optional
-        comma separated list of column names from 'coords' files
-        containing x,y coordinates, respectively. Will default to
+        comma separated list of column names from 'coordfile' file
+        containing x, y coordinates. Will default to
         first two columns if None are specified. Column names for ASCII
         files will use 'c1','c2',... convention.
 
     separator : str, optional
-        non-blank separator used as the column delimiter in the coords file
+        non-blank separator used as the column delimiter in the ``coordfile``
 
     hms : bool, optional  (Default: False)
         Produce output in ``HH:MM:SS.S`` format instead of decimal

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -77,7 +77,7 @@ def get_pool_size(usr_config_value, num_tasks):
 
 
 DEFAULT_LOGNAME = 'astrodrizzle.log'
-blank_list = [None, '', ' ',"None","INDEF"]
+blank_list = [None, '', ' ', 'None', 'INDEF']
 
 def is_blank(val):
     """ Determines whether or not a value is considered 'blank'.
@@ -85,11 +85,8 @@ def is_blank(val):
     return val in blank_list
 
 def check_blank(cvar):
-    """ Converts blank value (from configObj?) into a value of None.
-    """
-    if cvar in blank_list: val = None
-    else: val = cvar
-    return val
+    """ Converts blank value (from configObj?) into a value of None. """
+    return None if cvar in blank_list else cvar
 
 #
 # Logging routines


### PR DESCRIPTION
This PR fixes the behavior of `verbose` parameter to actually work as expected when `pixtopix` is not run as a script. In addition it also removes the `coords` parameter that has been deprecated for years. It is time to remove it.