### PR TITLE
Initial attempt to update poller file input formats

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -437,7 +437,3 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug =
                                                                                                          debug)
 
     return filter_product_catalogs
-
-
-
-

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -81,9 +81,6 @@ def interpret_obset_input(results):
     """
     log.info("Interpret the poller file for the observation set.")
     obset_table = build_poller_table(results)
-    # Now assign column names to obset_table
-    for i, colname in enumerate(POLLER_COLNAMES):
-        obset_table.columns[i].name = colname
 
     # Add INSTRUMENT column
     instr = INSTRUMENT_DICT[obset_table['filename'][0][0]]
@@ -367,4 +364,9 @@ def build_poller_table(input):
     # Build output table
     poller_data = [col for col in cols.values()]
     poller_table = Table(data=poller_data)
+
+    # Now assign column names to obset_table
+    for i, colname in enumerate(POLLER_COLNAMES):
+        poller_table.columns[i].name = colname
+
     return poller_table

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -313,9 +313,15 @@ def build_poller_table(input):
     """
     if isinstance(input, str):
         input = Table.read(input, format='ascii.fast_no_header')
+        if len(input.columns) == len(POLLER_COLNAMES):
+            # We were provided a poller file, so use as-is
+            # Now assign column names to obset_table
+            for i, colname in enumerate(POLLER_COLNAMES):
+                input.columns[i].name = colname
+            return input
+
         # Return first column
         filenames = input[input.colnames[0]].tolist()
-
     elif isinstance(input, list):
         filenames = input
 

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -49,7 +49,7 @@ def refine_product_headers(product, total_obj_list):
         Filename or HDUList object for product to be updated
 
     total_obj_list: list
-        List of TotalProduct objects which are composed of Filter and Exposure 
+        List of TotalProduct objects which are composed of Filter and Exposure
         Product objects
 
     """
@@ -107,13 +107,15 @@ def refine_product_headers(product, total_obj_list):
     if closefits:
         hdu.close()
 
-def get_acs_filters(image, delimiter=';'):
+def get_acs_filters(image, delimiter=';', all=False):
     hdu, closefits = _process_input(image)
     filters = [kw[1] for kw in hdu[0].header['filter?'].items()]
+    print(filters)
     acs_filters = []
     for f in filters:
-        if 'clear' not in f.lower():
+        if ('clear' not in f.lower() and not all) or all:
             acs_filters.append(f)
+
     if not acs_filters:
         acs_filters = ['clear']
     acs_filters = delimiter.join(acs_filters)

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -110,7 +110,6 @@ def refine_product_headers(product, total_obj_list):
 def get_acs_filters(image, delimiter=';', all=False):
     hdu, closefits = _process_input(image)
     filters = [kw[1] for kw in hdu[0].header['filter?'].items()]
-    print(filters)
     acs_filters = []
     for f in filters:
         if ('clear' not in f.lower() and not all) or all:


### PR DESCRIPTION
A request was made a while ago to support simpler input formats than the poller files.  This PR attempts to provide support for either a list of dataset names (singleton or ASN filenames only) or a poller file.  

This implementation replaces a simple Table.read() call with a call to a new function which interprets the input as either a list (assuming it is a list of dataset filenames) or a poller file.  If a list if provided, it will use astroquery to make sure all requested files are in the local directory without clobbering any that may already be present, and build a poller file in memory.  This function then returns the poller_table with column names as an in-memory object. 