### PR TITLE
ABMAG calculation cleanup

### DIFF
--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -358,7 +358,8 @@ def computeLinearStats(matchedRA,plotGen,diffMode,plot_title,verbose):
         ax1 = fig.add_subplot(111)
         fullPlotTitle = "Comparision - reference sourcelist %s differences" % (plot_title)
         plt.title(fullPlotTitle)
-        ax1.hist(diffRA,bins='auto')
+        bins = "auto"
+        ax1.hist(diffRA,bins=bins)
         ax1.axvline(x=clippedStats[0], color='k', linestyle='--')
         ax1.axvline(x=clippedStats[0] + clippedStats[2], color='k', linestyle=':')
         ax1.axvline(x=clippedStats[0] - clippedStats[2], color='k', linestyle=':')
@@ -369,7 +370,7 @@ def computeLinearStats(matchedRA,plotGen,diffMode,plot_title,verbose):
         ax1.set_ylabel("Number of matched sources")
 
         ax2 = ax1.twinx()
-        ax2.hist(diffRA, bins='auto', cumulative=-1, density=True, histtype='step', color='r')
+        ax2.hist(diffRA, bins=bins, cumulative=-1, density=True, histtype='step', color='r')
         ax2.set_ylabel("Fraction of all matched sources",color='r')
         for tl in ax2.get_yticklabels():
             tl.set_color('r')
@@ -829,6 +830,10 @@ def slFiles2dataTables(slNames):
                           "FLUX2": "Flux(0.125)", "MAGNITUDE1": "MagAp(0.03)", "MAGNITUDE2": "MagAp(0.125)",
                           "MERR1": "MagErr(0.03)", "MERR2": "MagErr(0.125)", "MSKY": "MSky(0.125)",
                           "STDEV": "Stdev(0.125)", "FLAGS": "Flags", "ID": "ID", "CI": "CI"}
+    titleSwapDict_dao4 = {"X": "X-Center", "Y": "Y-Center", "RA": "RA", "DEC": "DEC", "FLUX1": "n/a",
+                          "FLUX2": "FluxAp2", "MAGNITUDE1": "MagAp1", "MAGNITUDE2": "MagAp2",
+                          "MERR1": "MagErrAp1", "MERR2": "MagErrAp2", "MSKY": "MSkyAp2",
+                          "STDEV": "StdevAp2", "FLAGS": "Flags", "ID": "ID", "CI": "CI"}
     titleSwapDict_daoTemp={"X":"XCENTER","Y":"YCENTER","RA":"n/a","DEC":"n/a","FLUX1":"FLUX1","FLUX2":"FLUX2","MAGNITUDE1":"MAG1","MAGNITUDE2":"MAG2","FLAGS":"n/a","ID":"ID","MERR1":"MERR1","MERR2":"MERR2","MSKY":"MSKY","STDEV":"STDEV"}
     titleSwapDict_sourceX={"X":"X_IMAGE","Y":"Y_IMAGE","RA":"RA","DEC":"DEC","FLUX1":"FLUX_APER1","FLUX2":"FLUX_APER2","MAGNITUDE1":"MAG_APER1","MAGNITUDE2":"MAG_APER2","FLAGS":"FLAGS","ID":"NUMBER"}
     titleSwapDict_cooNew={"X":"col1","Y":"col2","RA":"n/a","DEC":"n/a","FLUX1":"n/a","FLUX2":"n/a","MAGNITUDE1":"n/a","MAGNITUDE2":"n/a","FLAGS":"n/a","ID":"col7"}
@@ -851,6 +856,9 @@ def slFiles2dataTables(slNames):
             elif (("MagAp(0.03)" in list(dataTable.keys())) and ("MagAp(0.125)" in list(dataTable.keys()))): #ACS/HRC
                 log.info("titleSwapDict_dao3")
                 titleSwapDict = titleSwapDict_dao3
+            elif "MagAp1" in list(dataTable.keys()):
+                log.info("titleSwapDict_dao4")
+                titleSwapDict = titleSwapDict_dao4
             else:
                 sys.exit("ERROR: Unrecognized format. Exiting...")
         elif ("XCENTER" in list(dataTable.keys()) and "FLUX1" in list(dataTable.keys())):

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -830,10 +830,14 @@ def slFiles2dataTables(slNames):
                           "FLUX2": "Flux(0.125)", "MAGNITUDE1": "MagAp(0.03)", "MAGNITUDE2": "MagAp(0.125)",
                           "MERR1": "MagErr(0.03)", "MERR2": "MagErr(0.125)", "MSKY": "MSky(0.125)",
                           "STDEV": "Stdev(0.125)", "FLAGS": "Flags", "ID": "ID", "CI": "CI"}
-    titleSwapDict_dao4 = {"X": "X-Center", "Y": "Y-Center", "RA": "RA", "DEC": "DEC", "FLUX1": "n/a",
-                          "FLUX2": "FluxAp2", "MAGNITUDE1": "MagAp1", "MAGNITUDE2": "MagAp2",
-                          "MERR1": "MagErrAp1", "MERR2": "MagErrAp2", "MSKY": "MSkyAp2",
-                          "STDEV": "StdevAp2", "FLAGS": "Flags", "ID": "ID", "CI": "CI"}
+    titleSwapDict_point = {"X": "X-Center", "Y": "Y-Center", "RA": "RA", "DEC": "DEC", "FLUX1": "n/a",
+                           "FLUX2": "FluxAp2", "MAGNITUDE1": "MagAp1", "MAGNITUDE2": "MagAp2",
+                           "MERR1": "MagErrAp1", "MERR2": "MagErrAp2", "MSKY": "MSkyAp2",
+                           "STDEV": "StdevAp2", "FLAGS": "Flags", "ID": "ID", "CI": "CI"}
+    titleSwapDict_segment = {"X": "X-Centroid", "Y": "Y-Centroid", "RA": "RA", "DEC": "DEC", "FLUX1": "n/a",
+                             "FLUX2": "FluxAp2", "MAGNITUDE1": "MagAp1", "MAGNITUDE2": "MagAp2",
+                             "MERR1": "MagErrAp1", "MERR2": "MagErrAp2", "MSKY": "n/a",
+                             "STDEV": "n/a", "FLAGS": "Flags", "ID": "ID", "CI": "CI"}
     titleSwapDict_daoTemp={"X":"XCENTER","Y":"YCENTER","RA":"n/a","DEC":"n/a","FLUX1":"FLUX1","FLUX2":"FLUX2","MAGNITUDE1":"MAG1","MAGNITUDE2":"MAG2","FLAGS":"n/a","ID":"ID","MERR1":"MERR1","MERR2":"MERR2","MSKY":"MSKY","STDEV":"STDEV"}
     titleSwapDict_sourceX={"X":"X_IMAGE","Y":"Y_IMAGE","RA":"RA","DEC":"DEC","FLUX1":"FLUX_APER1","FLUX2":"FLUX_APER2","MAGNITUDE1":"MAG_APER1","MAGNITUDE2":"MAG_APER2","FLAGS":"FLAGS","ID":"NUMBER"}
     titleSwapDict_cooNew={"X":"col1","Y":"col2","RA":"n/a","DEC":"n/a","FLUX1":"n/a","FLUX2":"n/a","MAGNITUDE1":"n/a","MAGNITUDE2":"n/a","FLAGS":"n/a","ID":"col7"}
@@ -857,8 +861,8 @@ def slFiles2dataTables(slNames):
                 log.info("titleSwapDict_dao3")
                 titleSwapDict = titleSwapDict_dao3
             elif "MagAp1" in list(dataTable.keys()):
-                log.info("titleSwapDict_dao4")
-                titleSwapDict = titleSwapDict_dao4
+                log.info("titleSwapDict_point")
+                titleSwapDict = titleSwapDict_point
             else:
                 sys.exit("ERROR: Unrecognized format. Exiting...")
         elif ("XCENTER" in list(dataTable.keys()) and "FLUX1" in list(dataTable.keys())):
@@ -876,6 +880,9 @@ def slFiles2dataTables(slNames):
         elif "X" in list(dataTable.keys()):
             log.info("titleSwapDict_daorep")
             titleSwapDict = titleSwapDict_daorep
+        elif "X-Centroid" in list(dataTable.keys()) and "MagAp1" in list(dataTable.keys()):
+            log.info("titleSwapDict_segment")
+            titleSwapDict = titleSwapDict_segment
         else: sys.exit("ERROR: Unrecognized format. Exiting...")
         outTable=Table()
         for swapKey in list(titleSwapDict.keys()):

--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -83,9 +83,13 @@ def read_cat_file(catfile):
     :type catfile: string
     :returns: Catalog file information (reshaped if need be)
     """
-    if catfile.endswith(".ecsv"):
+    if catfile.endswith("point-cat.ecsv"):
         ecsvData = Table.read(catfile, format='ascii.ecsv') #now will read in and process HAP catalog data
         data = numpy.stack((ecsvData["X-Center"].data, ecsvData["Y-Center"].data), axis=-1)
+    elif catfile.endswith("segment-cat.ecsv"):
+        ecsvData = Table.read(catfile, format='ascii.ecsv') #now will read in and process HAP catalog data
+        data = numpy.stack((ecsvData["X-Centroid"].data, ecsvData["Y-Centroid"].data), axis=-1)
+
     else:
         try:
             daoData = Table.read(catfile, format='ascii.daophot') #now will read in and process daophot data

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -154,7 +154,6 @@ def create_drizzle_products(total_list):
     # and finally the drizzle-combined total detection image.
     for total_obj in total_list:
         log.info("~" * 118)
-
         # Get the common WCS for all images which are part of a total detection product,
         # where the total detection product is detector-dependent.
         meta_wcs = total_obj.generate_metawcs()

--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -582,7 +582,9 @@ class HAPPointCatalog(HAPCatalogBase):
         # Create the list of photometric apertures to measure
         phot_apers = [CircularAperture(pos_xy, r=r) for r in self.aper_radius_list_pixels]
         # Perform aperture photometry
-        photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers, bg_apers, data=image,
+        photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers,
+                                                                bg_apers,
+                                                                data=image,
                                                                 photflam=self.image.imghdu[1].header['photflam'],
                                                                 photplam=self.image.imghdu[1].header['photplam'],
                                                                 error_array=self.image.bkg_rms_ra,
@@ -996,7 +998,9 @@ class HAPSegmentCatalog(HAPCatalogBase):
         filter_measurements_table = Table(self.source_cat.to_table())
 
         # Compute the MagIso
-        filter_measurements_table["MagIso"] = self.ab_zeropoint - 2.5 * np.log10(filter_measurements_table["source_sum"])
+        filter_measurements_table["MagIso"] = photometry_tools.convert_flux_to_abmag(filter_measurements_table["source_sum"],
+                                                                                     self.image.imghdu[1].header['photflam'],
+                                                                                     self.image.imghdu[1].header['photplam'])
 
         # Compute aperture photometry measurements and append the columns to the measurements table
         updated_table = self.do_aperture_photometry(imgarr_bkgsub, filter_measurements_table)
@@ -1071,11 +1075,11 @@ class HAPSegmentCatalog(HAPCatalogBase):
         photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers,
                                                                 bg_apers,
                                                                 data=bkg_subtracted_image,
-                                                                platescale=self.image.imgwcs.pscale,
+                                                                photflam=self.image.imghdu[1].header['photflam'],
+                                                                photplam=self.image.imghdu[1].header['photplam'],
                                                                 error_array=self.bkg.background_rms,
                                                                 bg_method=self.param_dict['salgorithm'],
-                                                                epadu=self.gain,
-                                                                zero_point=self.ab_zeropoint)
+                                                                epadu=self.gain)
 
         # Capture data computed by the photometry tools and append to the output table
         try:

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -1319,7 +1319,7 @@ def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_na
 
     if not debug:
         # Mike is going to re-work all of this to be in-memory
-        Remove _msk.fits, _NCTX.fits, and _NEXP.fits files created in this subroutine
+        # Remove _msk.fits, _NCTX.fits, and _NEXP.fits files created in this subroutine
         if os.path.exists(maskfile):
             os.remove(maskfile)
         if os.path.exists(nexp_image_ctx):

--- a/drizzlepac/hlautils/photometry_tools.py
+++ b/drizzlepac/hlautils/photometry_tools.py
@@ -142,7 +142,10 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, photflam, photplam
             flux_error = compute_phot_error(flux, bg_phot, bg_method, ap_area, epadu)
 
         mag = convert_flux_to_abmag(flux, photflam, photplam)
-        mag_err = 1.0857 * flux_error / flux # TODO: Doublecheck this
+
+        # NOTE: Magnitude error calculation comes from computing d(ABMAG)/d(flux).
+        # See https://iraf.net/forum/viewtopic.php?showtopic=83932 for details.
+        mag_err = 1.0857 * flux_error / flux
 
         # Build the final data table
         stacked = np.stack([flux, flux_error, mag, mag_err], axis=1)

--- a/drizzlepac/hlautils/photometry_tools.py
+++ b/drizzlepac/hlautils/photometry_tools.py
@@ -141,9 +141,6 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, photflam, photplam
         else:
             flux_error = compute_phot_error(flux, bg_phot, bg_method, ap_area, epadu)
 
-        #mag = zero_point - 2.5 * np.log10(flux)
-
-        #mag = -2.5 * np.log10(flux * photflam) - zero_point
         mag = convert_flux_to_abmag(flux, photflam, photplam)
         mag_err = 1.0857 * flux_error / flux # TODO: Doublecheck this
 
@@ -224,6 +221,6 @@ def convert_flux_to_abmag(in_flux, photflam, photplam):
     stmag = -2.5 * np.log10(f_lambda) - 21.10
 
     # Convert STMAG to ABMAG
-    abmag =  stmag - 5.0 * np.log10(photplam) + 18.692
+    abmag =  stmag - 5.0 * np.log10(photplam) + 18.6921
 
     return abmag

--- a/drizzlepac/hlautils/photometry_tools.py
+++ b/drizzlepac/hlautils/photometry_tools.py
@@ -199,7 +199,7 @@ def convert_flux_to_abmag(in_flux, photflam, photplam):
 
     Parameters
     ----------
-    in_flux : list
+    in_flux : astropy.table.column.Column object
         flux values to convert to ABMAG, in electrons/second
 
     photflam : float
@@ -210,7 +210,7 @@ def convert_flux_to_abmag(in_flux, photflam, photplam):
 
     Returns
     -------
-    abmag : list
+    abmag : astropy.table.column.Column object
         input flux values converted to ABMAG
     """
 

--- a/drizzlepac/hlautils/photometry_tools.py
+++ b/drizzlepac/hlautils/photometry_tools.py
@@ -63,7 +63,7 @@ from drizzlepac.hlautils.background_median import aperture_stats_tbl
 from photutils import aperture_photometry
 
 
-def iraf_style_photometry(phot_apertures, bg_apertures, data, platescale,
+def iraf_style_photometry(phot_apertures, bg_apertures, data, platescale, photflam,
                           error_array=None, bg_method='mode', epadu=1.0, zero_point=0.0):
     """
     Computes photometry with PhotUtils apertures, with IRAF formulae
@@ -81,6 +81,9 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, platescale,
 
     platescale : float
         instrument platescale in arcseconds per pixel.
+
+    photflam : float
+        inverse sensitivity, ergs/cm2/Hz/electron
 
     error_array : array
         (Optional) The array of pixelwise error of the data.  If none, the Poisson noise term in the error computation
@@ -141,8 +144,9 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, platescale,
         else:
             flux_error = compute_phot_error(flux, bg_phot, bg_method, ap_area, epadu)
 
-        mag = zero_point - 2.5 * np.log10(flux)
-        mag_err = 1.0857 * flux_error / flux
+        #mag = zero_point - 2.5 * np.log10(flux)
+        mag = -2.5 * np.log10(flux * photflam) - zero_point
+        mag_err = 1.0857 * flux_error / flux # TODO: Doublecheck this
 
         # Build the final data table
         stacked = np.stack([flux, flux_error, mag, mag_err], axis=1)


### PR DESCRIPTION
- ABMAG calculation from flux now handled by dedicated subroutine photometry_tools.convert_flux_to_abmag().
- Both point and segment code can use photometry_tools.convert_flux_to_abmag() to compute ABMAG from flux.
- Corrected units for flux columns of point catalogs from "erg cm^-2 sec^-1 Hz^-1" to "electrons/second"
- updated drizzlepac/devutils/comparison_tools/compare_sourcelists.py so that it can work with the new catalog format.




