### PR TITLE
Fix logic for interpreting wcsname

### DIFF
--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -533,6 +533,7 @@ def interpret_wcsname_type(wcsname):
                   'OPU': 'pipeline default '}
     no_fit = 'not aligned'
 
+    wcsname = wcsname.upper()  # make this comparison case-insensitive
     wcsname_list = wcsname.split('-')
     wcsname_term = wcsname_list[0][:3]
     if wcsname_term not in base_terms:

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -544,7 +544,15 @@ def interpret_wcsname_type(wcsname):
 
     # Interpret fit term (if any)
     fit_term = wcsname_list[1] if len(wcsname_list) > 1 else None
-    if len(wcsname_list) == 1 or fit_term not in fit_terms:
+    # Check to see whether any of the 'registered' fit types are found
+    # in the fit_term, e.g,, FIT_REL_GAIADR2 should be found as valid.
+    valid_fit_type = False
+    for term in fit_terms:
+        if term in fit_term:
+            valid_fit_type = True
+            break
+        
+    if len(wcsname_list) == 1 or not valid_fit_type:
         wcstype += no_fit
     else:
         if 'FIT' not in fit_term:

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -544,16 +544,8 @@ def interpret_wcsname_type(wcsname):
 
     # Interpret fit term (if any)
     fit_term = wcsname_list[1] if len(wcsname_list) > 1 else None
-    # Check to see whether any of the 'registered' fit types are found
-    # in the fit_term, e.g,, FIT_REL_GAIADR2 should be found as valid.
-    valid_fit_type = False
-    if fit_term:
-        for term in fit_terms:
-            if term in fit_term:
-                valid_fit_type = True
-                break
 
-    if len(wcsname_list) == 1 or not valid_fit_type:
+    if len(wcsname_list) == 1:
         wcstype += no_fit
     else:
         if 'FIT' not in fit_term:

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -547,11 +547,12 @@ def interpret_wcsname_type(wcsname):
     # Check to see whether any of the 'registered' fit types are found
     # in the fit_term, e.g,, FIT_REL_GAIADR2 should be found as valid.
     valid_fit_type = False
-    for term in fit_terms:
-        if term in fit_term:
-            valid_fit_type = True
-            break
-        
+    if fit_term:
+        for term in fit_terms:
+            if term in fit_term:
+                valid_fit_type = True
+                break
+
     if len(wcsname_list) == 1 or not valid_fit_type:
         wcstype += no_fit
     else:


### PR DESCRIPTION
Valid a posteriori WCSNAME values were being ignored when creating the WCSTYPE value when trying to account for user created WCSNAME values.  This logic has been revised to correctly allow valid a posteriori fits to be interpreted fully.  