### PR TITLE
Get log files written out correctly for multiple TDP

### DIFF
--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -46,7 +46,6 @@ import scipy
 import scipy.ndimage
 
 from drizzlepac.hlautils import ci_table
-# from drizzlepac import util
 from stsci.tools import logutil
 from stwcs import wcsutil
 
@@ -56,7 +55,6 @@ __taskname__ = 'hla_flag_filter'
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
 
 
-#@util.with_logging
 def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plate_scale, median_sky,
                              catalog_name, catalog_data, proc_type, drz_root_dir, hla_flag_msk, ci_lookup_file_path,
                              output_custom_pars_file, debug=True):
@@ -132,7 +130,8 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
     log.info("************************** * * * HLA_FLAG_FILTER * * * **************************")
     # -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
     # Flag sources based on concentration index.
-    log.info("ci_filter({} {} {} {} {} {} {} {} {})".format(drizzled_image, catalog_name, "<CATALOG DATA>", proc_type,
+    log.info("Determining concentration indices for sources.")
+    log.debug("ci_filter({} {} {} {} {} {} {} {} {})".format(drizzled_image, catalog_name, "<CATALOG DATA>", proc_type,
                                                             param_dict, ci_lookup_file_path, output_custom_pars_file,
                                                             column_titles, debug))
     catalog_data = ci_filter(drizzled_image, catalog_name, catalog_data, proc_type, param_dict, ci_lookup_file_path,
@@ -140,7 +139,8 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
 
     # -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
     # Flag saturated sources
-    log.info("hla_saturation_flags({} {} {} {} {} {} {} {} {})".format(drizzled_image, flt_list, catalog_name,
+    log.info("Flagging saturated sources in the catalogs.")
+    log.debug("hla_saturation_flags({} {} {} {} {} {} {} {} {})".format(drizzled_image, flt_list, catalog_name,
                                                                        "<Catalog Data>", proc_type, param_dict,
                                                                        plate_scale, column_titles, debug))
     catalog_data = hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, proc_type, param_dict,
@@ -148,7 +148,8 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
 
     # -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
     # Flag swarm sources
-    log.info("hla_swarm_flags({} {} {} {} {} {} {} {} {} {})".format(drizzled_image, catalog_name, "<Catalog Data>",
+    log.info("Flagging possible swarm features in catalogs")
+    log.debug("hla_swarm_flags({} {} {} {} {} {} {} {} {} {})".format(drizzled_image, catalog_name, "<Catalog Data>",
                                                                      exptime, plate_scale, median_sky, proc_type,
                                                                      param_dict, column_titles, debug))
     catalog_data = hla_swarm_flags(drizzled_image, catalog_name, catalog_data, exptime, plate_scale, median_sky,
@@ -156,7 +157,8 @@ def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plat
 
     # -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
     # Flag sources from regions where there are a low (or a null) number of contributing exposures
-    log.info("hla_nexp_flags({} {} {} {} {} {} {} {} {} {})".format(drizzled_image, flt_list, param_dict, plate_scale,
+    log.inf("Flagging sources from regions observed with only a small number of exposures.")
+    log.debug("hla_nexp_flags({} {} {} {} {} {} {} {} {} {})".format(drizzled_image, flt_list, param_dict, plate_scale,
                                                                  catalog_name, "<Catalog Data>", drz_root_dir,
                                                                  "<MASK_ARRAY>", column_titles, debug))
     catalog_data = hla_nexp_flags(drizzled_image, flt_list, param_dict, plate_scale, catalog_name, catalog_data,

--- a/drizzlepac/hlautils/processing_utils.py
+++ b/drizzlepac/hlautils/processing_utils.py
@@ -79,7 +79,7 @@ def refine_product_headers(product, total_obj_list):
     phdu['date-beg'] = (Time(phdu['expstart'], format='mjd').iso, "Starting Date and Time")
     phdu['date-end'] = (Time(phdu['expend'], format='mjd').iso, "Ending Date and Time")
 
-    phdu['equinox'] = hdu[('sci',1)].header['equinox'] if 'equinox' in hdu[('sci',1)].header else 2000.0
+    phdu['equinox'] = hdu[('sci', 1)].header['equinox'] if 'equinox' in hdu[('sci', 1)].header else 2000.0
 
     # Re-format ACS filter specification
     if phdu['instrume'] == 'ACS':
@@ -227,9 +227,14 @@ def _process_input(input):
             raise ValueError
 
     return hdu, closefits
-    
-def appendTrlFile(trlfile, drizfile):
+
+def append_trl_file(trlfile, drizfile, clean=True):
     """ Append log file to already existing log or trailer file.
+
+    Parameters
+    -----------
+    clean : bool
+        Remove the `drizfile` or not when finished appending it to `trlfile`
     """
     if not os.path.exists(drizfile):
         return
@@ -248,6 +253,6 @@ def appendTrlFile(trlfile, drizfile):
     ftrl.close()
     fdriz.close()
 
-    # Now, clean up astrodrizzle trailer file
-    os.remove(drizfile)
-
+    if clean:
+        # Now, clean up astrodrizzle trailer file
+        os.remove(drizfile)


### PR DESCRIPTION
These changes redirect the log output from Python to the multiple total products trailer files that get generated for single-visit processing.  It also adds a few key timestamps to the logging as well.   A few flagging comments were also set to use log.debug, instead of log.info just to keep the logs more relevant for casual users.  A lot more comments in this processing can also be moved to log.debug as well, but those will be tackled in later PRs.  Currently, more information goes to each log file than absolutely necessary, but at least they are present for all total products and populated with mostly relevant messages.  

The changes were tested by running `runsinglehap ib4606.out`.