### PR TITLE
Fix pyproject.toml exclusion from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,9 @@
 include RELIC-INFO
 recursive-include doc *
-global-include *.py *.md *.notes *.yml
+global-include *.py *.md *.notes *.yml *.toml
 global-include *.x *.c *.h *.par
 exclude */version.py
-prune .pytest_cache
+prune .
 prune .eggs
 prune .git
 prune relic


### PR DESCRIPTION
After `drizzlepac-2.2.6` the `pyproject.toml` stopped getting included by `sdist`. I suspect `setuptools` may be to blame for this, because we didn't change anything of note on our end.