### PR TITLE
Reset num_cores to 1 for all astrodrizzle processes

### DIFF
--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_filter_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_filter_hap_basic.json
@@ -9,7 +9,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": true,
     "_mdriztab_btn_": "Update From MDRIZTAB",
     "STATE OF INPUT FILES": {

--- a/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_n1.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_n1.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_single_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_single_hap_basic.json
@@ -9,7 +9,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "0",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": true,
     "_mdriztab_btn_": "Update From MDRIZTAB",
     "STATE OF INPUT FILES": {

--- a/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_total_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/any/any_astrodrizzle_total_hap_basic.json
@@ -9,7 +9,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "0",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": true,
     "_mdriztab_btn_": "Update From MDRIZTAB",
     "STATE OF INPUT FILES": {

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_filter_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_filter_hap_basic.json
@@ -9,7 +9,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": true,
     "_mdriztab_btn_": "Update From MDRIZTAB",
     "STATE OF INPUT FILES": {

--- a/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_n1.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_n1.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": false,

--- a/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_single_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_single_hap_basic.json
@@ -9,7 +9,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "0",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": true,
     "_mdriztab_btn_": "Update From MDRIZTAB",
     "STATE OF INPUT FILES": {

--- a/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_total_hap_basic.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/any/any_astrodrizzle_total_hap_basic.json
@@ -9,7 +9,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "0",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": true,
     "_mdriztab_btn_": "Update From MDRIZTAB",
     "STATE OF INPUT FILES": {

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
@@ -10,7 +10,7 @@
     "crbit": 4096,
     "stepsize": 10,
     "resetbits": "4096",
-    "num_cores": null,
+    "num_cores": 1,
     "in_memory": false,
     "STEP 1: STATIC MASK": {
         "static": true,


### PR DESCRIPTION
Reset value of `num_cores` parameter in all `astrodrizzle` JSON cfg files to 1 in order to minimize problems with resources when performing single-visit processing. 