### PR TITLE
Support user-defined WCSNAME values

### DIFF
--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -543,10 +543,10 @@ def interpret_wcsname_type(wcsname):
     wcstype += base_terms[wcsname_term]
 
     # Interpret fit term (if any)
+    fit_term = wcsname_list[1] if len(wcsname_list) > 1 else None
     if len(wcsname_list) == 1 or fit_term not in fit_terms:
         wcstype += no_fit
     else:
-        fit_term = wcsname_list[1]
         if 'FIT' not in fit_term:
             wcstype += default_fit.format(fit_term)
         else:

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -534,15 +534,19 @@ def interpret_wcsname_type(wcsname):
     no_fit = 'not aligned'
 
     wcsname_list = wcsname.split('-')
+    wcsname_term = wcsname_list[0][:3]
+    if wcsname_term not in base_terms:
+        wcstype = 'user-defined'  # Set to user-defined default
+        return wcstype
 
     # Interpret base terms
-    wcstype += base_terms[wcsname_list[0][:3]]
+    wcstype += base_terms[wcsname_term]
 
     # Interpret fit term (if any)
-    if len(wcsname_list) == 1:
+    fit_term = wcsname_list[1]
+    if len(wcsname_list) == 1 or fit_term not in fit_terms:
         wcstype += no_fit
     else:
-        fit_term = wcsname_list[1]
         if 'FIT' not in fit_term:
             wcstype += default_fit.format(fit_term)
         else:

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -543,10 +543,10 @@ def interpret_wcsname_type(wcsname):
     wcstype += base_terms[wcsname_term]
 
     # Interpret fit term (if any)
-    fit_term = wcsname_list[1]
     if len(wcsname_list) == 1 or fit_term not in fit_terms:
         wcstype += no_fit
     else:
+        fit_term = wcsname_list[1]
         if 'FIT' not in fit_term:
             wcstype += default_fit.format(fit_term)
         else:

--- a/tests/hla/test_apriori.py
+++ b/tests/hla/test_apriori.py
@@ -90,7 +90,7 @@ def compare_apriori(dataset):
 
     assert success
 
-    
+
 class TestAcsApriori(BaseACS):
     """ Tests which validate whether mosaics can be aligned to an astrometric standard,
         evaluate the quality of the fit, and generate a new WCS.
@@ -122,7 +122,7 @@ class TestWFC3Apriori(BaseWFC3):
 
     @pytest.mark.bigdata
     @pytest.mark.parametrize(
-        'dataset', ['ic0g0l010', 'icnw34040', 'ID6Y05010']
+        'dataset', ['ic0g0l010', 'icnw34040']
     )
     def test_apriori(self, dataset):
         compare_apriori(dataset)


### PR DESCRIPTION
Running 'tweakreg' or resetting WCSNAME by any other means to values other than those starting with 'OPUS' or 'IDC' caused 'tweakreg' and subsequent runs of 'astrodrizzle' to fail.  This was caught in our nightly regression tests https://plwishmaster.stsci.edu:8081/job/RT/job/drizzlepac/313/testReport/tests.acs.test_acs_tweak/TestAcsTweak/_3_6__test_tweak/

This failure showed up as: 

```
 
 >      wcstype += base_terms[wcsname_list[0][:3]]
 E       KeyError: 'TWE'
 
 ../../drizzlepac/updatehdr.py:539: KeyError
 
```

This problem has been resolved with this change to 'updatehdr'.  