### PR TITLE
Streamline refactoring of hla_flag_filter.hla_nexp_flags()

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -410,7 +410,11 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug =
     param_dict = filter_product_obj.configobj_pars.as_single_giant_dict()
     plate_scale = wcsutil.HSTWCS(drizzled_image, ext=('sci', 1)).pscale
     median_sky = filter_product_catalogs.image.bkg_median
-    hla_flag_filter.make_mask_file(drizzled_image)
+
+    # Create mask array that will be used by hla_flag_filter.hla_nexp_flags() for both point and segment catalogs.
+    if not hasattr(filter_product_obj, 'hla_flag_msk'):
+        filter_product_obj.hla_flag_msk = hla_flag_array.make_mask_file(drizzled_image)
+
     if filter_product_obj.configobj_pars.use_defaults:
         ci_lookup_file_path = "default_parameters/any"
     else:
@@ -432,6 +436,7 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug =
                                                                                                          catalog_data,
                                                                                                          cat_type,
                                                                                                          drz_root_dir,
+                                                                                                         filter_product_obj.hla_flag_msk,
                                                                                                          ci_lookup_file_path,
                                                                                                          output_custom_pars_file,
                                                                                                          debug)

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -413,7 +413,7 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug =
 
     # Create mask array that will be used by hla_flag_filter.hla_nexp_flags() for both point and segment catalogs.
     if not hasattr(filter_product_obj, 'hla_flag_msk'):
-        filter_product_obj.hla_flag_msk = hla_flag_array.make_mask_file(drizzled_image)
+        filter_product_obj.hla_flag_msk = hla_flag_filter.make_mask_array(drizzled_image)
 
     if filter_product_obj.configobj_pars.use_defaults:
         ci_lookup_file_path = "default_parameters/any"

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -1319,7 +1319,7 @@ def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_na
 
     if not debug:
         # Mike is going to re-work all of this to be in-memory
-        Remove _msk.fits, _NCTX.fits, and _NEXP.fits files created in this subroutine
+        # Remove _msk.fits, _NCTX.fits, and _NEXP.fits files created in this subroutine
         if os.path.exists(maskfile):
             os.remove(maskfile)
         if os.path.exists(nexp_image_ctx):

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -1200,29 +1200,6 @@ def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_na
     # if channel == 'IR':  # TODO: This was commented out in the HLA classic era, prior to adaption to the HAP pipeline. Ask Rick about it.
     #    return catalog_data
 
-    # ---------
-    # METHOD 1:
-    # ---------
-    # ctx = fits.getdata(drizzled_image, 3)
-    # if channel in ['UVIS', 'IR', 'WFC', 'HRC']:
-    #     ncombine = fits.getheader(drizzled_image, 1)['NCOMBINE']
-    # if channel in ['WFPC2', 'PC']:
-    #     ndrizim = fits.getheader(drizzled_image, 0)['NDRIZIM']
-    #     # ncombine = ndrizim/4
-    # if channel == 'SBC':
-    #     ndrizim = fits.getheader(drizzled_image, 0)['NDRIZIM']
-        # ncombine = ndrizim
-    # ctxarray = arrayfy_ctx(ctx, ncombine)
-
-    # nexp_array_ctx = ctxarray.sum(axis=-1)
-    # nexp_image_ctx = drizzled_image.split('.')[0]+'_NCTX.fits'
-    # if not os.path.isfile(nexp_image_ctx):
-    #     hdr = fits.getheader(drizzled_image, 1)
-    #     fits.writeto(nexp_image_ctx, numpy.float32(nexp_array_ctx), hdr)
-
-    # ---------
-    # METHOD 2:
-    # ---------
     drz_data = fits.getdata(drizzled_image, 1)
 
     component_drz_img_list = get_component_drz_list(drizzled_image, drz_root_dir, flt_list)
@@ -1292,7 +1269,6 @@ def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_na
     gy = gy[w]
 
     # check the pixel values for low nexp
-
     # this version uses numpy broadcasting sum gx+ix is [len(gx), nrows]
     gx = (gx[:, numpy.newaxis] + ix).clip(0, nexp_array.shape[0]-1)
     gy = (gy[:, numpy.newaxis] + iy).clip(0, nexp_array.shape[1]-1)
@@ -1310,11 +1286,6 @@ def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_na
         phot_table_temp = phot_table_root + '_NEXPFILT.txt'
         catalog_data.write(phot_table_temp, delimiter=",", format='ascii')
 
-    # if not debug:
-    #     # Mike is going to re-work all of this to be in-memory
-    #     # Remove _msk.fits, _NCTX.fits, and _NEXP.fits files created in this subroutine
-    #     if os.path.exists(nexp_image_ctx):
-    #         os.remove(nexp_image_ctx)
     return catalog_data
 
 # ======================================================================================================================
@@ -1596,62 +1567,6 @@ def xytord(xy_coord_array, image, image_ext):
     except AttributeError:
         rd_arr = wcs.all_pix2world(xy_coord_array, 1)
     return (rd_arr)
-
-# ======================================================================================================================
-
-
-# def arrayfy_ctx(ctx, maxindex):
-#
-#     """Function to turn the context array returned by AstroDrizzle
-#     into a bit datacube with the third dimension equal to maxindex.
-#     Requires care since vanilla python seems to be a bit loose with
-#     data types, while arrays in numpy are strictly typed.
-#     Comments indicate the why of certain operations.
-#     Current version requires maxindex to be specified.  In upgrade, could
-#     estimate maxindex from the highest non-zero bit set in ctx.
-#     (In principle maxindex can be greater, if the last images contribute
-#     to no pixels, or smaller, if the calling routine chooses to ignore
-#     the contribution of further images.)
-#
-#     Per AstroDrizzle specifications, ctx can be a 2-dimensional or 3-dimensional
-#     array of 32-bit integers.  It will be 2-dimensional if fewer than 32 images
-#     are combined; 3-dimensional if more images are combined, in which case the
-#     ctx[:, :, 0] contains the bit values for images 1-32, ctx[:, :, 1] for images
-#     33-64, and so forth.
-#
-#     Parameters
-#     ----------
-#     ctx : numpy.ndarray
-#         input context array to be converted
-#
-#     maxindex : int
-#         maximum index value to process
-#
-#     Returns
-#     -------
-#     ctxarray : numpy.ndarray
-#         ctxarray, The input context array converted to datacube form.
-#     """
-#     nx = ctx.shape[0]
-#     ny = ctx.shape[1]
-#     nz = 1
-#     if ctx.ndim > 2:
-#         nz = ctx.shape[2]
-#     n3 = maxindex
-#     # Need to find out how to handle the case in which maxindex is not specified
-#
-#     ctxarray = numpy.zeros((nx, ny, n3), dtype="bool")
-#     comparison = numpy.zeros((nx, ny), dtype="int32")
-#
-#     for i in range(n3):
-#         ilayer = int(i/32)
-#         ibit = i - 32*ilayer
-#         cc = comparison + 2**ibit
-#         if nz > 1:
-#             ctxarray[:, :, i] = numpy.bitwise_and(ctx[:, :, ilayer], cc)
-#         else:
-#             ctxarray[:, :, i] = numpy.bitwise_and(ctx[:, :], cc)
-#     return ctxarray
 
 # ======================================================================================================================
 


### PR DESCRIPTION
- hla_flag_filter.make_mask_file() renamed hla_flag_filter.make_mask_array()
- Modified said subroutine to return the mask array rather than write it to a file
- Updated hla_flag_filter to accept mask array data as input and pass it to hla_nexp_flags()
- Updated hla_nexp_flags code to use in-memory mask array rather than data from _msk.fits file
- Updated hapsequencer.run_sourcelist_flagging() to store the mask array generated by make_mask_array() as an filter_prod_obj attribute if it doesn't already exist so that it can be used for both point and segment hla_flag_filter() runs. This also solves the problem of the code crashing because the mask fits file was being deleted after the point catalog and was not available for the segment hla_flag_filter() run.

- Removed a few lines of code that created unnecessary <drizzled_image>_NEXP.fits file.
- Realized that all 'ctxarray' is created but never actually used in anywhere in hla_nexp_flags(). Removed all hla_nexp_flags() lines that are are in any way related to ctxarray and the creation of the <drizzled_image>_NCTX.fits file.
- Removed now unused subroutine hla_flag_filter. arrayfy_ctx()