### PR TITLE
Ignore Emacs temp file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage.xml
 .DS_Store
 *.egg-info
 *.swp
+*~


### PR DESCRIPTION
Emacs generate temp file in the format of `*~`.