### PR TITLE
Updating astroquery build reqs for testing

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -28,7 +28,6 @@ bc.test_configs = [data_config]
 
 bc1 = utils.copy(bc)
 bc1.name = '3.6-dev'
-bc1.conda_channels = ['http://ssb.stsci.edu/conda-dev']
 bc1.build_cmds[1] = "pip install -r requirements-dev.txt --upgrade -e '.[test]'"
 
 // Iterate over configurations that define the (distributed) build matrix.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ git+https://github.com/astropy/photutils.git#egg=photutils
 git+https://github.com/spacetelescope/stsci.tools.git#egg=stsci.tools
 git+https://github.com/astropy/astropy.git#egg=astropy
 git+https://github.com/spacetelescope/stwcs.git#egg=stwcs
+git+https://github.com/astropy/astroquery.git#egg=astroquery


### PR DESCRIPTION
Update the build requirements to pull in latest version of astroquery from master since it is being actively developed partly to stay in step with astropy as a whole.  Also, this will remove mention of the conda-dev channel for the Jenkins builds, not that it was being used. 