### PR TITLE
Adding cmd line interface to runhlaprocessing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,8 @@ setup(
             'mdriz=drizzlepac.mdriz:main',
             'resetbits=drizzlepac.resetbits:main',
             'updatenpol=drizzlepac.updatenpol:main',
-            'runastrodriz=drizzlepac.runastrodriz:main'
+            'runastrodriz=drizzlepac.runastrodriz:main',
+            'runhap=drizzlepac.runhlaprocessing:main'
         ],
     },
     ext_modules=[


### PR DESCRIPTION
This change automatically installs a command-line interface to 'runhlaprocessing.main()' in the same manner as done for 'runastrodriz'.  The interface is required for pipeline use.