### PR TITLE
Update real product headers for CAOM compatibility

### DIFF
--- a/drizzlepac/runhlaprocessing.py
+++ b/drizzlepac/runhlaprocessing.py
@@ -453,7 +453,7 @@ def run_astrodrizzle(obs_info_dict):
                                           runfile=trlname,
                                           configobj='{}{}astrodrizzle_single_hap.cfg'.format(cfgfile_path, os.path.sep))
                 # Rename Astrodrizzle log file as a trailer file
-                shutil.move(trlname, trlname.replace('.log','.txt'))
+                shutil.move(trlname, trlname.replace('.log', '.txt'))
 
         # 4 Create total image using the temp ref image as astrodrizzle param 'final_refimage'
         log.info("~" * 118)
@@ -461,8 +461,8 @@ def run_astrodrizzle(obs_info_dict):
         total_combined_image = obs_info_dict[tdp_keyname]['product filenames']['image']
         product_list.append(total_combined_image)
         adriz_in_list = obs_info_dict[tdp_keyname]['files']
-        trlname = '_'.join(total_combined_image.split('_')[:-1]+['trl.log'])
-        log.info("Total combined image..... {} {}".format(total_combined_image,adriz_in_list))
+        trlname = '_'.join(total_combined_image.split('_')[:-1] + ['trl.log'])
+        log.info("Total combined image..... {} {}".format(total_combined_image, adriz_in_list))
         astrodrizzle.AstroDrizzle(input=adriz_in_list, output=total_combined_image,
                                   final_refimage=ref_total_combined_image,
                                   final_outnx=total_shape[1],
@@ -470,7 +470,7 @@ def run_astrodrizzle(obs_info_dict):
                                   runfile=trlname,
                                   configobj='{}{}astrodrizzle_total_hap.cfg'.format(cfgfile_path, os.path.sep))
         # Rename Astrodrizzle log file as a trailer file
-        shutil.move(trlname, trlname.replace('.log','.txt'))
+        shutil.move(trlname, trlname.replace('.log', '.txt'))
 
         # 5: remove reference total temp file
         log.info("Removed temp ref file {}".format(ref_total_combined_image))
@@ -479,7 +479,9 @@ def run_astrodrizzle(obs_info_dict):
     # 6: Ensure that all drizzled products is have headers that are to spec.
     # drcfiles = sorted(glob.glob('*drc.fits'))
     # for d in drcfiles:
+    log.info("Updating these drizzle products for CAOM compatibility:")
     for d in product_list:
+        log.info("    {}".format(d))
         dpu.refine_product_headers(d, obs_info_dict)
 
     # 7: remove rules files copied to the CWD in step #0

--- a/drizzlepac/runhlaprocessing.py
+++ b/drizzlepac/runhlaprocessing.py
@@ -414,12 +414,14 @@ def run_astrodrizzle(obs_info_dict):
         rtci = fits.open(ref_total_combined_image)
         total_shape = rtci[('sci',1)].data.shape
         rtci.close()
+        product_list = []
 
         for fp_keyname in obs_info_dict[tdp_keyname]['associated filter products']:
             # 2: Create drizzle-combined filter image using the temp ref image as astrodrizzle param 'final_refimage'
             log.info("~" * 118)
             log.info("CREATE DRIZZLE-COMBINED FILTER IMAGE\n")
             filter_combined_imagename = obs_info_dict[fp_keyname]['product filenames']['image']
+            product_list.append(filter_combined_imagename)
             adriz_in_list = obs_info_dict[fp_keyname]['files']
             trlname = '_'.join(filter_combined_imagename.split('_')[:-1]+['trl.log'])
             print("FILTER PRODUCT trailer file: {}".format(trlname))
@@ -439,6 +441,7 @@ def run_astrodrizzle(obs_info_dict):
                 log.info("~" * 118)
                 log.info("CREATE SINGLY DRIZZLED IMAGE")
                 single_drizzled_filename = obs_info_dict[fp_keyname][sp_name]["image"]
+                product_list.append(single_drizzled_filename)
                 imgname_root = single_drizzled_filename.split("_")[-2]
                 trlname = '_'.join(single_drizzled_filename.split('_')[:-1]+['trl.log'])
                 adriz_in_file = [i for i in obs_info_dict[fp_keyname]['files'] if i.startswith(imgname_root)][0]
@@ -456,10 +459,11 @@ def run_astrodrizzle(obs_info_dict):
         log.info("~" * 118)
         log.info("CREATE TOTAL DRIZZLE-COMBINED IMAGE\n")
         total_combined_image = obs_info_dict[tdp_keyname]['product filenames']['image']
+        product_list.append(total_combined_image)
         adriz_in_list = obs_info_dict[tdp_keyname]['files']
         trlname = '_'.join(total_combined_image.split('_')[:-1]+['trl.log'])
         log.info("Total combined image..... {} {}".format(total_combined_image,adriz_in_list))
-        astrodrizzle.AstroDrizzle(input=adriz_in_list,output=total_combined_image,
+        astrodrizzle.AstroDrizzle(input=adriz_in_list, output=total_combined_image,
                                   final_refimage=ref_total_combined_image,
                                   final_outnx=total_shape[1],
                                   final_outny=total_shape[0],
@@ -473,8 +477,9 @@ def run_astrodrizzle(obs_info_dict):
         os.remove(ref_total_combined_image)
 
     # 6: Ensure that all drizzled products is have headers that are to spec.
-    drcfiles = sorted(glob.glob('*drc.fits'))
-    for d in drcfiles:
+    # drcfiles = sorted(glob.glob('*drc.fits'))
+    # for d in drcfiles:
+    for d in product_list:
         dpu.refine_product_headers(d, obs_info_dict)
 
     # 7: remove rules files copied to the CWD in step #0


### PR DESCRIPTION
The code originally looked for all DRC files to update with the CAOM columns necessary for linking the products with the inputs.  This resulted in real problems under a couple of different processing scenarios: inputs were FLT files and generated DRZ not DRC files and (as noted pipeline use by Lisa S. during testing) there may be DRC files in the current directory which are not part of this visit. 

The changes here keep track of only those products generated during the processing of the input visit (or set of exposures) and only update those specific drizzle products.  This should make the code compatible with pipeline processing or any other processing where multiple datasets are located in the same current working directory regardless of the suffix used for the products (DRZ vs DRC).   
