### PR TITLE
Simple change to report SVM in WCSNAME

### DIFF
--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -71,7 +71,7 @@ class AlignmentTable:
         self.alignment_pars.update(alignment_pars['general'])
         self.alignment_pars.update(alignment_pars['generate_source_catalogs'])
         self.alignment_pars.update(alignment_pars['determine_fit_quality'])
-        
+
         self.dqname = dqname
 
         self.zero_dt = starting_dt = datetime.datetime.now()
@@ -239,7 +239,8 @@ class AlignmentTable:
             raise ValueError
         # Call update_hdr_wcs()
         headerlet_dict = update_image_wcs_info(self.selected_fit,
-                                               headerlet_filenames=headerlet_filenames)
+                                               headerlet_filenames=headerlet_filenames,
+                                               fit_label='SVM')
 
         for table_index in range(0, len(self.filtered_table)):
             self.filtered_table[table_index]['headerletFile'] = headerlet_dict[

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -513,7 +513,8 @@ def interpret_wcsname_type(wcsname):
     """Interpret WCSNAME as a standardized human-understandable description """
     wcstype = ''
     fit_terms = {'REL': 'relatively aligned to {}',
-                 'IMG': 'aligned image-by-image to {}'}
+                 'IMG': 'aligned image-by-image to {}',
+                 'SVM': 'aligned by visit to {}'}
     post_fit = 'a posteriori solution '
     default_fit = 'a priori solution based on {}'
     base_terms = {'IDC': 'undistorted ',


### PR DESCRIPTION
This simple change takes advantage of the revised alignment code to report SVM as the type of alignment for single visit products (and input exposures), instead of IMG or REL.