### PR TITLE
Revise logging

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -3,7 +3,6 @@
 """This script is a modernized implementation of tweakreg.
 
 """
-import argparse
 import copy
 import datetime
 import sys
@@ -15,19 +14,13 @@ from collections import OrderedDict
 import traceback
 
 import numpy as np
-from astropy.io import fits
 from astropy.table import Table
-from astropy.coordinates import SkyCoord, Angle
-from astropy import units as u
-from stsci.tools import fileutil, logutil
-from stwcs.wcsutil import headerlet, HSTWCS
-import tweakwcs
 
-from . import updatehdr
+from stsci.tools import logutil
+
 from . import util
 from .hlautils import astrometric_utils as amutils
 from .hlautils import astroquery_utils as aqutils
-from .hlautils import analyze as filter
 from .hlautils import get_git_rev_info
 from .hlautils import align_utils
 
@@ -45,7 +38,6 @@ MAS_TO_ARCSEC = 1000.  # Conversion factor from milli-arcseconds to arcseconds
 
 
 log = logutil.create_logger('alignimages', level=logutil.logging.INFO, stream=sys.stdout)
-
 
 __version__ = 0.0
 __version_date__ = '21-Aug-2019'

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -16,10 +16,9 @@ import traceback
 
 import numpy as np
 from astropy.io import fits
-from astropy.table import Table, vstack
+from astropy.table import Table
 from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
-from scipy.stats import pearsonr
 from stsci.tools import fileutil, logutil
 from stwcs.wcsutil import headerlet, HSTWCS
 import tweakwcs
@@ -1249,7 +1248,7 @@ def generate_source_catalogs(imglist, **pars):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def update_image_wcs_info(tweakwcs_output,headerlet_filenames=None):
+def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None):
     """Write newly computed WCS information to image headers and write headerlet files
 
         Parameters
@@ -1304,7 +1303,7 @@ def update_image_wcs_info(tweakwcs_output,headerlet_filenames=None):
         ext = sci_ext_dict["{}".format(item.meta['chip'])]
         updatehdr.update_wcs(hdulist, ext, item.wcs,
                              wcsname=wcs_name,
-                             reusename=True, verbose=True)
+                             reusename=True)
         hdulist[ext].header['hdrname'] = hdrname
         log.info("Updated {} with WCSTYPE of {}\n".format(ext, wcstype))
 

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -228,6 +228,8 @@ def run(configobj, wcsmap=None):
         print()
         print("AstroDrizzle Version {:s} is finished processing at {:s}.\n"
               .format(__version__, util._ptime()[0]))
+        print("", flush=True)
+
 
     except:
         clean = False

--- a/drizzlepac/hapcatalog.py
+++ b/drizzlepac/hapcatalog.py
@@ -3,7 +3,6 @@ import argparse
 import datetime
 
 import os
-import pdb
 import sys
 
 from stsci.tools import logutil

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -299,7 +299,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
 
         # The product_list is a list of all the output products which will be put into the manifest file
         product_list = []
-        sys.exit(-1)
+
         # Update all of the product objects with their associated configuration information.
         for total_item in total_list:
             total_item.configobj_pars = config_utils.HapConfig(total_item,

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -22,7 +22,8 @@ from stsci.tools import logutil
 from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
-log = logutil.create_logger('hapsequencer', level=logutil.logging.INFO, stream=sys.stdout)
+log_level = logutil.logging.INFO
+log = logutil.create_logger('hapsequencer', level=log_level, stream=sys.stdout)
 
 __version__ = 0.1
 __version_date__ = '19-Mar-2019'
@@ -220,7 +221,8 @@ def create_drizzle_products(total_list):
 
 
 def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
-                       input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both"):
+                       input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
+                       log_level=logutil.logging.INFO):
     """
     Run the HST Advanced Products (HAP) generation code.  This routine is the sequencer or
     controller which invokes the high-level functionality to process the single visit data.
@@ -265,6 +267,17 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
     # Condor/OWL workflow code: 0 (zero) for success, 1 for error condition
     return_value = 0
 
+    # Define trailer file (log file) that will contain the log entries for all processing
+    if isinstance(input_filename, str):  # input file is a poller file -- easy case
+        trlroot = input_filename.replace('.out', '.log')
+    else:
+        trlroot = 'svm_process.log'
+    # attach trailer file to logger
+    fh = logutil.logging.FileHandler(trlroot)
+    fh.setLevel(log_level)
+    log.addHandler(fh)
+
+    # start processing
     starting_dt = datetime.datetime.now()
     log.info("Run start time: {}".format(str(starting_dt)))
     product_list = []

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -11,6 +11,7 @@ import glob
 import os
 import sys
 import traceback
+import logging
 
 import drizzlepac
 from drizzlepac.hlautils.catalog_utils import HAPCatalogs
@@ -22,13 +23,14 @@ from stsci.tools import logutil
 from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
-log_level = logutil.logging.INFO
+log_level = logging.INFO
 log = logutil.create_logger('hapsequencer', level=log_level, stream=sys.stdout)
+# log = logging.getLogger(__name__)
 
 __version__ = 0.1
 __version_date__ = '19-Mar-2019'
 
-# ----------------------------------------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------------------
 
 def create_catalog_products(total_list, debug=False, phot_mode='both'):
     """This subroutine utilizes hlautils/catalog_utils module to produce photometric sourcelists for the specified
@@ -269,13 +271,11 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
 
     # Define trailer file (log file) that will contain the log entries for all processing
     if isinstance(input_filename, str):  # input file is a poller file -- easy case
-        trlroot = input_filename.replace('.out', '.log')
+        logname = input_filename.replace('.out', '.log')
     else:
-        trlroot = 'svm_process.log'
-    # attach trailer file to logger
-    fh = logutil.logging.FileHandler(trlroot)
-    fh.setLevel(log_level)
-    log.addHandler(fh)
+        logname = 'svm_process.log'
+    print("Trailer filename: {}".format(logname))
+    logging.basicConfig(filename=logname)
 
     # start processing
     starting_dt = datetime.datetime.now()
@@ -291,6 +291,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         log.info("Parse the poller and determine what exposures need to be combined into separate products.\n")
         obs_info_dict, total_list = poller_utils.interpret_obset_input(input_filename)
 
+        k = input("Continue??")
         # Generate the name for the manifest file which is for the entire visit.  It is fine
         # to use only one of the Total Products to generate the manifest name as the name is not
         # dependent on the detector.

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -279,6 +279,8 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
     else:
         logname = 'svm_process.log'
     print("Trailer filename: {}".format(logname))
+    # Initialize total trailer filename as temp logname
+    total_trl_file = logname
     logging.basicConfig(filename=logname)
 
     # start processing

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -299,7 +299,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
 
         # The product_list is a list of all the output products which will be put into the manifest file
         product_list = []
-
+        sys.exit(-1)
         # Update all of the product objects with their associated configuration information.
         for total_item in total_list:
             total_item.configobj_pars = config_utils.HapConfig(total_item,

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -25,10 +25,9 @@ from stwcs import wcsutil
 __taskname__ = 'hapsequencer'
 log_level = logging.INFO
 log = logutil.create_logger('hapsequencer', level=log_level, stream=sys.stdout)
-# log = logging.getLogger(__name__)
 
 __version__ = 0.1
-__version_date__ = '19-Mar-2019'
+__version_date__ = '07-Nov-2019'
 
 # --------------------------------------------------------------------------------------------------------------
 
@@ -291,7 +290,6 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         log.info("Parse the poller and determine what exposures need to be combined into separate products.\n")
         obs_info_dict, total_list = poller_utils.interpret_obset_input(input_filename)
 
-        k = input("Continue??")
         # Generate the name for the manifest file which is for the entire visit.  It is fine
         # to use only one of the Total Products to generate the manifest name as the name is not
         # dependent on the detector.
@@ -384,9 +382,11 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
     finally:
-        log.info('Total processing time: {} sec'.format((datetime.datetime.now() - starting_dt).total_seconds()))
-        log.info("Return exit code for use by calling Condor/OWL workflow code: 0 (zero) for success, 1 for error "
-                 "condition {}".format(return_value))
+        end_dt = datetime.datetime.now()
+        log.info('Processing completed at {}'.format(str(end_dt)))
+        log.info('Total processing time: {} sec'.format((end_dt - starting_dt).total_seconds()))
+        log.info("Return exit code for use by calling Condor/OWL workflow code: 0 (zero) for success, 1 for error ")
+        log.info("Return condition {}".format(return_value))
         return return_value
 
 

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -1,7 +1,7 @@
 import os
-import sys
 import datetime
 import copy
+import sys
 
 from collections import OrderedDict
 
@@ -15,7 +15,7 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 
 import photutils
-from photutils import Background2D, SExtractorBackground, StdBackgroundRMS
+from photutils import Background2D
 
 from stwcs.wcsutil import HSTWCS
 from stwcs.wcsutil import headerlet
@@ -38,7 +38,6 @@ CATALOG_TYPES = ['point', 'segment']
 MIN_CATALOG_THRESHOLD = 3
 
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
-
 
 class AlignmentTable:
     def __init__(self, input_list, clobber=False, dqname='DQ', **alignment_pars):
@@ -196,7 +195,6 @@ class AlignmentTable:
         # Protect the writing of the table within the best_fit_rms
         info_keys = OrderedDict(imglist[0].meta['fit_info']).keys()
         # Update filtered table with number of matched sources and other information
-        print(imglist[0].meta)
         for item in imglist:
             imgname = item.meta['name']
             index = np.where(self.filtered_table['imageName'] == imgname)[0][0]
@@ -742,15 +740,17 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
                 sci_ext_dict["{}".format(sci_ext_ctr)] = fileutil.findExtname(hdulist, 'sci', extver=sci_ext_ctr)
 
         # update header with new WCS info
-        updatehdr.update_wcs(hdulist, sci_ext_dict["{}".format(item.meta['chip'])], item.wcs, wcsname=wcs_name,
-                                 reusename=True, verbose=True)
+        updatehdr.update_wcs(hdulist, sci_ext_dict["{}".format(item.meta['chip'])], item.wcs,
+                             wcsname=wcs_name,
+                             reusename=True)
         if chipctr == num_sci_ext:
             # Close updated flc.fits or flt.fits file
             hdulist.flush()
             hdulist.close()
 
             # Create headerlet
-            out_headerlet = headerlet.create_headerlet(image_name, hdrname=wcs_name, wcsname=wcs_name, logging=False)
+            out_headerlet = headerlet.create_headerlet(image_name, hdrname=wcs_name, wcsname=wcs_name,
+                                                       logging=False)
 
             # Update headerlet
             update_headerlet_phdu(item, out_headerlet)

--- a/drizzlepac/hlautils/analyze.py
+++ b/drizzlepac/hlautils/analyze.py
@@ -8,6 +8,7 @@ to create a mosaic.
 """
 import math
 import sys
+
 from enum import Enum
 from astropy.io.fits import getheader
 from astropy.table import Table

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -68,7 +68,6 @@ __taskname__ = 'astrometric_utils'
 
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
 
-
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = 'http://gsss.stsci.edu/webservices'
 

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -1,6 +1,7 @@
 """Wrappers for astroquery-related functionality"""
 import shutil
 import os
+
 try:
     from astroquery.mast import Observations
 except FileExistsError:
@@ -14,7 +15,6 @@ __taskname__ = 'astroquery_utils'
 log = logutil.create_logger(__name__,
                             level=logutil.logging.INFO,
                             stream=sys.stdout)
-
 
 def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
     """Simple interface for retrieving an observation from the MAST archive

--- a/drizzlepac/hlautils/ci_table.py
+++ b/drizzlepac/hlautils/ci_table.py
@@ -9,8 +9,8 @@ ci_ap_cor_table_ap_20_2016.txt
 
 
 """
-import os, sys
-import pdb
+import os
+import sys
 
 from stsci.tools import logutil
 
@@ -23,7 +23,7 @@ ci_table = None
 def read_ci_apcorr_file(ci_lookup_file_path, debug=False, infile_name='ci_ap_cor_table_ap_20_2016.txt'):
 
     """Read the table of CI values
-    
+
     Parameters
     ----------
     ci_lookup_file_path : string

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -61,7 +61,7 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
                              catalog_name, catalog_data, proc_type, drz_root_dir, hla_flag_msk, ci_lookup_file_path,
                              output_custom_pars_file, debug=True):
     """Simple calling subroutine that executes the other flagging subroutines.
-    
+
     Parameters
     ----------
     drizzled_image : string
@@ -70,7 +70,7 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
     flt_list : list
         list of calibrated images that were drizzle-combined to produce image specified by input parameter
         'drizzled_image'
-    
+
     param_dict : dictionary
         Dictionary of instrument/detector - specific drizzle, source finding and photometric parameters
 
@@ -106,7 +106,7 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
 
     debug : bool
         write intermediate files?
-    
+
     Returns
     -------
     catalog_data : astropy.Table object
@@ -585,7 +585,7 @@ def hla_swarm_flags(drizzled_image, catalog_name, catalog_data, exptime, plate_s
     ----------
     drizzled_image : string
         Name of drizzled image to process
-    
+
     catalog_name : string
         drizzled filter product catalog filename to process
 
@@ -612,7 +612,7 @@ def hla_swarm_flags(drizzled_image, catalog_name, catalog_data, exptime, plate_s
 
     debug : bool
         write intermediate files?
-    
+
     Returns
     -------
     catalog_data : astropy.Table object
@@ -1155,7 +1155,7 @@ def hla_swarm_flags(drizzled_image, catalog_name, catalog_data, exptime, plate_s
 def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_name, catalog_data, drz_root_dir,
                    mask_data, column_titles, debug):
     """flags out sources from regions where there are a low (or a null) number of contributing exposures
-   
+
     drizzled_image : string
         Name of drizzled image to process
 
@@ -1269,6 +1269,7 @@ def hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_na
     gy = gy[w]
 
     # check the pixel values for low nexp
+
     # this version uses numpy broadcasting sum gx+ix is [len(gx), nrows]
     gx = (gx[:, numpy.newaxis] + ix).clip(0, nexp_array.shape[0]-1)
     gy = (gy[:, numpy.newaxis] + iy).clip(0, nexp_array.shape[1]-1)
@@ -1404,27 +1405,27 @@ def xymatch(cat1, cat2, sep, multiple=False, stack=True, verbose=True):
 
     Marcel Haas, 2012-06-29, after IDL routine xymatch.pro by Rick White
     With some tweaks by Rick White
-    
+
     Parameters
     ----------
     cat1 : numpy.ndarray
         list of x,y source coords to match.
-    
+
     cat2 : numpy.ndarray
         list of x,y source coords to match.
-    
+
     sep : float
         maximum separation (in pixels) allowed for source matching.
-    
+
     multiple : Boolean
         If multiple is true, returns a tuple (p1,p2) such that cat1[p1] and cat2[p2] are within sep.
         p1 and p2 may include multiple pointers to the same objects in cat1 or cat2.  In this case objects that don't
         match are simply omitted from the lists. Default value is 'False'.
-    
+
     stack : Boolean
         If stack is true, the returned matching pointers are stacked into a single big array, so both p1 and p2 are 1-D
         arrays of length nmatches. Default value is 'True'.
-    
+
     verbose : Boolean
         print verbose output? Default value is 'True'.
 
@@ -1519,13 +1520,13 @@ def rdtoxy(rd_coord_array, image, image_ext):
 
     rd_coord_array : numpy.ndarray
         array containing RA and dec values to convert.
-    
+
     image : string
-        drizzled image whose WCS info will be used in the coordinate conversion. 
-    
+        drizzled image whose WCS info will be used in the coordinate conversion.
+
     image_ext : string
         fits image extension to be used in the conversion.
-    
+
     Returns
     xy_arr: array
         array of converted x, y coordinate value pairs

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -56,7 +56,7 @@ __taskname__ = 'hla_flag_filter'
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
 
 
-@util.with_logging
+#@util.with_logging
 def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plate_scale, median_sky,
                              catalog_name, catalog_data, proc_type, drz_root_dir, hla_flag_msk, ci_lookup_file_path,
                              output_custom_pars_file, debug=True):

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -46,7 +46,7 @@ import scipy
 import scipy.ndimage
 
 from drizzlepac.hlautils import ci_table
-from drizzlepac import util
+# from drizzlepac import util
 from stsci.tools import logutil
 from stwcs import wcsutil
 

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -28,7 +28,9 @@ POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
                     'exptime', 'filters', 'detector', 'pathname']
 
 __taskname__ = 'poller_utils'
-log = logutil.create_logger('poller_utils', level=logutil.logging.INFO, stream=sys.stdout)
+# log = logutil.create_logger('poller_utils', level=logutil.logging.INFO, stream=sys.stdout)
+log = logging.getLogger('poller_utils')
+log.setLevel(logging.INFO)
 
 def interpret_obset_input(results):
     """

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -27,8 +27,8 @@ INSTRUMENT_DICT = {'i': 'WFC3', 'j': 'ACS', 'o': 'STIS', 'u': 'WFPC2', 'x': 'FOC
 POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
                     'exptime', 'filters', 'detector', 'pathname']
 
-__taskname__ = 'drizzlepac.poller_utils'
-log = logutil.create_logger('poller_utils', level=logutil.logging.INFO, stream=sys.stdout)
+__taskname__ = 'poller_utils'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
 
 def interpret_obset_input(results):
     """

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -27,10 +27,9 @@ INSTRUMENT_DICT = {'i': 'WFC3', 'j': 'ACS', 'o': 'STIS', 'u': 'WFPC2', 'x': 'FOC
 POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
                     'exptime', 'filters', 'detector', 'pathname']
 
-__taskname__ = 'poller_utils'
+__taskname__ = 'drizzlepac.poller_utils'
 # log = logutil.create_logger('poller_utils', level=logutil.logging.INFO, stream=sys.stdout)
-log = logging.getLogger('poller_utils')
-log.setLevel(logging.INFO)
+log.getLogger(__name__)
 
 def interpret_obset_input(results):
     """

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -28,8 +28,7 @@ POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
                     'exptime', 'filters', 'detector', 'pathname']
 
 __taskname__ = 'drizzlepac.poller_utils'
-# log = logutil.create_logger('poller_utils', level=logutil.logging.INFO, stream=sys.stdout)
-log.getLogger(__name__)
+log = logutil.create_logger('poller_utils', level=logutil.logging.INFO, stream=sys.stdout)
 
 def interpret_obset_input(results):
     """

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -8,6 +8,7 @@ parse_obset_tree, converts the tree into product catagories.
 import os
 import sys
 from collections import OrderedDict
+import numpy as np
 
 from stsci.tools import logutil
 
@@ -141,7 +142,7 @@ def build_obset_tree(obset_table):
 
 def create_row_info(row):
     """Build info string for a row from the obset table"""
-    info_list = [str(row['proposal_id']), "{:02d}".format(row['obset_id']), row['instrument'],
+    info_list = [str(row['proposal_id']), "{:s}".format(row['obset_id']), row['instrument'],
                  row['detector'], row['filename'][:row['filename'].find('_')], row['filters']]
     return ' '.join(map(str.upper, info_list)), row['filename']
 
@@ -318,6 +319,9 @@ def build_poller_table(input):
             # Now assign column names to obset_table
             for i, colname in enumerate(POLLER_COLNAMES):
                 input.columns[i].name = colname
+
+            # Convert to a string column, instead of int64
+            input['obset_id'] = input['obset_id'].astype(np.str)
             return input
 
         # Return first column
@@ -356,7 +360,7 @@ def build_poller_table(input):
         with fits.open(d) as dhdu:
             hdr = dhdu[0].header
             cols['program_id'].append(d[1:4].upper())
-            cols['obset_id'].append(int(d[4:6]))
+            cols['obset_id'].append(str(d[4:6]))
             cols['proposal_id'].append(hdr['proposid'])
             cols['exptime'].append(hdr['exptime'])
             cols['detector'].append(hdr['detector'])

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -227,3 +227,27 @@ def _process_input(input):
             raise ValueError
 
     return hdu, closefits
+    
+def appendTrlFile(trlfile, drizfile):
+    """ Append log file to already existing log or trailer file.
+    """
+    if not os.path.exists(drizfile):
+        return
+    # Open already existing trailer file for appending
+    ftrl = open(trlfile, 'a')
+    # Open astrodrizzle trailer file
+    fdriz = open(drizfile)
+
+    # Read in drizzle comments
+    _dlines = fdriz.readlines()
+
+    # Append them to CALWF3 trailer file
+    ftrl.writelines(_dlines)
+
+    # Close all files
+    ftrl.close()
+    fdriz.close()
+
+    # Now, clean up astrodrizzle trailer file
+    os.remove(drizfile)
+

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -16,7 +16,7 @@ from . import align_utils
 from . import astrometric_utils as amutils
 from . import cell_utils
 
-log = logutil.create_logger('product', level=logutil.logging.INFO, stream=sys.stdout)
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
 
 class HAPProduct:
     """ HAPProduct is the base class for the various products generated during the

--- a/drizzlepac/hlautils/se_source_generation.py
+++ b/drizzlepac/hlautils/se_source_generation.py
@@ -14,23 +14,23 @@ is the output of the routine.
 
 """
 import sys
-from distutils.version import LooseVersion
+# from distutils.version import LooseVersion
 
-import numpy as np
+# import numpy as np
 try:
     from matplotlib import pyplot as plt
 except Exception:
     plt = None
 
 import astropy.units as u
-from astropy.io import ascii
+# from astropy.io import ascii
 from astropy.io import fits as fits
 from astropy.table import Column, Table
 from astropy.convolution import Gaussian2DKernel, MexicanHat2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
-import photutils
-from photutils import detect_sources, source_properties, deblend_sources
-from photutils import Background2D, MedianBackground, SExtractorBackground, StdBackgroundRMS
+# import photutils
+# from photutils import detect_sources, source_properties, deblend_sources
+# from photutils import Background2D, MedianBackground, SExtractorBackground, StdBackgroundRMS
 from stwcs.wcsutil import HSTWCS
 from stsci.tools import logutil
 

--- a/drizzlepac/hlautils/sourcelist_generation.py
+++ b/drizzlepac/hlautils/sourcelist_generation.py
@@ -6,7 +6,6 @@
 import pdb
 import sys
 
-
 from astropy.io import fits
 from astropy.stats import mad_std
 import numpy as np

--- a/drizzlepac/hlautils/testutils.py
+++ b/drizzlepac/hlautils/testutils.py
@@ -36,7 +36,7 @@ def compare_wcs_alignment(dataset, force=False):
         results : dict
             A dictionary whose keys are the WCS's found and fit to GAIA.
             Each WCS has entries for:
-            
+
                 * imageName - filenames of input exposures included in the fit
                 * offset_x - offset in X (pixels)
                 * offset_y - offset in X (pixels)

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -18,14 +18,14 @@ Python USAGE:
 import argparse
 
 import sys
-# import logging
+import logging
 
 # THIRD-PARTY
 from stsci.tools import logutil
 
 from drizzlepac import hapsequencer
 
-__taskname__ = "drizzlepac.runsinglehap"
+__taskname__ = "runsinglehap"
 
 # Local variables
 __version__ = "0.1.1"
@@ -33,18 +33,11 @@ __version_date__ = "(16-Oct-2019)"
 #
 # These lines (or something similar) will be needed in the HAP processing code
 #
-log = logutil.create_logger('drizzlepac.runsinglehap', level=logutil.logging.INFO, stream=sys.stdout)
+log = logutil.create_logger('runsinglehap', level=logutil.logging.INFO, stream=sys.stdout)
+# Any module which uses 'util.with_logging' should be added separately here...
 # logging.getLogger('astrodrizzle').addHandler(log)
 # logging.getLogger('alignimages').addHandler(log)
 
-"""
-#
-# These lines (or something similar) will be needed in the HAP processing code
-#
-log = logutil.create_logger('runsinglehap', level=logutil.logging.INFO, stream=sys.stdout)
-logging.getLogger('astrodrizzle').addHandler(log)
-logging.getLogger('alignimages').addHandler(log)
-"""
 # ----------------------------------------------------------------------------------------------------------------------
 
 def perform(input_filename, **kwargs):
@@ -66,6 +59,7 @@ def perform(input_filename, **kwargs):
         a simple status value. '0' for a successful run and '1' for a failed
         run
     """
+    log.info("Starting single-visit processing of {}".format(input_filename))
     return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
     return return_value
 

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -17,19 +17,26 @@ Python USAGE:
 # Import standard Python modules
 import argparse
 
-# import sys
+import sys
 # import logging
 
 # THIRD-PARTY
-# from stsci.tools import logutil
+from stsci.tools import logutil
 
 from drizzlepac import hapsequencer
 
-__taskname__ = "runsinglehap"
+__taskname__ = "drizzlepac.runsinglehap"
 
 # Local variables
 __version__ = "0.1.1"
 __version_date__ = "(16-Oct-2019)"
+#
+# These lines (or something similar) will be needed in the HAP processing code
+#
+log = logutil.create_logger('drizzlepac.runsinglehap', level=logutil.logging.INFO, stream=sys.stdout)
+# logging.getLogger('astrodrizzle').addHandler(log)
+# logging.getLogger('alignimages').addHandler(log)
+
 """
 #
 # These lines (or something similar) will be needed in the HAP processing code

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -152,7 +152,7 @@ def end_logging(filename=None):
             # This generally shouldn't happen if logging was started with
             # init_logging and a filename was given...
             print('No trailer file saved...')
-        
+
         logutil.teardown_global_logging()
     else:
         print('No trailer file saved...')
@@ -321,6 +321,7 @@ class ProcSteps:
         """
         ptime = _ptime()
         print('==== Processing Step ',key,' started at ',ptime[0])
+        print("", flush=True)
         self.steps[key] = {'start':ptime}
         self.order.append(key)
 
@@ -337,8 +338,7 @@ class ProcSteps:
             self.steps[key]['elapsed'] = ptime[1] - self.steps[key]['start'][1]
         self.end = ptime
 
-        print('==== Processing Step ',key,' finished at ',ptime[0])
-        print('')
+        print('==== Processing Step {} finished at {}'.format(key,ptime[0]), flush=True)
 
     def reportTimes(self):
         """
@@ -359,6 +359,7 @@ class ProcSteps:
 
         print('   %20s          %s' % ('=' * 20, '=' * 20))
         print('   %20s          %0.4f sec.' % ('Total', total_time))
+        print("", flush=True)
 
         # Compute overall runtime of entire program, including overhead
         #total = self.end[1] - self.start[1]
@@ -616,7 +617,7 @@ def verifyFilePermissions(filelist, chmod=True):
             print('    %s'%(img))
         print('\nPlease reset permissions for these files and restart...')
         print('#'*40)
-        print('\n')
+        print('\n', flush=True)
         filelist = None
 
     return filelist
@@ -805,7 +806,7 @@ def printParams(paramDictionary, all=False, log=None):
             log.info(msg)
     else:
         def output(msg):
-            print(msg)
+            print(msg, flush=True)
 
     if not paramDictionary:
         output('No parameters were supplied')


### PR DESCRIPTION
These changes implement a single file as the full log of all processing that takes place for a single visit through `runsinglehap`.  This logging relies entirely on Python's basic logging functionality, with standardized, Python-recommended setup being performed by `stsci.tools.logutil`.

In addition, I addressed some syntax (PEP8) issues and removed some extraneous import statements as well.  
