### PR TITLE
Add converter to correctly interpret obset_id poller column

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -530,7 +530,9 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
 
     finally:
-
+        for refcat in alignment_table.reference_catalogs:
+            if os.path.exists(refcat):
+                os.remove(refcat)
         # Now update the result with the filtered_table contents
         if result:
             result.meta = filtered_table.meta

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -279,7 +279,6 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         logname = 'svm_process.log'
     print("Trailer filename: {}".format(logname))
     # Initialize total trailer filename as temp logname
-    total_trl_file = logname
     logging.basicConfig(filename=logname)
 
     # start processing

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -12,7 +12,9 @@ import numpy as np
 
 from stsci.tools import logutil
 
+
 from astropy.io import fits
+from astropy.io import ascii
 from astropy.table import Table, Column
 from drizzlepac.hlautils.product import ExposureProduct, FilterProduct, TotalProduct
 from . import astroquery_utils as aqutils
@@ -82,7 +84,7 @@ def interpret_obset_input(results):
     """
     log.info("Interpret the poller file for the observation set.")
     obset_table = build_poller_table(results)
-
+    print(obset_table['obset_id'])
     # Add INSTRUMENT column
     instr = INSTRUMENT_DICT[obset_table['filename'][0][0]]
     # convert input to an Astropy Table for parsing
@@ -142,7 +144,7 @@ def build_obset_tree(obset_table):
 
 def create_row_info(row):
     """Build info string for a row from the obset table"""
-    info_list = [str(row['proposal_id']), "{:s}".format(row['obset_id']), row['instrument'],
+    info_list = [str(row['proposal_id']), "{}".format(row['obset_id']), row['instrument'],
                  row['detector'], row['filename'][:row['filename'].find('_')], row['filters']]
     return ' '.join(map(str.upper, info_list)), row['filename']
 
@@ -175,7 +177,6 @@ def parse_obset_tree(det_tree):
     # Determine if the individual files being processed are flt or flc and
     # set the filetype accordingly (flt->drz or flc->drc).
     filetype = ''
-
     # Setup products for each detector used
     for filt_tree in det_tree.values():
         totprod = TDP_STR.format(det_indx)
@@ -312,8 +313,9 @@ def build_poller_table(input):
         Astropy table object with the same columns as a poller file.
 
     """
+    obs_converters = {'col4': [ascii.convert_numpy(np.str)]}
     if isinstance(input, str):
-        input = Table.read(input, format='ascii.fast_no_header')
+        input = ascii.read(input, format='no_header', converters=obs_converters)
         if len(input.columns) == len(POLLER_COLNAMES):
             # We were provided a poller file, so use as-is
             # Now assign column names to obset_table


### PR DESCRIPTION
The Astropy code used to read in the poller file automatically converted everything to numpy numeric types when at all possible, causing the 'obset_id' column to be converted to non-0-starting integers (1 instead of 01).  This change adds the correct converter to interpret that column as a string and retain the original formatting.  

In addition, the reference catalogs from the alignment step are also (intended to be) removed.