### PR TITLE
Global rename of variable 'debug' to 'diagnostic_mode'

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -411,7 +411,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, diagnostic_mode = True):
+def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, diagnostic_mode = False):
     """
     Super-basic and profoundly inelegant interface to hla_flag_filter.py.
 
@@ -427,7 +427,7 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, diagnos
         drizzled filter product catalog object
 
     diagnostic_mode : Boolean, optional.
-        create intermediate diagnostic files? Default value is True.
+        create intermediate diagnostic files? Default value is False.
 
     Returns
     -------

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -31,7 +31,7 @@ __version_date__ = '07-Nov-2019'
 
 # --------------------------------------------------------------------------------------------------------------
 
-def create_catalog_products(total_list, debug=False, phot_mode='both'):
+def create_catalog_products(total_list, diagnostic_mode=False, phot_mode='both'):
     """This subroutine utilizes hlautils/catalog_utils module to produce photometric sourcelists for the specified
     total drizzle product and it's associated child filter products.
 
@@ -41,7 +41,7 @@ def create_catalog_products(total_list, debug=False, phot_mode='both'):
         total drizzle product that will be processed by catalog_utils. catalog_utils will also create photometric
         sourcelists for the child filter products of this total product.
 
-    debug : bool, optional
+    diagnostic_mode : bool, optional
         generate ds9 region file counterparts to the photometric sourcelists? Default value is False.
 
     phot_mode : str, optional
@@ -61,7 +61,7 @@ def create_catalog_products(total_list, debug=False, phot_mode='both'):
                                              total_product_obj.configobj_pars.get_pars('catalog generation'),
                                              total_product_obj.configobj_pars.get_pars('quality control'),
                                              types=phot_mode,
-                                             debug=debug)
+                                             diagnostic_mode=diagnostic_mode)
 
         # Generate an "n" exposure mask which has the image footprint set to the number
         # of exposures which constitute each pixel.
@@ -90,7 +90,7 @@ def create_catalog_products(total_list, debug=False, phot_mode='both'):
                                                   total_product_obj.configobj_pars.get_pars('catalog generation'),
                                                   total_product_obj.configobj_pars.get_pars('quality control'),
                                                   types=phot_mode,
-                                                  debug=debug,
+                                                  diagnostic_mode=diagnostic_mode,
                                                   tp_sources=sources_dict)
 
             # Perform photometry
@@ -100,7 +100,7 @@ def create_catalog_products(total_list, debug=False, phot_mode='both'):
             filter_product_catalogs.measure(filter_name)
 
             log.info("Flagging sources in filter product catalog")
-            filter_product_catalogs = run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug)
+            filter_product_catalogs = run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, diagnostic_mode)
 
             # Replace zero-value total-product catalog 'Flags' column values with meaningful filter-product catalog
             # 'Flags' column values
@@ -225,7 +225,7 @@ def create_drizzle_products(total_list):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
+def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_configs=True,
                        input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
                        log_level=logutil.logging.INFO):
     """
@@ -238,7 +238,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         The 'poller file' where each line contains information regarding an exposures taken
         during a single visit.
 
-    debug : bool, optional
+    diagnostic_mode : bool, optional
         Allows printing of additional diagnostic information to the log.  Also, can turn on
         creation and use of pickled information.
 
@@ -329,7 +329,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         log.info("\n{}: Align the images on a filter-by-filter basis.".format(str(datetime.datetime.now())))
         for tot_obj in total_list:
             for filt_obj in tot_obj.fdp_list:
-                align_table, filt_exposures = filt_obj.align_to_gaia(output=debug)
+                align_table, filt_exposures = filt_obj.align_to_gaia(output=diagnostic_mode)
 
                 # Report results and track the output files
                 if align_table:
@@ -367,7 +367,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         # Create source catalogs from newly defined products (HLA-204)
         log.info("{}: Create source catalog from newly defined product.\n".format(str(datetime.datetime.now())))
         if "total detection product 00" in obs_info_dict.keys():
-            catalog_list = create_catalog_products(total_list, debug=debug, phot_mode=phot_mode)
+            catalog_list = create_catalog_products(total_list, diagnostic_mode=diagnostic_mode, phot_mode=phot_mode)
             product_list += catalog_list
         else:
             log.warning("No total detection product has been produced.  The sourcelist generation step has been skipped.")
@@ -411,7 +411,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug = True):
+def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, diagnostic_mode = True):
     """
     Super-basic and profoundly inelegant interface to hla_flag_filter.py.
 
@@ -426,7 +426,7 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug =
     filter_product_catalogs : drizzlepac.hlautils.catalog_utils.HAPCatalogs object
         drizzled filter product catalog object
 
-    debug : Boolean, optional.
+    diagnostic_mode : Boolean, optional.
         create intermediate diagnostic files? Default value is True.
 
     Returns
@@ -471,6 +471,6 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, debug =
                                                  filter_product_obj.hla_flag_msk,
                                                  ci_lookup_file_path,
                                                  output_custom_pars_file,
-                                                 debug)
+                                                 diagnostic_mode)
 
     return filter_product_catalogs

--- a/drizzlepac/hlautils/ci_table.py
+++ b/drizzlepac/hlautils/ci_table.py
@@ -20,7 +20,7 @@ log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.std
 
 ci_table = None
 
-def read_ci_apcorr_file(ci_lookup_file_path, debug=False, infile_name='ci_ap_cor_table_ap_20_2016.txt'):
+def read_ci_apcorr_file(ci_lookup_file_path, diagnostic_mode=False, infile_name='ci_ap_cor_table_ap_20_2016.txt'):
 
     """Read the table of CI values
 
@@ -29,7 +29,7 @@ def read_ci_apcorr_file(ci_lookup_file_path, debug=False, infile_name='ci_ap_cor
     ci_lookup_file_path : string
         final path elements of the concentration index lookup file
 
-    debug : Boolean, optional
+    diagnostic_mode : Boolean, optional
         print CI info to screen (True/False)? Default value = False
 
     infile_name : string, optional
@@ -63,13 +63,13 @@ def read_ci_apcorr_file(ci_lookup_file_path, debug=False, infile_name='ci_ap_cor
             except ValueError as e:
                 raise ValueError("Illegal line in %s (bad value):\n%s" % (infile_name, ci_line))
             ci_table[obs_config] = (eff_wave, ci_lower, ci_peak, ci_upper, ap_corr)
-    if debug:
+    if diagnostic_mode:
         for key in sorted(ci_table.keys()):
             log.info(key,ci_table[key])
     return ci_table
 
 
-def get_ci_info(inst, detect, filt, ci_lookup_file_path, debug=False,
+def get_ci_info(inst, detect, filt, ci_lookup_file_path, diagnostic_mode=False,
         eff_wave=-999, ci_lower=-999.0, ci_peak=-999.0, ci_upper=-999.0, ap_corr=-999.0):
 
     """Return dictionary with CI info for given detector/filter
@@ -88,7 +88,7 @@ def get_ci_info(inst, detect, filt, ci_lookup_file_path, debug=False,
     ci_lookup_file_path : string
         final path elements of the concentration index lookup file
 
-    debug : Boolean
+    diagnostic_mode : Boolean
         Print information to screen (True/False)? If not specified, default value = False
 
     eff_wave : float
@@ -114,13 +114,13 @@ def get_ci_info(inst, detect, filt, ci_lookup_file_path, debug=False,
 
     global ci_table
     if ci_table is None:
-        ci_table = read_ci_apcorr_file(ci_lookup_file_path, debug=debug)
+        ci_table = read_ci_apcorr_file(ci_lookup_file_path, diagnostic_mode=diagnostic_mode)
 
     obs_config=("%s_%s_%s"%(inst,detect,filt)).upper()
-    if debug:
+    if diagnostic_mode:
         log.info("obs_config: {}".format(obs_config))
     if obs_config in ci_table:
-        if debug:
+        if diagnostic_mode:
             log.info("CI values found.")
         eff_wave, ci_lower, ci_peak, ci_upper, ap_corr = ci_table[obs_config]
     else:

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -57,7 +57,7 @@ log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.std
 
 def run_source_list_flagging(drizzled_image, flt_list, param_dict, exptime, plate_scale, median_sky,
                              catalog_name, catalog_data, proc_type, drz_root_dir, hla_flag_msk, ci_lookup_file_path,
-                             output_custom_pars_file, diagnostic_mode=True):
+                             output_custom_pars_file, diagnostic_mode):
     """Simple calling subroutine that executes the other flagging subroutines.
 
     Parameters

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -76,7 +76,7 @@ def main():
     user_args = parser.parse_args()
 
     print("Single-visit processing started for: {}".format(user_args.input_filename))
-    rv = perform(user_args.input_filename, debug=user_args.debug)
+    rv = perform(user_args.input_filename, diagnostic_mode=user_args.diagnostic_mode)
     print("Return Value: ", rv)
     return rv
 

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -70,12 +70,9 @@ def main():
     parser = argparse.ArgumentParser(description='Process images, produce drizzled images and sourcelists')
     parser.add_argument('input_filename', help='Name of the input csv file containing information about the files to '
                         'be processed')
-    parser.add_argument('-d', '--debug', required=False, action='store_true', help='If this option is turned on, the '
-                        'align_images.perform_align() will attempt to use saved sourcelists stored in a pickle file '
-                        'generated during a previous run. Using a saved sorucelist instead of generating new '
-                        'sourcelists greatly reduces overall run time. If the pickle file does not exist, the program '
-                        'will generate new sourcelists and save them in a pickle file named after the first input '
-                        'file.')
+    parser.add_argument('-d', '--diagnostic_mode', required=False, action='store_true', help='If this option is turned '
+                        'on, additional log messages will be displayed and additional files will be created during the '
+                        'course of the run.')
     user_args = parser.parse_args()
 
     print("Single-visit processing started for: {}".format(user_args.input_filename))


### PR DESCRIPTION
See Issue #500.
The rename was done to decouple the variable 'debug' from the python logging level 'debug'. There was never any actual functional overloading--The variable 'debug' never changed logging behaviour, and vice-versa. The rename was done to simply minimize future potential confusion.