### PR TITLE
Necessary changes to setup.py for proper code and config file distrib…

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -6,6 +6,7 @@
     Legacy Archive (HLA) pipeline in that it provides the overall sequence of
     the processing.
 """
+import argparse
 import datetime
 import glob
 import os
@@ -510,3 +511,26 @@ def run_hap_processing(input_filename, result=None, debug=False, use_defaults_co
         log.info("9: Return exit code for use by calling Condor/OWL workflow code: 0 (zero) for success, 1 for error "
                  "condition")
         return return_value
+
+def main():
+    """ The __main__ and main() functionality here are TEMPORARILY to allow the Single Visit Mosaic
+    processing to be invoked from the command line by INS.  At this time there is no high-level Hubble
+    Advanced Products (HAP) driver which would contain the "main".
+
+    This command line processing is invoked as 
+    $ runhap poller_file  (e.g., runhap ib4606.out)
+    """
+
+    parser = argparse.ArgumentParser(description="Process images, produce drizzled images and sourcelists")
+    parser.add_argument("input_filename", help="Name of the input csv file containing information about the files to "
+                        "be processed")
+    ARGS = parser.parse_args()
+
+    print("Single-visit processing started for: {}".format(ARGS.input_filename))
+    rv = run_hap_processing(ARGS.input_filename)
+    print("Return Value: ", rv)
+    return rv
+
+if __name__ == "__main__":
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         'tweakwcs>=0.5.0',
         'stregion',
         'requests',
-        # HLA-pipeline specific:
+        # HAP-pipeline specific:
         'astroquery',
         'photutils>=0.7',
         'pysynphot',
@@ -112,6 +112,13 @@ setup(
         '': ['README.md', 'LICENSE.txt'],
         'drizzlepac': [
             'pars/*',
+            'pars/hap_pars/*',
+            'pars/hap_pars/acs/hrc/*',
+            'pars/hap_pars/acs/sbc/*',
+            'pars/hap_pars/acs/wfc/*',
+            'pars/hap_pars/any/*',
+            'pars/hap_pars/wfc3/ir/*',
+            'pars/hap_pars/wfc3/uvis/*',
             '*.help',
             'htmlhelp/*',
             'htmlhelp/_*/*',
@@ -124,7 +131,7 @@ setup(
             'resetbits=drizzlepac.resetbits:main',
             'updatenpol=drizzlepac.updatenpol:main',
             'runastrodriz=drizzlepac.runastrodriz:main',
-            'runhap=drizzlepac.runhlaprocessing:main'
+            'runhap=drizzlepac.hapsequencer:main'
         ],
     },
     ext_modules=[


### PR DESCRIPTION
…ution, and need main() to run as command line task.

__main__ and main() were added **_temporarily_** to hapsequencer.py in order to accommodate running the HAP processing from the command line and there is no high-level driver at this time.  Updated setup.py so the HAP portion of the drizzlepac code properly handles the configuration files upon installation and has the proper entry point.