### PR TITLE
[WIP] Add functionality for auto-determining kernel for source finding

### DIFF
--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -35,7 +35,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits as fits
 from astropy.io import ascii
 from astropy.convolution import Gaussian2DKernel
-from astropy.stats import gaussian_fwhm_to_sigma
+from astropy.stats import gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm
 from astropy.nddata.bitmask import bitfield_to_boolean_mask
 from astropy.visualization import SqrtStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
@@ -490,10 +490,16 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
 
     # convert segm to mask for daofind
     if centering_mode == 'starfind':
+
+        # Extract the average sigma for detected sources
+        source_table = cat.to_table()
+        smajor_sigma = source_table['semimajor_axis_sigma'].mean().value
+        source_fwhm = smajor_sigma * gaussian_sigma_to_fwhm
+
         src_table = None
         # daofind = IRAFStarFinder(fwhm=fwhm, threshold=5.*bkg.background_rms_median)
         log.info("Setting up DAOStarFinder with: \n    fwhm={}  threshold={}".format(fwhm, bkg_rms_mean))
-        daofind = DAOStarFinder(fwhm=fwhm, threshold=bkg_rms_mean)
+        daofind = DAOStarFinder(fwhm=source_fwhm, threshold=bkg_rms_mean)
 
         # Identify nbrightest/largest sources
         if nlargest is not None:

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -291,8 +291,77 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
 
     return delta_ra, delta_dec
 
+def build_auto_kernel(imgarr, fwhm=3.0, threshold=None, source_box=7,
+                      isolation_size=50, saturation_limit=70000.):
+    """Build kernel for use in source detection based on image PSF
+
+    This algorithm looks for an isolated point-source that is non-saturated to use as a template
+    for the source detection kernel.  Failing to find any suitable sources, it will return a
+    Gaussian2DKernel based on the provided FWHM as a default.
+
+    Parameters
+    ----------
+    imgarr : ndarray
+        Image array (ndarray object) with sources to be identified
+    fwhm : float
+        Value of FWHM to use for creating a Gaussian2DKernel object in case no suitable source
+        can be identified in the image.
+    threshold : float
+        Value from the image which serves as the limit for determining sources.
+        If None, compute a default value of (background+5*rms(background)).
+        If threshold < 0.0, use absolute value as scaling factor for default value.
+    source_box : int
+        Size of box (in pixels) which defines the minimum size of a valid source.
+    isolation_size : int
+        Separation (in pixels) to use to identify sources that are isolated from any other sources
+        in the image.
+    saturation_limit : float
+        Flux in the image that represents the onset of saturation for a pixel.
+
+    Notes
+    ------
+    Ideally, it would be best to determine the saturation_limit value from the data itself,
+    perhaps by looking at the pixels flagged (in the DQ array) as saturated and selecting
+    the value less than the minimum flux of all those pixels, or maximum pixel value in the
+    image if non-were flagged as saturated (in the DQ array).
+    """
+
+    # Try to use PSF derived from image as detection kernel
+    # Kernel must be derived from well-isolated sources not near the edge of the image
+    kern_img = imgarr.copy()
+    edge = source_box * 2
+    kern_img[:edge, :] = 0.0
+    kern_img[-edge:, :] = 0.0
+    kern_img[:, :edge] = 0.0
+    kern_img[:, -edge:] = 0.0
+    peaks = photutils.detection.find_peaks(kern_img, threshold=threshold, box_size=isolation_size)
+    if len(peaks['peak_value'][peaks['peak_value'] > saturation_limit]):
+        # Make sure only peaks less than saturation limit are evaluated
+        peaks['peak_value'][peaks['peak_value'] >= saturation_limit] = 0.
+    # Sort based on peak_value to identify brightest sources for use as a kernel
+    peaks.sort('peak_value')
+
+    # Identify position of brightest, non-saturated peak (in numpy index order)
+    kernel_pos = [peaks['y_peak'][-1], peaks['x_peak'][-1]]
+    kernel = imgarr[kernel_pos[0] - source_box:kernel_pos[0] + source_box + 1,
+                    kernel_pos[1] - source_box:kernel_pos[1] + source_box + 1]
+    log.info("kernel[{},{}]".format(kernel_pos[1], kernel_pos[0]))
+    peaks['x_peak'] += 1
+    peaks['y_peak'] += 1
+
+    # Normalize the new kernel to a total flux of 1.0
+    if kernel.sum() > 0.0:
+        kernel /= kernel.sum()
+    else:
+        # Generate a default kernel using a simple 2D Gaussian
+        sigma = fwhm * gaussian_fwhm_to_sigma
+        kernel = Gaussian2DKernel(sigma, x_size=source_box, y_size=source_box)
+        kernel.normalize()
+
+    return kernel
 
 def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
+                    isolation_size=50, saturation_limit=70000.,
                     classify=True, centering_mode="starfind", nlargest=None,
                     outroot=None, plot=False, vmax=None, deblend=False):
     """Use photutils to find sources in image based on segmentation.
@@ -337,6 +406,11 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
     deblend : bool, optional
         Specify whether or not to apply photutils deblending algorithm when
         evaluating each of the identified segments (sources) from the chip.
+    isolation_size : int
+        Separation (in pixels) to use to identify sources that are isolated from any other sources
+        in the image.
+    saturation_limit : float
+        Flux in the image that represents the onset of saturation for a pixel.
     """
     # apply any provided dqmask for segmentation only
     if dqmask is not None:
@@ -382,9 +456,9 @@ def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
         bkg_rms_mean = max(0.01, imgarr.min())
         bkg_rms = bkg_rms_mean * 5
 
-    sigma = fwhm * gaussian_fwhm_to_sigma
-    kernel = Gaussian2DKernel(sigma, x_size=source_box, y_size=source_box)
-    kernel.normalize()
+    kernel = build_auto_kernel(imgarr, source_box=source_box, threshold=threshold, fwhm=fwhm,
+                                isolation_size=isolation_size, saturation_limit=saturation_limit)
+
     segm = detect_sources(imgarr, threshold, npixels=source_box,
                           filter_kernel=kernel)
     # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0


### PR DESCRIPTION
Basic implementation of an algorithm which attempts to define the source finding kernel using the sources it finds in the image.  This initial attempt has not been optimized or made robust against some error conditions.  However, it should work for any type of image from any detector and provide a reasonable kernel that can be used to more accurately identify sources in that image while taking into account exposure-specific changes to the PSF due to breathing, focus changes, guiding errors, and so on.
For safety, should no suitable PSF be identified, it will provide the same default Gaussian2DKernel that has been used so far. 