### PR TITLE
Correct singleton CTE processing in runastrodriz

### DIFF
--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -112,12 +112,7 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
             # Identify what sub-directory was created by astroquery for the
             # download
             if download_dir is None:
-                new_file_path = os.path.dirname(os.path.abspath(file))
-                file_path = file.split(os.sep)
-                log.info("Defining download directory based on: {} or [new]{}".format(file_path, new_file_path))
-                if '.' in file_path:
-                    file_path.remove('.')
-                download_dir = file_path[0]
+                download_dir = os.path.dirname(os.path.abspath(file))
             # Move or copy downloaded file to current directory
             local_file = os.path.abspath(os.path.basename(file))
             if archive:

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -112,7 +112,7 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
             # Identify what sub-directory was created by astroquery for the
             # download
             if download_dir is None:
-                new_file_path = os.path.dirname(file)
+                new_file_path = os.path.dirname(os.path.abspath(file))
                 file_path = file.split(os.sep)
                 log.info("Defining download directory based on: {} or [new]{}".format(file_path, new_file_path))
                 if '.' in file_path:

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -114,7 +114,7 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
             if download_dir is None:
                 new_file_path = os.path.dirname(file)
                 file_path = file.split(os.sep)
-                print("Defining download directory based on: {} or [new]{}".format(file_path, new_file_path))
+                log.info("Defining download directory based on: {} or [new]{}".format(file_path, new_file_path))
                 if '.' in file_path:
                     file_path.remove('.')
                 download_dir = file_path[0]

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -113,7 +113,8 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
             # download
             if download_dir is None:
                 file_path = file.split(os.sep)
-                file_path.remove('.')
+                if '.' in file_path:
+                    file_path.remove('.')
                 download_dir = file_path[0]
             # Move or copy downloaded file to current directory
             local_file = os.path.abspath(os.path.basename(file))

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -112,7 +112,9 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
             # Identify what sub-directory was created by astroquery for the
             # download
             if download_dir is None:
+                new_file_path = os.path.dirname(file)
                 file_path = file.split(os.sep)
+                print("Defining download directory based on: {} or [new]{}".format(file_path, new_file_path))
                 if '.' in file_path:
                     file_path.remove('.')
                 download_dir = file_path[0]

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -366,7 +366,7 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
 
             # Write the perform_align log to the trailer file...(this will delete the _alignlog)
             shutil.copy(_alignlog, _alignlog_copy)
-            _appendTrlFile(_trlfile, _alignlog)
+            _appendTrlFile(_trlfile, _alignlog_copy)
 
             # Append messages from this calling routine post-perform_align
             ftmp = open(_tmptrl, 'w')

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -275,6 +275,7 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
     _drizfile = _trlroot + '_pydriz'
     _drizlog = _drizfile + ".log"  # the '.log' gets added automatically by astrodrizzle
     _alignlog = _trlroot + '_align.log'
+    _alignlog_copy = _alignlog.replace('.log', '_copy.log')
     if dcorr == 'PERFORM':
         if '_asn.fits' not in inFilename:
             # Working with a singleton
@@ -364,8 +365,7 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
                 _trlmsg += "   No correction to absolute astrometric frame applied!\n"
 
             # Write the perform_align log to the trailer file...(this will delete the _alignlog)
-            # Start by disabling the alignimages logger...
-            logging.getLogger('alignimages').disable = True
+            shutil.copy(_alignlog, _alignlog_copy)
             _appendTrlFile(_trlfile, _alignlog)
 
             # Append messages from this calling routine post-perform_align
@@ -513,6 +513,11 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
         ftrl = open(_trlfile, 'a')
         ftrl.write(hlet_msg)
         ftrl.close()
+
+    # Remove secondary log files for good...
+    logging.shutdown()
+    if os.path.exists(_alignlog):
+        os.remove(_alignlog)
 
     # If processing was done in a temp working dir, restore results to original
     # processing directory, return to original working dir and remove temp dir

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -328,6 +328,9 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
         if _calfiles_flc:
             updatewcs.updatewcs(_calfiles_flc)
         print("WCSNAME[FLT]: {}   WCSNAME[FLC]: {}".format(fits.getval(_calfiles[0], 'wcsname', ext=1), fits.getval(_calfiles_flc[0], 'wcsname', ext=1)))
+        print("FLT: {}".format(fits.info(_calfiles[0])))
+        print("ENV[step_control]: {}".format(os.environ['ASTROMETRY_STEP_CONTROL']))
+        print("ENV[a_priori]: {}".format(os.environ['ASTROMETRY_APPLY_APRIORI']))
 
         if align_to_gaia:
             # Perform additional alignment on the FLC files, if present

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -75,6 +75,7 @@ import os
 import shutil
 import sys
 import time
+import logging
 
 # THIRD-PARTY
 from astropy.io import fits
@@ -363,6 +364,8 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
                 _trlmsg += "   No correction to absolute astrometric frame applied!\n"
 
             # Write the perform_align log to the trailer file...(this will delete the _alignlog)
+            # Start by disabling the alignimages logger...
+            logging.getLogger('alignimages').disable = True
             _appendTrlFile(_trlfile, _alignlog)
 
             # Append messages from this calling routine post-perform_align

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -435,7 +435,8 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
 
             # Now, append comments created by PyDrizzle to CALXXX trailer file
             print('Updating trailer file %s with astrodrizzle comments.' % _trlfile)
-            _drizlog_copy = _drizlog.replac('.log', '_copy.log')
+            _drizlog_copy = _drizlog.replace('.log', '_copy.log')
+            shutil.copy(_drizlog, _drizlog_copy)
             _appendTrlFile(_trlfile, _drizlog_copy)
 
         # Save this for when astropy.io.fits can modify a file 'in-place'

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -435,7 +435,8 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
 
             # Now, append comments created by PyDrizzle to CALXXX trailer file
             print('Updating trailer file %s with astrodrizzle comments.' % _trlfile)
-            _appendTrlFile(_trlfile, _drizlog)
+            _drizlog_copy = _drizlog.replac('.log', '_copy.log')
+            _appendTrlFile(_trlfile, _drizlog_copy)
 
         # Save this for when astropy.io.fits can modify a file 'in-place'
         # Update calibration switch
@@ -516,8 +517,9 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
 
     # Remove secondary log files for good...
     logging.shutdown()
-    if os.path.exists(_alignlog):
-        os.remove(_alignlog)
+    for _olog in [_alignlog, _drizlog]:
+        if os.path.exists(_olog):
+            os.remove(_olog)
 
     # If processing was done in a temp working dir, restore results to original
     # processing directory, return to original working dir and remove temp dir

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -331,6 +331,8 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
         print("FLT: {}".format(fits.info(_calfiles[0])))
         print("ENV[step_control]: {}".format(os.environ['ASTROMETRY_STEP_CONTROL']))
         print("ENV[a_priori]: {}".format(os.environ['ASTROMETRY_APPLY_APRIORI']))
+        import stwcs
+        print("STWCS: {}".format(stwcs.__version__))
 
         if align_to_gaia:
             # Perform additional alignment on the FLC files, if present

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -327,6 +327,7 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
         updatewcs.updatewcs(_calfiles)
         if _calfiles_flc:
             updatewcs.updatewcs(_calfiles_flc)
+        print("WCSNAME[FLT]: {}   WCSNAME[FLC]: {}".format(fits.getval(_calfiles[0], 'wcsname', ext=1), fits.getval(_calfiles_flc[0], 'wcsname', ext=1)))
 
         if align_to_gaia:
             # Perform additional alignment on the FLC files, if present

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -327,12 +327,6 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
         updatewcs.updatewcs(_calfiles)
         if _calfiles_flc:
             updatewcs.updatewcs(_calfiles_flc)
-        print("WCSNAME[FLT]: {}   WCSNAME[FLC]: {}".format(fits.getval(_calfiles[0], 'wcsname', ext=1), fits.getval(_calfiles_flc[0], 'wcsname', ext=1)))
-        print("FLT: {}".format(fits.info(_calfiles[0])))
-        print("ENV[step_control]: {}".format(os.environ['ASTROMETRY_STEP_CONTROL']))
-        print("ENV[a_priori]: {}".format(os.environ['ASTROMETRY_APPLY_APRIORI']))
-        import stwcs
-        print("STWCS: {}".format(stwcs.__version__))
 
         if align_to_gaia:
             # Perform additional alignment on the FLC files, if present

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -287,7 +287,7 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
 
             # Add CTE corrected filename as additional input if present
             if os.path.exists(_infile_flc) and _infile_flc != _infile:
-                _inlist.append(_infile_flc)
+                _calfiles_flc = [_infile_flc]
 
         else:
             # Working with an ASN table...
@@ -305,10 +305,14 @@ def process(inFile, force=False, newpath=None, inmemory=False, num_cores=None,
             _cal_prodname = inFilename
             _new_asn.extend(_inlist)  # kept so we can delete it when finished
 
-        # check to see whether FLC files are also present, and need to be updated
-        # generate list of FLC files
+            # check to see whether FLC files are also present, and need to be updated
+            # generate list of FLC files
+            _calfiles_flc = [f.replace('_flt.fits', '_flc.fits')
+                             for f in _calfiles
+                             if os.path.exists(f.replace('_flt.fits', '_flc.fits'))]
+
         align_files = None
-        _calfiles_flc = [f.replace('_flt.fits', '_flc.fits') for f in _calfiles]
+
         # insure these files exist, if not, blank them out
         # Also pick out what files will be used for additional alignment to GAIA
         if not os.path.exists(_calfiles_flc[0]):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
-git+https://github.com/spacetelescope/stwcs.git@e1da1f11736b2507afd92cf045eedba717d9e820#egg=stwcs
 git+https://github.com/astropy/photutils.git@cc9bb4534ab76bac98cb5f374a348a2573d10401#egg=photutils
 git+https://github.com/spacetelescope/stsci.tools@9a022503ad24ca54ce83331482dfa3ff6de9f403#egg=stsci.tools

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         'stsci.imagestats',
         'stsci.skypac',
         'stsci.stimage',
-        'stwcs',
+        'stwcs>=1.5.1',
         'tweakwcs>=0.5.0',
         'stregion',
         'requests',

--- a/tests/hla/test_pipeline.py
+++ b/tests/hla/test_pipeline.py
@@ -4,37 +4,147 @@
 import os
 import pytest
 
+from astropy.utils.data import conf
+
+from ci_watson.artifactory_helpers import get_bigdata
+from ci_watson.hst_helpers import download_crds, ref_from_image
+
 from drizzlepac.hlautils import astroquery_utils as aqutils
 from drizzlepac import runastrodriz
 from astropy.io import fits
 
 
+class BasePipeline:
+    prevdir = os.getcwd()
+    use_ftp_crds = True
+    timeout = 30  # seconds
+    tree = ''
 
-def test_astrometric_singleton():
-    """ Tests pipeline-style processing of a singleton exposure using runastrodriz.
-    """
-    dataset_names = ['iaaua1n4q']
-    # Get sample data through astroquery
-    flcfile = aqutils.retrieve_observation(dataset_names, suffix=['FLC'])[0]
-    fltfile = aqutils.retrieve_observation(dataset_names, suffix=['FLT'])[0]
-    rawfile = aqutils.retrieve_observation(dataset_names, suffix=['RAW'])[0]
+    # Numpy default for allclose comparison
+    rtol = 1e-6
+    atol = 1e-5
 
-    # Insure environment variables are set for full processing
-    os.environ['ASTROMETRY_STEP_CONTROL'] = 'on'
-    os.environ['ASTROMETRY_COMPUTE_APOSTERIORI'] = 'on'
-    os.environ['ASTROMETRY_APPLY_APRIORI'] = 'on'
+    # To be defined by instrument
+    refstr = ''
+    prevref = ''
+    input_loc = ''
+    ref_loc = ''
+    ignore_keywords = []
 
-    # Run pipeline processing using
-    runastrodriz.process(rawfile, force=True, inmemory=True)
+    # To be defined by individual test
+    subdir = ''
 
-    # compare WCSNAMEs from flt and flc files
-    flc_wcsname = fits.getval(flcfile, 'wcsname', ext=1)
-    flt_wcsname = fits.getval(fltfile, 'wcsname', ext=1)
+    @pytest.fixture(autouse=True)
+    def setup_class(self, tmpdir, envopt, pytestconfig):
+        """
+        Run test in own dir so we can keep results separate from
+        other tests.
+        """
+        if not tmpdir.ensure(self.subdir, dir=True):
+            p = tmpdir.mkdir(self.subdir).strpath
+        else:
+            p = tmpdir.join(self.subdir).strpath
+        os.chdir(p)
 
-    # Perform comparisons:
-    #   - WCSNAME values should contain '-' from either a priori or a posteriori solution
-    #   - WCSNAME value should be the same for FLT and FLC images
-    assert('-' in flc_wcsname)
-    assert('-' in flt_wcsname)
-    assert(flc_wcsname == flt_wcsname)
-    
+        # NOTE: This could be explicitly controlled using pytest fixture
+        #       but too many ways to do the same thing would be confusing.
+        #       Refine this logic if using pytest fixture.
+        # HSTCAL cannot open remote CRDS on FTP but central storage is okay.
+        # So use central storage if available to avoid FTP.
+        if self.prevref is None or self.prevref.startswith(('ftp', 'http')):
+            os.environ[self.refstr] = p + os.sep
+            self.use_ftp_crds = True
+        os.environ['TEST_BIGDATA'] = p
+
+        # This controls astropy.io.fits timeout
+        conf.remote_timeout = self.timeout
+
+        # Update tree to point to correct environment
+        self.tree = envopt
+
+        # Collect pytest configuration values specified in setup.cfg or pytest.ini
+        self.inputs_root = pytestconfig.getini('inputs_root')[0]
+        self.results_root = pytestconfig.getini('results_root')[0]
+
+    def teardown_class(self):
+        """Reset path and variables."""
+        conf.reset('remote_timeout')
+        os.chdir(self.prevdir)
+        if self.use_ftp_crds and self.prevref is not None:
+            os.environ[self.refstr] = self.prevref
+
+    def get_data(self, *args, docopy=True):
+        """
+        Download `filename` into working directory using
+        `get_bigdata`.  This will then return the full path to
+        the local copy of the file.
+        """
+        local_file = get_bigdata(*args, docopy=docopy)
+
+        return local_file
+
+    def get_input_file(self, *args, refsep='$', docopy=True):
+        """
+        Download or copy input file (e.g., RAW) into the working directory.
+        The associated CRDS reference files in ``refstr`` are also
+        downloaded, if necessary.
+        """
+        filename = self.get_data(*args, docopy=docopy)
+        ref_files = ref_from_image(filename, ['IDCTAB', 'OFFTAB', 'NPOLFILE', 'D2IMFILE', 'DGEOFILE'])
+        print("Looking for REF_FILES: {}".format(ref_files))
+
+        for ref_file in ref_files:
+            if ref_file.strip() == '':
+                continue
+            if refsep not in ref_file:  # Local file
+                refname = self.get_data('customRef', ref_file)
+            else:  # Download from FTP, if applicable
+                refname = os.path.join(ref_file)
+                if self.use_ftp_crds:
+                    download_crds(refname, self.timeout)
+        return filename
+
+
+class BaseWFC3Pipeline(BasePipeline):
+    refstr = 'iref'
+    input_loc = ''
+    ref_loc = 'wfc3/ref'
+    prevref = os.environ.get(refstr)
+    ignore_keywords = ['origin', 'filename', 'date', 'iraf-tlm', 'fitsdate',
+                       'upwtim', 'wcscdate', 'upwcsver', 'pywcsver',
+                       'history', 'prod_ver', 'rulefile']
+
+
+
+class TestSingleton(BaseWFC3Pipeline):
+
+    def test_astrometric_singleton(self):
+        """ Tests pipeline-style processing of a singleton exposure using runastrodriz.
+        """
+        dataset_names = ['iaaua1n4q']
+        # Get sample data through astroquery
+        flcfile = aqutils.retrieve_observation(dataset_names, suffix=['FLC'])[0]
+        fltfile = aqutils.retrieve_observation(dataset_names, suffix=['FLT'])[0]
+        rawfile = aqutils.retrieve_observation(dataset_names, suffix=['RAW'])[0]
+
+        # Retrieve reference files for these as well
+        self.get_input_file('', fltfile, docopy=False)
+
+        # Insure environment variables are set for full processing
+        os.environ['ASTROMETRY_STEP_CONTROL'] = 'on'
+        os.environ['ASTROMETRY_COMPUTE_APOSTERIORI'] = 'on'
+        os.environ['ASTROMETRY_APPLY_APRIORI'] = 'on'
+
+        # Run pipeline processing using
+        runastrodriz.process(rawfile, force=True, inmemory=True)
+
+        # compare WCSNAMEs from flt and flc files
+        flc_wcsname = fits.getval(flcfile, 'wcsname', ext=1)
+        flt_wcsname = fits.getval(fltfile, 'wcsname', ext=1)
+
+        # Perform comparisons:
+        #   - WCSNAME values should contain '-' from either a priori or a posteriori solution
+        #   - WCSNAME value should be the same for FLT and FLC images
+        assert('-' in flc_wcsname)
+        assert('-' in flt_wcsname)
+        assert(flc_wcsname == flt_wcsname)

--- a/tests/hla/test_pipeline.py
+++ b/tests/hla/test_pipeline.py
@@ -1,0 +1,40 @@
+""" This module tests full pipeline use of the drizzlepac package.
+
+"""
+import os
+import pytest
+
+from drizzlepac.hlautils import astroquery_utils as aqutils
+from drizzlepac import runastrodriz
+from astropy.io import fits
+
+
+
+def test_astrometric_singleton():
+    """ Tests pipeline-style processing of a singleton exposure using runastrodriz.
+    """
+    dataset_names = ['iaaua1n4q']
+    # Get sample data through astroquery
+    flcfile = aqutils.retrieve_observation(dataset_names, suffix=['FLC'])[0]
+    fltfile = aqutils.retrieve_observation(dataset_names, suffix=['FLT'])[0]
+    rawfile = aqutils.retrieve_observation(dataset_names, suffix=['RAW'])[0]
+
+    # Insure environment variables are set for full processing
+    os.environ['ASTROMETRY_STEP_CONTROL'] = 'on'
+    os.environ['ASTROMETRY_COMPUTE_APOSTERIORI'] = 'on'
+    os.environ['ASTROMETRY_APPLY_APRIORI'] = 'on'
+
+    # Run pipeline processing using
+    runastrodriz.process(rawfile, force=True, inmemory=True)
+
+    # compare WCSNAMEs from flt and flc files
+    flc_wcsname = fits.getval(flcfile, 'wcsname', ext=1)
+    flt_wcsname = fits.getval(fltfile, 'wcsname', ext=1)
+
+    # Perform comparisons:
+    #   - WCSNAME values should contain '-' from either a priori or a posteriori solution
+    #   - WCSNAME value should be the same for FLT and FLC images
+    assert('-' in flc_wcsname)
+    assert('-' in flt_wcsname)
+    assert(flc_wcsname == flt_wcsname)
+    

--- a/tests/hla/test_pipeline.py
+++ b/tests/hla/test_pipeline.py
@@ -90,7 +90,8 @@ class BasePipeline:
         downloaded, if necessary.
         """
         filename = self.get_data(*args, docopy=docopy)
-        ref_files = ref_from_image(filename, ['IDCTAB', 'OFFTAB', 'NPOLFILE', 'D2IMFILE', 'DGEOFILE'])
+        ref_files = ref_from_image(filename, ['IDCTAB', 'OFFTAB', 'NPOLFILE', 'D2IMFILE',
+                                              'DGEOFILE', 'MDRIZTAB'])
         print("Looking for REF_FILES: {}".format(ref_files))
 
         for ref_file in ref_files:


### PR DESCRIPTION
Pipeline testing under HSTDP 2019.3b uncovered problems with how singleton observations which are CTE-corrected are processed that resulted in FLC and FLT versions of the calibrated data having different WCSs.  
The base cause for this came down to how runastrodriz tried to include the FLC file for processing for singletons, then subsequently added another list that also included the FLC filename for additional processing.  Combined with STWCS v1.5.1, this resulted in the FLC file WCS getting reset by stwcs.updatewcs while the FLT image did not.  

The changes here will resolve this (long-standing hidden) problem with runastrodriz, while also adding a fast, simple regression test to insure it is fixed and that it stays fixed. 