### PR TITLE
Add warning about minmed for N>5

### DIFF
--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -160,6 +160,13 @@ def setCommonInput(configObj, createOutwcs=True):
     configObj[step3name]['driz_sep_bits'] = interpret_bit_flags(
                                         configObj[step3name]['driz_sep_bits']
     )
+    step4name = util.getSectionName(configObj,4)
+    if len(files) > 5 and 'minmed' in configObj[step4name]['combine_type']:
+        msg = '“minmed” is highly recommended for three images, \n'+\
+        ' and is good for four to six images, \n'+\
+        ' but should be avoided for ten or more images.\n'
+        print(textutil.textbox(msg))
+
     step7name = util.getSectionName(configObj,7)
     configObj[step7name]['final_bits'] = interpret_bit_flags(
                                         configObj[step7name]['final_bits']


### PR DESCRIPTION
Simple fix to warn users about use of 'minmed' option in combine step of astrodrizzle when combining more than 5 images.

Tested against j9l902010 and jd5702030.
Addresses #473 .