### PR TITLE
Point-source source identification upgrade

### DIFF
--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -292,7 +292,7 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
     return delta_ra, delta_dec
 
 
-def build_auto_kernel(imgarr, fwhm=3.0, threshold=None, source_box=7,
+def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
                       isolation_size=50, saturation_limit=70000.):
     """Build kernel for use in source detection based on image PSF
     This algorithm looks for an isolated point-source that is non-saturated to use as a template
@@ -341,9 +341,20 @@ def build_auto_kernel(imgarr, fwhm=3.0, threshold=None, source_box=7,
 
     # Identify position of brightest, non-saturated peak (in numpy index order)
     kernel_pos = [peaks['y_peak'][-1], peaks['x_peak'][-1]]
+    
     kernel = imgarr[kernel_pos[0] - source_box:kernel_pos[0] + source_box + 1,
                     kernel_pos[1] - source_box:kernel_pos[1] + source_box + 1]
+    kernel_wht = whtarr[kernel_pos[0] - source_box:kernel_pos[0] + 5 + 1,
+                    kernel_pos[1] - source_box:kernel_pos[1] + 5 + 1]
+    # TODO: check in kernel_wht for any zero-value pixels with np.where(kernel_wht ==0.). If found, go to the previous item in peaks, and so on until a source with now wht array zero value is found.
     log.info("kernel[{},{}]".format(kernel_pos[1], kernel_pos[0]))
+    import matplotlib.pyplot as plt
+    import pdb
+    plt.imshow(kernel_wht)
+    plt.show()
+    pdb.set_trace()
+
+
     peaks['x_peak'] += 1
     peaks['y_peak'] += 1
 

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -292,6 +292,74 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
     return delta_ra, delta_dec
 
 
+def build_auto_kernel(imgarr, fwhm=3.0, threshold=None, source_box=7,
+                      isolation_size=50, saturation_limit=70000.):
+    """Build kernel for use in source detection based on image PSF
+    This algorithm looks for an isolated point-source that is non-saturated to use as a template
+    for the source detection kernel.  Failing to find any suitable sources, it will return a
+    Gaussian2DKernel based on the provided FWHM as a default.
+    Parameters
+    ----------
+    imgarr : ndarray
+        Image array (ndarray object) with sources to be identified
+    fwhm : float
+        Value of FWHM to use for creating a Gaussian2DKernel object in case no suitable source
+        can be identified in the image.
+    threshold : float
+        Value from the image which serves as the limit for determining sources.
+        If None, compute a default value of (background+5*rms(background)).
+        If threshold < 0.0, use absolute value as scaling factor for default value.
+    source_box : int
+        Size of box (in pixels) which defines the minimum size of a valid source.
+    isolation_size : int
+        Separation (in pixels) to use to identify sources that are isolated from any other sources
+        in the image.
+    saturation_limit : float
+        Flux in the image that represents the onset of saturation for a pixel.
+    Notes
+    ------
+    Ideally, it would be best to determine the saturation_limit value from the data itself,
+    perhaps by looking at the pixels flagged (in the DQ array) as saturated and selecting
+    the value less than the minimum flux of all those pixels, or maximum pixel value in the
+    image if non-were flagged as saturated (in the DQ array).
+    """
+
+    # Try to use PSF derived from image as detection kernel
+    # Kernel must be derived from well-isolated sources not near the edge of the image
+    kern_img = imgarr.copy()
+    edge = source_box * 2
+    kern_img[:edge, :] = 0.0
+    kern_img[-edge:, :] = 0.0
+    kern_img[:, :edge] = 0.0
+    kern_img[:, -edge:] = 0.0
+    peaks = photutils.detection.find_peaks(kern_img, threshold=threshold, box_size=isolation_size)
+    if len(peaks['peak_value'][peaks['peak_value'] > saturation_limit]):
+        # Make sure only peaks less than saturation limit are evaluated
+        peaks['peak_value'][peaks['peak_value'] >= saturation_limit] = 0.
+    # Sort based on peak_value to identify brightest sources for use as a kernel
+    peaks.sort('peak_value')
+
+    # Identify position of brightest, non-saturated peak (in numpy index order)
+    kernel_pos = [peaks['y_peak'][-1], peaks['x_peak'][-1]]
+    kernel = imgarr[kernel_pos[0] - source_box:kernel_pos[0] + source_box + 1,
+                    kernel_pos[1] - source_box:kernel_pos[1] + source_box + 1]
+    log.info("kernel[{},{}]".format(kernel_pos[1], kernel_pos[0]))
+    peaks['x_peak'] += 1
+    peaks['y_peak'] += 1
+
+    # Normalize the new kernel to a total flux of 1.0
+    if kernel.sum() > 0.0:
+        kernel /= kernel.sum()
+    else:
+        # Generate a default kernel using a simple 2D Gaussian
+        sigma = fwhm * gaussian_fwhm_to_sigma
+        kernel = Gaussian2DKernel(sigma, x_size=source_box, y_size=source_box)
+        kernel.normalize()
+
+    return kernel
+
+
+
 def extract_sources(img, dqmask=None, fwhm=3.0, threshold=None, source_box=7,
                     classify=True, centering_mode="starfind", nlargest=None,
                     outroot=None, plot=False, vmax=None, deblend=False):

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -354,7 +354,7 @@ def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
         # search square cut-out (of size 2 x wht_box + 1 pixels on a side) of weight image centered on peak coords for
         # zero-value pixels. Reject peak if any are found.
         if len(np.where(kernel_wht == 0.)[0]) == 0:
-            log.info("kernel[{},{}]".format(kernel_pos[1], kernel_pos[0]))
+            log.info("Kernel source PSF located at [{},{}]".format(kernel_pos[1], kernel_pos[0]))
             break
         else:
             kernel[:] = 0.0 # reset kernel values to zero each time to guard against case where all peaks are saturated.

--- a/drizzlepac/hlautils/run_sourcelist_generation.py
+++ b/drizzlepac/hlautils/run_sourcelist_generation.py
@@ -33,28 +33,18 @@ print("\n"*25)
 print("Current path: ",os.getcwd())
 confirm_execution()
 try:
-    # cmd = "rm -f *.*"
-    # print(cmd)
-    # os.system(cmd)
-    #
-    # cmd = "cp sl_gen_orig2/* ."
-    # print(cmd)
-    # os.system(cmd)
+    cmd = "rm -f *.*"
+    print(cmd)
+    os.system(cmd)
+
+    cmd = "cp sl_gen_orig/* ."
+    print(cmd)
+    os.system(cmd)
 
     pickle_in = open(sys.argv[1], "rb")
     [obs_info_dict,param_dict] = pickle.load(pickle_in)
     pickle_in.close()
 
-    #copy Warren's custom-created f606W and total drizzle images in for testing!
-    # cmdlist = ["cp -f artif_orig/hst_10265_01_acs_wfc_f606w_j92c01_drc.fits ."]
-    # cmdlist.append("cp -f artif_orig/hst_10265_01_acs_wfc_total_j92c01_drc.fits .")
-    # for cmd in cmdlist:
-    #     print(cmd)
-    #     os.system(cmd)
-
-    param_dict["ACS WFC"]["sourcex"]["fwhm"] = 0.13
-    param_dict["ACS WFC"]["sourcex"]["source_box"] = 5
-    param_dict["ACS WFC"]["sourcex"]["thresh"] = None
     sourcelist_generation.run_create_sourcelists(obs_info_dict,param_dict)
 except Exception:
     print("\a\a\a")

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -64,14 +64,7 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
     log.info("bkg sigma: {}".format(bkg_sigma))
 
     pd_fwhm = param_dict['dao']['TWEAK_FWHMPSF']/param_dict['astrodrizzle']['SCALE']
-    pd_thresh = param_dict['dao']['TWEAK_THRESHOLD']*bkg_sigma
     calc_thresh = bkgsig_sf * bkg_sigma
-
-    log.info("param_dict fwhm: {}".format(pd_fwhm))
-    log.info("calculated fwhm: {}\n".format("3.5"))
-    log.info("param_dict_thresh: {}".format(pd_thresh))
-    log.info("calculated thresh: {}".format(bkgsig_sf * bkg_sigma))
-
 
     # Estimate FWHM from image sources
     kernel = astrometric_utils.build_auto_kernel(image, wht_image, threshold=calc_thresh, fwhm=pd_fwhm)

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -111,7 +111,7 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
 
     # Estimate FWHM from image sources
     kernel = astrometric_utils.build_auto_kernel(image, wht_image, threshold=bkg_rms, fwhm=pd_fwhm)
-    segm = detect_sources(image, bkg_rms, npixels=param_dict["sourcex"]["source_box"], filter_kernel=kernel)
+    segm = detect_sources(image, calc_thresh, npixels=param_dict["sourcex"]["source_box"], filter_kernel=kernel)
     cat = source_properties(image, segm)
     bad_srcs = np.where(astrometric_utils.classify_sources(cat) == 0)[0] + 1
     segm.remove_labels(bad_srcs)

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -57,6 +57,7 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
     """
     hdulist = fits.open(fitsfile)
     image = hdulist['SCI'].data
+    wht_image = hdulist['WHT'].data
     image -= np.nanmedian(image)
     bkg_sigma = mad_std(image, ignore_nan=True)
     log.info("bkg sigma: {}".format(bkg_sigma))
@@ -72,7 +73,7 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
 
 
 
-    kernel = astrometric_utils.build_auto_kernel(image, threshold=calc_thresh, fwhm=pd_fwhm,saturation_limit=60000.)
+    kernel = astrometric_utils.build_auto_kernel(image, wht_image, threshold=calc_thresh, fwhm=pd_fwhm)
     segm = detect_sources(image, calc_thresh, npixels=param_dict["sourcex"]["source_box"], filter_kernel=kernel)
     cat = source_properties(image, segm)
     bad_srcs = np.where(astrometric_utils.classify_sources(cat) == 0)[0] + 1

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -64,7 +64,14 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
     log.info("bkg sigma: {}".format(bkg_sigma))
 
     pd_fwhm = param_dict['dao']['TWEAK_FWHMPSF']/param_dict['astrodrizzle']['SCALE']
+    pd_thresh = param_dict['dao']['TWEAK_THRESHOLD']*bkg_sigma
     calc_thresh = bkgsig_sf * bkg_sigma
+
+    log.info("param_dict fwhm: {}".format(pd_fwhm))
+    log.info("calculated fwhm: {}\n".format("3.5"))
+    log.info("param_dict_thresh: {}".format(pd_thresh))
+    log.info("calculated thresh: {}".format(bkgsig_sf * bkg_sigma))
+
 
     # Estimate FWHM from image sources
     kernel = astrometric_utils.build_auto_kernel(image, wht_image, threshold=calc_thresh, fwhm=pd_fwhm)

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -64,12 +64,10 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
     log.info("bkg sigma: {}".format(bkg_sigma))
 
     pd_fwhm = param_dict['dao']['TWEAK_FWHMPSF']/param_dict['astrodrizzle']['SCALE']
-    pd_thresh = param_dict['dao']['TWEAK_THRESHOLD']*bkg_sigma
     calc_thresh = bkgsig_sf * bkg_sigma
 
     log.info("param_dict fwhm: {}".format(pd_fwhm))
     log.info("calculated fwhm: {}\n".format("3.5"))
-    log.info("param_dict_thresh: {}".format(pd_thresh))
     log.info("calculated thresh: {}".format(bkgsig_sf * bkg_sigma))
 
 

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -63,12 +63,12 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
     #daofind = DAOStarFinder(fwhm=dao_fwhm, threshold=bkgsig_sf * bkg_sigma)
     pd_fwhm = param_dict['dao']['TWEAK_FWHMPSF']/param_dict['astrodrizzle']['SCALE']
     pd_thresh = param_dict['dao']['TWEAK_THRESHOLD']*bkg_sigma
-    pd_thresh = 0.05
+    calc_thresh = bkgsig_sf * bkg_sigma
     log.info("param_dict fwhm: {}".format(pd_fwhm))
     log.info("calculated fwhm: {}\n".format("3.5"))
     log.info("param_dict_thresh: {}".format(pd_thresh))
     log.info("calculated thresh: {}".format(bkgsig_sf * bkg_sigma))
-    daofind = DAOStarFinder(fwhm=pd_fwhm, threshold=pd_thresh, ratio=0.8)
+    daofind = DAOStarFinder(fwhm=pd_fwhm, threshold=calc_thresh, ratio=0.8)
     sources = daofind(image)
     hdulist.close()
 

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -114,9 +114,6 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
     kernel = astrometric_utils.build_auto_kernel(image, wht_image, threshold=bkg_rms, fwhm=default_fwhm)
     segm = detect_sources(image, detect_sources_thresh, npixels=param_dict["sourcex"]["source_box"], filter_kernel=kernel)
     cat = source_properties(image, segm)
-    bad_srcs = np.where(astrometric_utils.classify_sources(cat) == 0)[0] + 1
-    segm.remove_labels(bad_srcs)
-
     source_table = cat.to_table()
     smajor_sigma = source_table['semimajor_axis_sigma'].mean().value
     source_fwhm = smajor_sigma * gaussian_sigma_to_fwhm

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -111,7 +111,7 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,param_dict,make_regi
 
     # Estimate FWHM from image sources
     kernel = astrometric_utils.build_auto_kernel(image, wht_image, threshold=bkg_rms, fwhm=pd_fwhm)
-    segm = detect_sources(image, calc_thresh, npixels=param_dict["sourcex"]["source_box"], filter_kernel=kernel)
+    segm = detect_sources(image, bkg_rms, npixels=param_dict["sourcex"]["source_box"], filter_kernel=kernel)
     cat = source_properties(image, segm)
     bad_srcs = np.where(astrometric_utils.classify_sources(cat) == 0)[0] + 1
     segm.remove_labels(bad_srcs)

--- a/drizzlepac/runhlaprocessing.py
+++ b/drizzlepac/runhlaprocessing.py
@@ -123,7 +123,7 @@ param_dict = {
             "ci_seupper_limit": 1.23},
         "dao": {
             "TWEAK_FWHMPSF": 0.076,
-            "TWEAK_THRESHOLD": None,
+            "TWEAK_THRESHOLD": 3.0,
             "aperture_1": 0.05,  # update from 0.15
             "aperture_2": 0.15,  # update from 0.25
             "bthresh": 5.0},

--- a/drizzlepac/runhlaprocessing.py
+++ b/drizzlepac/runhlaprocessing.py
@@ -123,7 +123,7 @@ param_dict = {
             "ci_seupper_limit": 1.23},
         "dao": {
             "TWEAK_FWHMPSF": 0.076,
-            "TWEAK_THRESHOLD": 3.0,
+            "TWEAK_THRESHOLD": None,
             "aperture_1": 0.05,  # update from 0.15
             "aperture_2": 0.15,  # update from 0.25
             "bthresh": 5.0},


### PR DESCRIPTION
* Added code to better estimate an overall FWHM value based on PSFs of image sources
* Added code to better estimate DAOstarfinder input "threshold" value. 
* Upgraded code seems to preform much better than before, yielding much more sensible results for noisier images (ACS 10595_06) while still still generating sourcelists that are in line with what was previously produced for cleaner images (ACS 1065_01)