### PR TITLE
Set reg and cat files as debug only

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -300,7 +300,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         log.info("\nAlign the images on a filter-by-filter basis.")
         for tot_obj in total_list:
             for filt_obj in tot_obj.fdp_list:
-                align_table, filt_exposures = filt_obj.align_to_gaia()
+                align_table, filt_exposures = filt_obj.align_to_gaia(output=debug)
 
                 # Report results and track the output files
                 if align_table:

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -183,7 +183,7 @@ class FilterProduct(HAPProduct):
         """
         self.edp_list.append(edp)
 
-    def align_to_gaia(self, catalog_name='GAIADR2', headerlet_filenames=None):
+    def align_to_gaia(self, catalog_name='GAIADR2', headerlet_filenames=None, output=True):
         """Extract the flt/flc filenames from the exposure product list, as
            well as the corresponding headerlet filenames to use legacy alignment
            routine.
@@ -204,7 +204,7 @@ class FilterProduct(HAPProduct):
                     headerlet_filenames[edp.full_filename] = edp.headerlet_filename
 
                 align_table = align_utils.AlignmentTable(exposure_filenames, **alignment_pars)
-                align_table.find_alignment_sources()
+                align_table.find_alignment_sources(output=output)
                 align_table.configure_fit()
                 refname = "{}_ref_cat.ecsv".format(self.product_basename)
                 log.info('Creating reference catalog {}'.format(refname))


### PR DESCRIPTION
These changes simply tie the generation of the alignment .reg and .cat files from single-visit processing to the 'debug' parameter, so that they are only generated if 'debug' mode is turned on.  As a result, they are not created during standard pipeline processing.