### PR TITLE
Force updatewcs in cases where exptime==0 for all inputs

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -387,6 +387,15 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         updatewcs.updatewcs(_calfiles)
         if _calfiles_flc:
             updatewcs.updatewcs(_calfiles_flc)
+        # Check for the case where no update was performed due to all inputs
+        # having EXPTIME==0 (for example) and apply updatewcs anyway to allow
+        # for successful creation of updated headerlets for this data.
+        with fits.open(_calfiles[0]) as img0:
+            if 'wcsname' not in img0[1].header:
+                updatewcs.updatewcs(_calfiles, checkfiles=False)
+                if _calfiles_flc:
+                    updatewcs.updatewcs(_calfiles_flc, checkfiles=False)
+
         try:
             tmpname = "_".join([_trlroot, 'apriori'])
             sub_dirs.append(tmpname)


### PR DESCRIPTION
This revision addresses the pipeline processing problem where all inputs are 'bad' (EXPTIME==0, for example) and updatewcs does not get applied.  The change forces updatewcs to run (checkfiles=False) in order to apply solutions from astrometry database and reformat the WCS in the header to include the WCSNAME keyword for use in creating a more accurate headerlet for archiving.

Fix was tested on ibvz01010.