### PR TITLE
Format log messages to be DMS-compatible

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -37,7 +37,10 @@ MAX_SOURCES_PER_CHIP = 250  # Maximum number of sources per chip to include in s
 MAS_TO_ARCSEC = 1000.  # Conversion factor from milli-arcseconds to arcseconds
 
 
-log = logutil.create_logger('alignimages', level=logutil.logging.INFO, stream=sys.stdout)
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 __version__ = 0.0
 __version_date__ = '21-Aug-2019'

--- a/drizzlepac/alignimages.py
+++ b/drizzlepac/alignimages.py
@@ -60,7 +60,10 @@ detector_specific_params = {"acs": {"hrc": {"fwhmpsf": 0.152,  # 0.073
                                               "classify": True,
                                               "threshold": None}}}
 
-log = logutil.create_logger('alignimages', level=logutil.logging.INFO, stream=sys.stdout)
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 __version__ = 0.1
 __version_date__ = '15-Feb-2019'

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -23,8 +23,13 @@ from stsci.tools import logutil
 from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
+
 log_level = logging.INFO
-log = logutil.create_logger(__name__, level=log_level, stream=sys.stdout)
+
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 __version__ = 0.1
 __version_date__ = '07-Nov-2019'

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -66,7 +66,10 @@ from ..tweakutils import build_xy_zeropoint
 
 __taskname__ = 'astrometric_utils'
 
-log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = 'http://gsss.stsci.edu/webservices'

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -12,9 +12,10 @@ from stsci.tools import logutil
 
 __taskname__ = 'astroquery_utils'
 
-log = logutil.create_logger(__name__,
-                            level=logutil.logging.INFO,
-                            stream=sys.stdout)
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
     """Simple interface for retrieving an observation from the MAST archive

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -31,7 +31,11 @@ POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
                     'exptime', 'filters', 'detector', 'pathname']
 
 __taskname__ = 'poller_utils'
-log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout)
+
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 def interpret_obset_input(results):
     """

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -33,7 +33,10 @@ __version_date__ = "(16-Oct-2019)"
 #
 # These lines (or something similar) will be needed in the HAP processing code
 #
-log = logutil.create_logger('runsinglehap', level=logutil.logging.INFO, stream=sys.stdout)
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 # Any module which uses 'util.with_logging' should be added separately here...
 # logging.getLogger('astrodrizzle').addHandler(log)
 # logging.getLogger('alignimages').addHandler(log)


### PR DESCRIPTION
This updates the format of the log messages generated by single-visit processing modules (as per #502 ).  
The changes were implemented for 'runsinglehap' and 'hapsequencer' in order to enable easier testing of the log format and datetime format changes.  
