### PR TITLE
Updates to include integration of configuration management and catalog utilities

### DIFF
--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -964,15 +964,17 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, print_fit
                                           fit_rms_val,
                                           max_rms_val,
                                           num_xmatches))
-        # print fit params to screen
+        # print important fit params to screen
         if print_fit_parameters:
+            log_info_keys = ['status', 'fitgeom', 'eff_minobj', 'matrix', 'shift', 'center', 'rot', 'proper',
+                'rotxy', 'scale', 'skew', 'rmse', 'mae', 'nmatches', 'FIT_RMS', 'TOTAL_RMS', 'NUM_FITS', 
+                'RMS_RA', 'RMS_DEC', 'catalog']
             log.info("{} FIT PARAMETERS {}".format("~" * 35, "~" * 34))
             log.info("image: {}".format(image_name))
             log.info("chip: {}".format(item.meta['chip']))
             log.info("group_id: {}".format(item.meta['group_id']))
-            for tweakwcs_info_key in tweakwcs_info_keys:
-                if not tweakwcs_info_key.startswith("matched"):
-                    log.info("{} : {}".format(tweakwcs_info_key, item.meta['fit_info'][tweakwcs_info_key]))
+            for tweakwcs_info_key in log_info_keys:
+                log.info("{} : {}".format(tweakwcs_info_key, item.meta['fit_info'][tweakwcs_info_key]))
             log.info("~" * 84)
             log.info("nmatches_check: {} radial_offset_check: {}"
                      " large_rms_check: {},"
@@ -1302,7 +1304,8 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
             if item.meta['group_id'] == group_id and \
                group_id not in group_dict:
                 group_dict[group_id] = {'ref_idx': None, 'FIT_RMS': None}
-                log.info("fit_info: {}".format(item.meta['fit_info']))
+                # MDD FIX
+                # log.info("fit_info: {}".format(item.meta['fit_info']))
                 tinfo = item.meta['fit_info']
                 ref_idx = tinfo['matched_ref_idx']
                 fitmask = tinfo['fitmask']

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -1304,8 +1304,6 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
             if item.meta['group_id'] == group_id and \
                group_id not in group_dict:
                 group_dict[group_id] = {'ref_idx': None, 'FIT_RMS': None}
-                # MDD FIX
-                # log.info("fit_info: {}".format(item.meta['fit_info']))
                 tinfo = item.meta['fit_info']
                 ref_idx = tinfo['matched_ref_idx']
                 fitmask = tinfo['fitmask']

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -13,13 +13,7 @@ import sys
 import traceback
 
 import drizzlepac
-<<<<<<< HEAD
-from drizzlepac import alignimages
-from drizzlepac import astrodrizzle
-from drizzlepac import wcs_functions
 from drizzlepac.hlautils.catalog_utils import HAPCatalogs
-=======
->>>>>>> Integration of HapConfig into hapsequencer
 from drizzlepac.hlautils import config_utils
 from drizzlepac.hlautils import poller_utils
 from drizzlepac.hlautils import processing_utils as proc_utils
@@ -203,7 +197,6 @@ param_dict = {
             "scale_factor_list": [2.3e-6, 4.e-6, 8.e-6, 2.e-5, 0.0005, 0.005, 0.005, 0.015, 0.45, 1.],
             # "scale_factor_list_orig": [2.3e-6, 4.e-6, 8.e-6, 2.e-5, 6.e-5, 0.0005, 0.005, 0.015, 0.45, 1.],
             "proximity_binary": "yes"}}}
-
 # ----------------------------------------------------------------------------------------------------------------------
 
 
@@ -231,15 +224,10 @@ def create_catalog_products(total_list, debug=False, phot_mode='both'):
     """
     product_list = []
     for total_product_obj in total_list:
-        # determine total product filename
-        if os.path.exists(total_product_obj.product_basename+"_drc.fits"):
-            total_product_name = total_product_obj.product_basename + "_drc.fits"
-        else:
-            total_product_name = total_product_obj.product_basename + "_drz.fits"
 
         # Instantiate filter catalog product object
-        total_product_catalogs = HAPCatalogs(total_product_name,
-                                             total_product_obj.pars.get_pars('catalog generation'),
+        total_product_catalogs = HAPCatalogs(total_product_obj.drizzle_filename,
+                                             total_product_obj.configobj_pars.get_pars('catalog generation'),
                                              types=phot_mode,
                                              debug=debug)
 
@@ -265,15 +253,10 @@ def create_catalog_products(total_list, debug=False, phot_mode='both'):
                 sources_dict['segment']['kernel'] = total_product_catalogs.catalogs['segment'].kernel
 
         for filter_product_obj in total_product_obj.fdp_list:
-            # determine filter product filename
-            if os.path.exists(filter_product_obj.product_basename + "_drc.fits"):
-                filter_product_name = filter_product_obj.product_basename + "_drc.fits"
-            else:
-                filter_product_name = filter_product_obj.product_basename + "_drz.fits"
 
             # Instantiate filter catalog product object
-            filter_product_catalogs = HAPCatalogs(filter_product_name,
-                                                  filter_product_obj.pars.get_pars('catalog generation'),
+            filter_product_catalogs = HAPCatalogs(filter_product_obj.drizzle_filename,
+                                                  filter_product_obj.configobj_pars.get_pars('catalog generation'),
                                                   types=phot_mode,
                                                   debug=debug,
                                                   tp_sources=sources_dict)
@@ -373,12 +356,8 @@ def create_drizzle_products(total_list):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-<<<<<<< HEAD
-def run_hla_processing(input_filename, result=None, debug=False, use_defaults_configs=True,
-                       input_custom_pars_file=None, output_custom_pars_file=None, phot_mode='both'):
-=======
 def run_hap_processing(input_filename, result=None, debug=False, use_defaults_configs=True,
-                       input_custom_pars_file=None, output_custom_pars_file=None):
+                       input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both"):
     """
     Run the HST Advanced Products (HAP) generation code.  This routine is the sequencer or
     controller which invokes the high-level functionality to process the single visit data.
@@ -386,7 +365,7 @@ def run_hap_processing(input_filename, result=None, debug=False, use_defaults_co
     Parameters
     ----------
     input_filename: string
-        The "poller file" where each line contains information regarding an exposures taken 
+        The 'poller file' where each line contains information regarding an exposures taken 
         during a single visit.
 
     result: ---
@@ -397,24 +376,31 @@ def run_hap_processing(input_filename, result=None, debug=False, use_defaults_co
         creation and use of pickled information.
 
     use_default_configs: bool, optional
-
+        If True, use the configuration parameters in the 'default' portion of the configuration 
+        JSON files.  If False, use the configuration parameters in the "parameters" portion of
+        the file.  The default is True.
 
     input_custom_pars_file: string, optional
-        Fully specified input filename of a configuration file which has been customized 
-        for specialized processing.  These customized configuration values will override the
-        corresponding default settings.
+        Represents a fully specified input filename of a configuration JSON file which has been 
+        customized for specialized processing.  This file should contain ALL the input parameters
+        necessary for processing.  If there is a filename present for this parameter, the
+        'use_default_configs' parameter is ignored. The default is None.
 
     output_custom_pars_file: string, optional
         Fully specified output filename which contains all the configuration parameters
-        available during the processing session.
+        available during the processing session.  The default is None.
+
+    phot_mode : str, optional
+        Which algorithm should be used to generate the sourcelists? 'aperture' for aperture photometry;
+        'segment' for segment map photometry; 'both' for both 'segment' and 'aperture'. Default value is 'both'.
 
 
     RETURNS
     -------
-    product_list: list
-        A list of output products
+    return_value: integer
+        A return exit code used by the calling Condor/OWL workflow code: 0 (zero) for success, 1 for error
+
     """
->>>>>>> Integration of HapConfig into hapsequencer
     # This routine needs to return an exit code, return_value, for use by the calling
     # Condor/OWL workflow code: 0 (zero) for success, 1 for error condition
     return_value = 0
@@ -524,14 +510,3 @@ def run_hap_processing(input_filename, result=None, debug=False, use_defaults_co
         log.info("9: Return exit code for use by calling Condor/OWL workflow code: 0 (zero) for success, 1 for error "
                  "condition")
         return return_value
-
-# ----------------------------------------------------------------------------------------------------------------------
-# TODO: COMMENT OUT/REMOVE BELOW COMMAND-LINE INTERFACE PRIOR TO PULL REQUEST
-
-# if __name__ == '__main__':
-#     os.system("rm -f *.*")
-#     os.system("cp orig/* .")
-#     out_pars_file = sys.argv[1].replace(".out", "_config.json")
-#
-#     x = run_hla_processing(sys.argv[1], debug=True, output_custom_pars_file=out_pars_file, phot_mode='aperture')
-#     print("\a")

--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -2,6 +2,7 @@
 segmentation-map based photometry.
 """
 import sys
+import pickle # FIX Remove
 
 import astropy.units as u
 from astropy.io import fits as fits
@@ -519,9 +520,15 @@ class HAPPointCatalog(HAPCatalogBase):
         photometry_tbl.add_column(ra_col, index=2)
         photometry_tbl.add_column(dec_col, index=3)
 
-        # Calculate and add concentration index (CI) column to table
-        ci_data = photometry_tbl["MAG_{}".format(aper_radius_arcsec[0])].data - photometry_tbl[
-            "MAG_{}".format(aper_radius_arcsec[1])].data
+        try:
+            # Calculate and add concentration index (CI) column to table
+            ci_data = photometry_tbl["MAG_{}".format(aper_radius_arcsec[0])].data - photometry_tbl[
+                "MAG_{}".format(aper_radius_arcsec[1])].data
+        except Exception:
+            pickle_out = open("catalog.pickle", "wb")
+            pickle.dump(photometry_tbl, pickle_out)
+            pickle_out.close()
+
         ci_mask = np.logical_and(np.abs(ci_data) > 0.0, np.abs(ci_data) < 1.0e-30)
         big_bad_index = np.where(abs(ci_data) > 1.0e20)
         ci_mask[big_bad_index] = True

--- a/drizzlepac/hlautils/config_utils.py
+++ b/drizzlepac/hlautils/config_utils.py
@@ -50,6 +50,10 @@ class HapConfig(object):
         self.use_defaults = use_defaults
         self.input_custom_pars_file = input_custom_pars_file
         self.output_custom_pars_file = output_custom_pars_file
+
+        # The filters attribute is populated by _determine_conditions()
+        self.filters = None
+
         self._determine_conditions(prod_obj)
         self._get_cfg_index()
 
@@ -108,6 +112,9 @@ class HapConfig(object):
             if n_exp == 1:
                 self.conditions.append("any_n1")
             else:
+                # Get the filter of the first exposure in the filter exposure product list.  The filter 
+                # will be the same for all the exposures in the list.
+                self.filters = prod_obj.edp_list[0].filters
                 if self.instrument == "acs":
                     if self.detector == "hrc":
                         if n_exp in [2, 3]:
@@ -150,7 +157,11 @@ class HapConfig(object):
                                 self.conditions.append("wfc3_ir_any_n4")
                     elif self.detector == "uvis":
                         thresh_time = Time("2012-11-08T02:59:15", format='isot', scale='utc').mjd
-                        if self.mjd >= thresh_time:
+                        # Get the MJDUTC of the first exposure in the filter exposure product list. While
+                        # each exposure will have its own MJDUTC (the EXPSTART keyword), this is probably
+                        # granular enough.
+                        mjdutc = prod_obj.edp_list[0].mjdutc
+                        if mjdutc >= thresh_time:
                             if n_exp in [2, 3]:
                                 self.conditions.append("wfc3_uvis_any_post_n2")
                             if n_exp in [4, 5]:
@@ -351,6 +362,22 @@ class Par():
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+    # Mike's new stuff
+    def _flatten_dict(self, current, key, result):
+        """Flatten nested dictionaries into a non-nested dictionary. Assumes that there are no non-unique keys.
+        Code credit: https://stackoverflow.com/questions/24448543/how-would-i-flatten-a-nested-dictionary-in-python-3
+        Solution submitted by user 'Matthew Franglen'.
+        """
+        if isinstance(current, dict):
+            for k in current:
+                new_key = "{1}".format(key, k) if len(key) > 0 else k
+                self._flatten_dict(current[k], new_key, result)
+        else:
+            result[key] = current
+        return result
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
     def _get_params(self):
         """read in params from config files based on instrument, detector, and condition(s), and return a ordered
         dictionary of these values."""
@@ -424,6 +451,9 @@ class AstrodrizzlePars(Par):
             self._read_custom_pars()
         else:
             self._combine_conditions()
+
+        # Mike's new stuff
+        self.outpars = self._flatten_dict(self.outpars, '', {})
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/drizzlepac/hlautils/photometry_tools.py
+++ b/drizzlepac/hlautils/photometry_tools.py
@@ -116,7 +116,7 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, platescale,
         if item.startswith("aperture_sum_") and not item.startswith("aperture_sum_err_"):
             aper_size_arcsec = phot_apertures[n_aper].r * platescale
             for name in name_list:
-                names.append("{}_{}".format(name, aper_size_arcsec))
+                names.append("{}_{:.2f}".format(name, aper_size_arcsec))
             n_aper += 1
 
     for aperCtr in range(0, n_aper):

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -141,7 +141,6 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
                         for exposure in tot_obj.edp_list:
                             if rootname in exposure.full_filename:
                                 name_col.append(exposure.drizzle_filename)
-                                log.info("UTILS. FOUND IT. exposure.drizzle_filename: {}".format(exposure.drizzle_filename))
                                 foundit = True
                                 break
 

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -62,7 +62,6 @@ class TotalProduct(HAPProduct):
         self.point_cat_filename = self.product_basename + "_point-cat.ecsv"
         self.segment_cat_filename = self.product_basename + "_segment-cat.ecsv"
         self.drizzle_filename = self.product_basename + "_" + self.filetype + ".fits"
-        self.ref_drizzle_filename = self.product_basename + "_ref_" + self.filetype + ".fits"
 
         # Generate the name for the manifest file which is for the entire visit.  It is fine
         # to create it as an attribute of a TotalProduct as it is independent of

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -7,9 +7,14 @@ import sys
 import traceback
 import shutil
 
+from stsci.tools import logutil
+from astropy.io import fits
+
 from drizzlepac import wcs_functions
 from drizzlepac import alignimages
 from drizzlepac import astrodrizzle
+
+log = logutil.create_logger('product', level=logutil.logging.INFO, stream=sys.stdout)
 
 class HAPProduct:
     """ HAPProduct is the base class for the various products generated during the
@@ -28,11 +33,9 @@ class HAPProduct:
         # exposure_name is the ipppssoo or a portion thereof
         self.exposure_name = filename[0:8]
 
-        # TO DO: update this variable
-        self.mjdutc = None
-
-        # class variables to be set later
-        self.pars = None
+        # HAPConfig objects are created after these Product objects have been instantiated so
+        # this attribute is updated in the hapsequncer.py module (run_hla_processing()).
+        self.configobj_pars = None
 
     # def print_info(self):
         # """ Generic print at this time to indicate the information used in the
@@ -40,11 +43,6 @@ class HAPProduct:
         # """
         # print("Object information: {}".format(self.info))
 
-    def update_config(self, param_dict):
-        """ Method reserved for potential update of configuration information
-            for the particular data product in question.
-        """
-        pass
 
 class TotalProduct(HAPProduct):
     """ A Total Detection Product is a 'white' light mosaic comprised of
@@ -88,51 +86,47 @@ class TotalProduct(HAPProduct):
         """
         self.fdp_list.append(fdp)
 
-    def build_metawcs(self):
-        """ A reserved method to build a unique WCS for each TotalProduct product which is
-            generated based upon the merging of all the ExposureProductss which comprise the
-            specific TotalProduct.
+    def generate_metawcs(self):
+        """ A method to build a unique WCS for each TotalProduct product which is
+            generated based upon the merging of all the ExposureProducts which comprise the
+            specific TotalProduct.  This is done on a per TotalProduct basis as the Single
+            Visit Mosaics need to be represented in their native scale.
 
-        image_list = [element.full_filename for element in edp_list]
-        meta_wcs = wcs_functions.make_mosaic_wcs(image_list)
-        outnx = meta_wcs.pixel_shape[1]
-        outny = meta_wcs.pixel_shape[0]
         """
-        pass
+        exposure_filenames = [element.full_filename for element in self.edp_list]
+        log.info("\n\nRun make_mosaic_wcs to create a common WCS.")
+        log.info("The following images will be used: ")
+        log.info("{}\n".format(exposure_filenames))
 
-    def wcs_drizzle_product(self, meta_wcs, configobj):
+        # Set the rotation to 0.0 to force North as up
+        if exposure_filenames:
+            meta_wcs = wcs_functions.make_mosaic_wcs(exposure_filenames, rot=0.0)
+
+        # Store this for potential use.  The wcs_drizzle_product methods use the
+        # WCS passed in as a parameter which provides flexibility which may not
+        # be needed.  MONITOR for possible clean up.
+        self.meta_wcs = meta_wcs
+
+        return meta_wcs
+
+    def wcs_drizzle_product(self, meta_wcs):
         """
-        Create the drizzle-combined total image using the meta_wcs as the reference output
+            Create the drizzle-combined total image using the meta_wcs as the reference output
         """
+        # Retrieve the configuration parameters for astrodrizzle
+        drizzle_pars = self.configobj_pars.get_pars("astrodrizzle")
+        drizzle_pars["final_refimage"] = meta_wcs
+        drizzle_pars["runfile"] = self.trl_filename
+
         edp_filenames = [element.full_filename for element in self.edp_list]
         astrodrizzle.AstroDrizzle(input=edp_filenames,
                                   output=self.drizzle_filename,
-                                  final_refimage=meta_wcs,
-                                  final_outnx=meta_wcs.pixel_shape[1],
-                                  final_outny=meta_wcs.pixel_shape[0],
-                                  runfile=self.trl_filename,
-                                  configobj=configobj)
+                                  **drizzle_pars)
 
         # Rename Astrodrizzle log file as a trailer file
+        log.info("Total combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
         shutil.move(self.trl_filename, self.trl_filename.replace('.log', '.txt'))
 
-    def image_drizzle_product(self, ref_image, total_shape, configobj):
-        """
-        Create the drizzle-combined total image using the reference image as the reference output
-        """
-        edp_filenames = [element.full_filename for element in self.edp_list]
-        astrodrizzle.AstroDrizzle(input=edp_filenames,
-                                  output=self.drizzle_filename,
-                                  final_refimage=ref_image,
-                                  final_outnx=total_shape[1],
-                                  final_outny=total_shape[0],
-                                  runfile=self.trl_filename,
-                                  configobj=configobj)
-
-        # Rename Astrodrizzle log file as a trailer file
-        shutil.move(self.trl_filename, self.trl_filename.replace('.log', '.txt'))
-
-        # log.info("Total combined image consists of ... {} {}".format(self.drizzle_filename, edp_filenames))
 
 
 class FilterProduct(HAPProduct):
@@ -186,12 +180,11 @@ class FilterProduct(HAPProduct):
                                                         headerlet_filenames=headerlet_filenames)
 
         except Exception:
-            # TODO: Fix up the logging
             # Report a problem with the alignment
-            # log.info("EXCEPTION encountered in alignimages.\n")
+            log.info("EXCEPTION encountered in align_to_gaia for the FilteredProduct.\n")
             exc_type, exc_value, exc_tb = sys.exc_info()
             traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
-            # log.info("No correction to absolute astrometric frame applied.\n")
+            log.info("No correction to absolute astrometric frame applied.\n")
             align_table = None
 
         # Return a table which contains data regarding the alignment, as well as the
@@ -200,39 +193,25 @@ class FilterProduct(HAPProduct):
         # excluded from alignment.
         return align_table, exposure_filenames
 
-    def wcs_drizzle_product(self, meta_wcs, configobj):
+    def wcs_drizzle_product(self, meta_wcs):
         """
-        Create the drizzle-combined filter image using the meta_wcs as the reference output
+            Create the drizzle-combined filter image using the meta_wcs as the reference output
         """
+
+        # Retrieve the configuration parameters for astrodrizzle
+        drizzle_pars = self.configobj_pars.get_pars("astrodrizzle")
+        drizzle_pars["final_refimage"] = meta_wcs
+        drizzle_pars["runfile"] = self.trl_filename
+
         edp_filenames = [element.full_filename for element in self.edp_list]
         astrodrizzle.AstroDrizzle(input=edp_filenames,
                                   output=self.drizzle_filename,
-                                  final_refimage=meta_wcs,
-                                  final_outnx=meta_wcs.pixel_shape[1],
-                                  final_outny=meta_wcs.pixel_shape[0],
-                                  runfile=self.trl_filename,
-                                  configobj=configobj)
+                                  **drizzle_pars)
 
         # Rename Astrodrizzle log file as a trailer file
+        log.info("Filter combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
         shutil.move(self.trl_filename, self.trl_filename.replace('.log', '.txt'))
 
-    def image_drizzle_product(self, ref_image, total_shape, configobj):
-        """
-        Create the drizzle-combined filter image using the reference image as the reference output
-        """
-        edp_filenames = [element.full_filename for element in self.edp_list]
-        astrodrizzle.AstroDrizzle(input=edp_filenames,
-                                  output=self.drizzle_filename,
-                                  final_refimage=ref_image,
-                                  final_outnx=total_shape[1],
-                                  final_outny=total_shape[0],
-                                  runfile=self.trl_filename,
-                                  configobj=configobj)
-
-        # Rename Astrodrizzle log file as a trailer file
-        shutil.move(self.trl_filename, self.trl_filename.replace('.log', '.txt'))
-
-        # log.info("Filter combined image... {} {}".format(self.drizzle_filename, edp_filenames))
 
 class ExposureProduct(HAPProduct):
     """ An Exposure Product is an individual exposure/image (flt/flc).
@@ -246,8 +225,11 @@ class ExposureProduct(HAPProduct):
         self.full_filename = filename
         self.filters = filters
 
-        # TO DO: update this variable
-        # self.exptime = exptime
+        # Open the input FITS file to mine some header information.
+        hdu_list = fits.open(filename)
+        self.mjdutc = hdu_list[0].header['EXPSTART']
+        self.exptime = hdu_list[0].header['EXPTIME']
+        hdu_list.close()
 
         self.product_basename = self.basename + "_".join(map(str, [filters, self.exposure_name]))
         self.drizzle_filename = self.product_basename + "_" + self.filetype + ".fits"
@@ -256,35 +238,20 @@ class ExposureProduct(HAPProduct):
 
         self.regions_dict = {}
 
-    def wcs_drizzle_product(self, meta_wcs, configobj):
+    def wcs_drizzle_product(self, meta_wcs):
         """
             Create the drizzle-combined exposure image using the meta_wcs as the reference output
         """
-        # AstroDrizzle will soon take a meta_wcs object which contains outnx, outny
+
+        # Retrieve the configuration parameters for astrodrizzle
+        drizzle_pars = self.configobj_pars.get_pars("astrodrizzle")
+        drizzle_pars["final_refimage"] = meta_wcs
+        drizzle_pars["runfile"] = self.trl_filename
+
         astrodrizzle.AstroDrizzle(input=self.full_filename,
                                   output=self.drizzle_filename,
-                                  final_refimage=meta_wcs,
-                                  final_outnx=meta_wcs.pixel_shape[1],
-                                  final_outny=meta_wcs.pixel_shape[0],
-                                  runfile=self.trl_filename,
-                                  configobj=configobj)
+                                  **drizzle_pars)
 
         # Rename Astrodrizzle log file as a trailer file
+        log.info("Exposure image {}".format(self.drizzle_filename))
         shutil.move(self.trl_filename, self.trl_filename.replace('.log', '.txt'))
-
-    def image_drizzle_product(self, ref_image, total_shape, configobj):
-        """
-            Create the drizzle-combined exposure image using the reference image as the reference output
-        """
-        astrodrizzle.AstroDrizzle(input=self.full_filename,
-                                  output=self.drizzle_filename,
-                                  final_refimage=ref_image,
-                                  final_outnx=total_shape[1],
-                                  final_outny=total_shape[0],
-                                  runfile=self.trl_filename,
-                                  configobj=configobj)
-
-        # Rename Astrodrizzle log file as a trailer file
-        shutil.move(self.trl_filename, self.trl_filename.replace('.log', '.txt'))
-
-        # log.info("Filter combined image... {} {}".format(self.drizzle_filename, self.full_filename))

--- a/drizzlepac/pars/hap_pars/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
+++ b/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
+++ b/drizzlepac/pars/hap_pars/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
@@ -9,7 +9,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +107,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -132,7 +132,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +230,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/any/any_astrodrizzle_filter_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/any/any_astrodrizzle_filter_hap_basic.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "",
-        "output": "",
         "runfile": "",
         "wcskey": "",
         "proc_unit": "native",
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "",
-        "output": "",
         "runfile": "",
         "wcskey": "",
         "proc_unit": "native",

--- a/drizzlepac/pars/hap_pars/any/any_astrodrizzle_n1.json
+++ b/drizzlepac/pars/hap_pars/any/any_astrodrizzle_n1.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/any/any_astrodrizzle_single_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/any/any_astrodrizzle_single_hap_basic.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "",
-        "output": "",
         "runfile": "",
         "wcskey": "",
         "proc_unit": "native",
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "",
-        "output": "",
         "runfile": "",
         "wcskey": "",
         "proc_unit": "native",

--- a/drizzlepac/pars/hap_pars/any/any_astrodrizzle_total_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/any/any_astrodrizzle_total_hap_basic.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "",
-        "output": "",
         "runfile": "",
         "wcskey": "",
         "proc_unit": "native",
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "",
-        "output": "",
         "runfile": "",
         "wcskey": "",
         "proc_unit": "native",

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_alignment_all.json
@@ -1,0 +1,118 @@
+{
+  "parameters":
+  {
+    "general":
+      {
+        "MIN_FIT_MATCHES": 6,
+        "MAX_FIT_RMS": 10,
+        "MAX_SOURCES_PER_CHIP": 250
+      },
+    "run_align":
+      {
+        "update_hdr_wcs": true,
+        "catalog_list": ["GAIADR2", "GAIADR1"],
+        "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
+        "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
+        "MIN_CATALOG_THRESHOLD": 3,
+        "MIN_OBSERVABLE_THRESHOLD": 10,
+        "MAX_FIT_LIMIT": 150
+      },
+    "generate_source_catalogs":
+      {
+        "centering_mode": "starfind",
+        "num_sources": 250,
+        "fwhmpsf": 0.25,
+        "classify": false,
+        "threshold": null
+      },
+    "generate_astrometric_catalog":
+      {
+        "gaia_only": false,
+        "existing_wcs": null
+      },
+    "match_relative_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "match_default_fit":
+      {
+        "searchrad": 250,
+        "separation": 0.1,
+        "tolerance": 100,
+        "use2dhist": false
+      },
+    "match_2dhist_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "determine_fit_quality":
+      {
+        "MIN_CROSS_MATCHES": 3,
+        "MAS_TO_ARCSEC": 1000
+      }
+  },
+  "default_values":
+  {
+    "general":
+      {
+        "MIN_FIT_MATCHES": 6,
+        "MAX_FIT_RMS": 10,
+        "MAX_SOURCES_PER_CHIP": 250
+      },
+    "run_align":
+      {
+        "update_hdr_wcs": true,
+        "catalog_list": ["GAIADR2", "GAIADR1"],
+        "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
+        "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
+        "MIN_CATALOG_THRESHOLD": 3,
+        "MIN_OBSERVABLE_THRESHOLD": 10,
+        "MAX_FIT_LIMIT": 150
+      },
+    "generate_source_catalogs":
+      {
+        "centering_mode": "starfind",
+        "num_sources": 250,
+        "fwhmpsf": 0.25,
+        "classify": false,
+        "threshold": null
+      },
+    "generate_astrometric_catalog":
+      {
+        "gaia_only": false,
+        "existing_wcs": null
+      },
+    "match_relative_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "match_default_fit":
+      {
+        "searchrad": 250,
+        "separation": 0.1,
+        "tolerance": 100,
+        "use2dhist": false
+      },
+    "match_2dhist_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "determine_fit_quality":
+      {
+        "MIN_CROSS_MATCHES": 3,
+        "MAS_TO_ARCSEC": 1000
+      }
+  }
+}

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -24,27 +24,33 @@
      }
    },
   "parameters":
-   {
-     "dao":
-     {
-       "bkgsig_sf": 4.0,
-       "kernel_sd_aspect_ratio": 0.8,
-       "simple_bkg": false,
-       "TWEAK_FWHMPSF": 0.14,
-       "TWEAK_THRESHOLD": 3.0,
-       "aperture_1": 0.15,
-       "aperture_2": 0.45,
-       "bthresh": 5.0,
-       "scale": 0.09,
-       "skyannulus_arcsec": 0.25,
-       "dskyannulus_arcsec": 0.25,
-       "salgorithm": "mode"
-     },
-     "sourcex": {
-       "fwhm": 0.14,
-       "thresh": 1.4,
-       "bthresh": 5.0,
-       "source_box": 7
-     }
-   }
+  {
+    "input": "stuff.txt",
+    "SOURCELIST GENERATION":
+    {
+      "DAO":
+      {
+        "fwhm": 0.8
+      },
+      "SOURCEX":
+      {
+        "fwhm": 0.2
+      }
+    }
+  },
+  "default_values":
+  {
+    "input": "stuff.txt",
+    "SOURCELIST GENERATION":
+    {
+      "DAO":
+      {
+        "fwhm": 80.0
+      },
+      "SOURCEX":
+      {
+        "fwhm": 20.0
+      }
+    }
+  }
 }

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -24,33 +24,27 @@
      }
    },
   "parameters":
-  {
-    "input": "stuff.txt",
-    "SOURCELIST GENERATION":
-    {
-      "DAO":
-      {
-        "fwhm": 0.8
-      },
-      "SOURCEX":
-      {
-        "fwhm": 0.2
-      }
-    }
-  },
-  "default_values":
-  {
-    "input": "stuff.txt",
-    "SOURCELIST GENERATION":
-    {
-      "DAO":
-      {
-        "fwhm": 80.0
-      },
-      "SOURCEX":
-      {
-        "fwhm": 20.0
-      }
-    }
-  }
+   {
+     "dao":
+     {
+       "bkgsig_sf": 4.0,
+       "kernel_sd_aspect_ratio": 0.8,
+       "simple_bkg": false,
+       "TWEAK_FWHMPSF": 0.14,
+       "TWEAK_THRESHOLD": 3.0,
+       "aperture_1": 0.15,
+       "aperture_2": 0.45,
+       "bthresh": 5.0,
+       "scale": 0.09,
+       "skyannulus_arcsec": 0.25,
+       "dskyannulus_arcsec": 0.25,
+       "salgorithm": "mode"
+     },
+     "sourcex": {
+       "fwhm": 0.14,
+       "thresh": 1.4,
+       "bthresh": 5.0,
+       "source_box": 7
+     }
+   }
 }

--- a/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/ir/wfc3_ir_quality_control_all.json
@@ -1,0 +1,10 @@
+{
+  "parameters":
+  {
+    "placeholder":"QC"
+  },
+  "default_values":
+  {
+    "placeholder":"QC"
+  }
+}

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -1,0 +1,118 @@
+{
+  "parameters":
+  {
+    "general":
+      {
+        "MIN_FIT_MATCHES": 6,
+        "MAX_FIT_RMS": 10,
+        "MAX_SOURCES_PER_CHIP": 250
+      },
+    "run_align":
+      {
+        "update_hdr_wcs": true,
+        "catalog_list": ["GAIADR2", "GAIADR1"],
+        "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
+        "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
+        "MIN_CATALOG_THRESHOLD": 3,
+        "MIN_OBSERVABLE_THRESHOLD": 10,
+        "MAX_FIT_LIMIT": 150
+      },
+    "generate_source_catalogs":
+      {
+        "centering_mode": "starfind",
+        "num_sources": 250,
+        "fwhmpsf": 0.152,
+        "classify": true,
+        "threshold": null
+      },
+    "generate_astrometric_catalog":
+      {
+        "gaia_only": false,
+        "existing_wcs": null
+      },
+    "match_relative_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "match_default_fit":
+      {
+        "searchrad": 250,
+        "separation": 0.1,
+        "tolerance": 100,
+        "use2dhist": false
+      },
+    "match_2dhist_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "determine_fit_quality":
+      {
+        "MIN_CROSS_MATCHES": 3,
+        "MAS_TO_ARCSEC": 1000
+      }
+  },
+  "default_values":
+  {
+    "general":
+      {
+        "MIN_FIT_MATCHES": 6,
+        "MAX_FIT_RMS": 10,
+        "MAX_SOURCES_PER_CHIP": 250
+      },
+    "run_align":
+      {
+        "update_hdr_wcs": true,
+        "catalog_list": ["GAIADR2", "GAIADR1"],
+        "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
+        "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
+        "MIN_CATALOG_THRESHOLD": 3,
+        "MIN_OBSERVABLE_THRESHOLD": 10,
+        "MAX_FIT_LIMIT": 150
+      },
+    "generate_source_catalogs":
+      {
+        "centering_mode": "starfind",
+        "num_sources": 250,
+        "fwhmpsf": 0.152,
+        "classify": true,
+        "threshold": null
+      },
+    "generate_astrometric_catalog":
+      {
+        "gaia_only": false,
+        "existing_wcs": null
+      },
+    "match_relative_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "match_default_fit":
+      {
+        "searchrad": 250,
+        "separation": 0.1,
+        "tolerance": 100,
+        "use2dhist": false
+      },
+    "match_2dhist_fit":
+      {
+        "searchrad": 75,
+        "separation": 0.1,
+        "tolerance": 2,
+        "use2dhist": true
+      },
+    "determine_fit_quality":
+      {
+        "MIN_CROSS_MATCHES": 3,
+        "MAS_TO_ARCSEC": 1000
+      }
+  }
+}

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
@@ -1,7 +1,5 @@
 {
     "parameters": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -9,7 +7,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -107,7 +105,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,
@@ -123,8 +121,6 @@
         }
     },
     "default_values": {
-        "input": "*flt.fits",
-        "output": "",
         "_mdriztab_btn_": "Update From MDRIZTAB",
         "runfile": "astrodrizzle.log",
         "wcskey": "",
@@ -132,7 +128,7 @@
         "coeffs": true,
         "context": true,
         "group": "",
-        "build": false,
+        "build": true,
         "crbit": 4096,
         "stepsize": 10,
         "resetbits": "4096",
@@ -230,7 +226,7 @@
             "restore": false,
             "preserve": true,
             "overwrite": false,
-            "clean": false
+            "clean": true
         },
         "STEP 3a: CUSTOM WCS FOR SEPARATE OUTPUTS": {
             "driz_sep_wcs": false,

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -24,27 +24,33 @@
      }
    },
   "parameters":
-   {
-     "dao":
-     {
-       "bkgsig_sf": 4.0,
-       "kernel_sd_aspect_ratio": 0.8,
-       "simple_bkg": false,
-       "TWEAK_FWHMPSF": 0.076,
-       "TWEAK_THRESHOLD": 3.0,
-       "aperture_1": 0.05,
-       "aperture_2": 0.15,
-       "bthresh": 5.0,
-       "scale": 0.04,
-       "skyannulus_arcsec": 0.25,
-       "dskyannulus_arcsec": 0.25,
-       "salgorithm": "mode"
-     },
-     "sourcex": {
-       "fwhm": 0.076,
-       "thresh": 1.4,
-       "bthresh": 5.0,
-       "source_box": 7
-     }
-   }
+  {
+    "input": "stuff.txt",
+    "SOURCELIST GENERATION":
+    {
+      "DAO":
+      {
+        "fwhm": 0.8
+      },
+      "SOURCEX":
+      {
+        "fwhm": 0.2
+      }
+    }
+  },
+  "default_values":
+  {
+    "input": "stuff.txt",
+    "SOURCELIST GENERATION":
+    {
+      "DAO":
+      {
+        "fwhm": 80.0
+      },
+      "SOURCEX":
+      {
+        "fwhm": 20.0
+      }
+    }
+  }
 }

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -24,33 +24,27 @@
      }
    },
   "parameters":
-  {
-    "input": "stuff.txt",
-    "SOURCELIST GENERATION":
-    {
-      "DAO":
-      {
-        "fwhm": 0.8
-      },
-      "SOURCEX":
-      {
-        "fwhm": 0.2
-      }
-    }
-  },
-  "default_values":
-  {
-    "input": "stuff.txt",
-    "SOURCELIST GENERATION":
-    {
-      "DAO":
-      {
-        "fwhm": 80.0
-      },
-      "SOURCEX":
-      {
-        "fwhm": 20.0
-      }
-    }
-  }
+   {
+     "dao":
+     {
+       "bkgsig_sf": 4.0,
+       "kernel_sd_aspect_ratio": 0.8,
+       "simple_bkg": false,
+       "TWEAK_FWHMPSF": 0.076,
+       "TWEAK_THRESHOLD": 3.0,
+       "aperture_1": 0.05,
+       "aperture_2": 0.15,
+       "bthresh": 5.0,
+       "scale": 0.04,
+       "skyannulus_arcsec": 0.25,
+       "dskyannulus_arcsec": 0.25,
+       "salgorithm": "mode"
+     },
+     "sourcex": {
+       "fwhm": 0.076,
+       "thresh": 1.4,
+       "bthresh": 5.0,
+       "source_box": 7
+     }
+   }
 }

--- a/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/wfc3/uvis/wfc3_uvis_quality_control_all.json
@@ -1,0 +1,10 @@
+{
+  "parameters":
+  {
+    "placeholder":"QC"
+  },
+  "default_values":
+  {
+    "placeholder":"QC"
+  }
+}

--- a/drizzlepac/test_config_utils.py
+++ b/drizzlepac/test_config_utils.py
@@ -17,13 +17,13 @@ input_filename = sys.argv[1]
 # param_filename = "superparamfile.json"
 #
 # for item in expo_list+filt_list+total_list:
-#     item.pars = config_utils.HapConfig(item,input_custom_pars_file=param_filename,use_defaults=False)
+#     item.configobj_pars = config_utils.HapConfig(item,input_custom_pars_file=param_filename,use_defaults=False)
 # #
 # print(" ")
-# print(expo_list[0].pars.get_pars("alignment"))
+# print(expo_list[0].configobj_pars.get_pars("alignment"))
 #
 
-rv = hapsequencer.run_hla_processing(input_filename)
+rv = hapsequencer.run_hap_processing(input_filename)
 # pdb.set_trace()
 
 # config_utils.reformat_json_file("superparamfile.json","new_superparamfile.json")

--- a/drizzlepac/wcs_functions.py
+++ b/drizzlepac/wcs_functions.py
@@ -1044,7 +1044,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
         hwcs = altwcs.pc2cd(hwcs, key=wcskey)
     return hwcs
 
-def make_mosaic_wcs(filenames, rot=0.0, scale=0.05):
+def make_mosaic_wcs(filenames, rot=None, scale=None):
     """Combine WCSs from all input files into a single meta-WCS
 
     Parameters
@@ -1053,10 +1053,10 @@ def make_mosaic_wcs(filenames, rot=0.0, scale=0.05):
         list of filenames to process
 
     rot : float
-        desired rotation of meta-WCS. Default value is 0.0.
+        desired rotation of meta-WCS. Default value is None.
 
     scale : float
-        desired scale of meta-WCS. Default value is 0.05.
+        desired scale of meta-WCS. Default value is None.
 
     Returns
     --------


### PR DESCRIPTION
The configuration management and catalog utilities have been fully integrated into the OO HAP code.  Some additional updates include:
- Implemented use of meta_wcs for all instrument/detector products. This is
  in contrast to creating a temporary total drizzled image.
- Added the mjdutc and exptime attributes to the ExposureProduct class.
  - Modified the HapConfig class (_determine_conditions) to use
    the mjdutc and filters attributes of the ExposureProduct objects
    for conditioning.
- Modified the function signature of make_mosaic_wcs in the wcs_functions
  module so the native scale of the input image is retained.
- Removed deprecated code in the Product classes and hapsequencer.
- Improved comments in the Product classes and hapsequencer.
- Modified JSON configuration files:
  - Removed all "input" and "output" entries.
  - Set all "build" entries to true.
  - Set all "clean" entries to true.
- Created WFC3, both IR and UVIS, missing JSON configuration files for
  testing.  These files should be verified for correctness.
- Modified the logging in the alignment code to remove the copious
  amount of detailed fit information which was obscuring the
  useful data.
- Added logging to the Product classes.
- Mike provided code for the config_utils module to flatten the
  "astrodrizzle" configuration values stored in a dictionary.
