### PR TITLE
Add command-line input "log_level" to runsinglehap.py, hapsequencer.run_hap_processing

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -277,7 +277,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
     # This routine needs to return an exit code, return_value, for use by the calling
     # Condor/OWL workflow code: 0 (zero) for success, 1 for error condition
     return_value = 0
-    log.level = log_level
+    log.setLevel(log_level)
     # Define trailer file (log file) that will contain the log entries for all processing
     if isinstance(input_filename, str):  # input file is a poller file -- easy case
         logname = input_filename.replace('.out', '.log')

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -25,7 +25,7 @@ from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
 log_level = logging.ERROR
-log = logutil.create_logger(__name__, level=log_level, stream=sys.stdout)
+log = logutil.create_logger(__name__, stream=sys.stdout)
 
 __version__ = 0.1
 __version_date__ = '07-Nov-2019'
@@ -228,7 +228,7 @@ def create_drizzle_products(total_list):
 
 def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
                        input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
-                       log_level=logutil.logging.WARNING):
+                       log_level=logutil.logging.INFO):
     """
     Run the HST Advanced Products (HAP) generation code.  This routine is the sequencer or
     controller which invokes the high-level functionality to process the single visit data.
@@ -262,8 +262,9 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         Which algorithm should be used to generate the sourcelists? 'aperture' for aperture photometry;
         'segment' for segment map photometry; 'both' for both 'segment' and 'aperture'. Default value is 'both'.
 
-    log_level : string, optional
+    log_level : int, optional
         The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+        Default value is 20, or 'info'.
 
 
     RETURNS
@@ -275,15 +276,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
     # This routine needs to return an exit code, return_value, for use by the calling
     # Condor/OWL workflow code: 0 (zero) for success, 1 for error condition
     return_value = 0
-    log.critical("CRITICAL")
-    log.error("ERROR")
-    log.warning("WARNING")
-    log.info("INFO")
-    log.debug("DEBUG")
-    a;sldfkjasd;lfkm
-    print("\a")
-    pdb.set_trace()
-    sys.exit()
+    log.level = log_level
     # Define trailer file (log file) that will contain the log entries for all processing
     if isinstance(input_filename, str):  # input file is a poller file -- easy case
         logname = input_filename.replace('.out', '.log')

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -261,6 +261,9 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         Which algorithm should be used to generate the sourcelists? 'aperture' for aperture photometry;
         'segment' for segment map photometry; 'both' for both 'segment' and 'aperture'. Default value is 'both'.
 
+    log_level : string, optional
+        The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+
 
     RETURNS
     -------

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -9,6 +9,7 @@
 import datetime
 import glob
 import os
+import pdb
 import sys
 import traceback
 import logging
@@ -23,7 +24,7 @@ from stsci.tools import logutil
 from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
-log_level = logging.INFO
+log_level = logging.ERROR
 log = logutil.create_logger(__name__, level=log_level, stream=sys.stdout)
 
 __version__ = 0.1
@@ -227,7 +228,7 @@ def create_drizzle_products(total_list):
 
 def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
                        input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
-                       log_level=logutil.logging.INFO):
+                       log_level=logutil.logging.WARNING):
     """
     Run the HST Advanced Products (HAP) generation code.  This routine is the sequencer or
     controller which invokes the high-level functionality to process the single visit data.
@@ -274,7 +275,15 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
     # This routine needs to return an exit code, return_value, for use by the calling
     # Condor/OWL workflow code: 0 (zero) for success, 1 for error condition
     return_value = 0
-
+    log.critical("CRITICAL")
+    log.error("ERROR")
+    log.warning("WARNING")
+    log.info("INFO")
+    log.debug("DEBUG")
+    a;sldfkjasd;lfkm
+    print("\a")
+    pdb.set_trace()
+    sys.exit()
     # Define trailer file (log file) that will contain the log entries for all processing
     if isinstance(input_filename, str):  # input file is a poller file -- easy case
         logname = input_filename.replace('.out', '.log')

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -24,7 +24,6 @@ from stsci.tools import logutil
 from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
-log_level = logging.ERROR
 log = logutil.create_logger(__name__, stream=sys.stdout)
 
 __version__ = 0.1
@@ -284,7 +283,7 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
         logname = 'svm_process.log'
     print("Trailer filename: {}".format(logname))
     # Initialize total trailer filename as temp logname
-    logging.basicConfig(filename=logname)
+    logging.basicConfig(filename=logname, filemode='w', level=log_level)
 
     # start processing
     starting_dt = datetime.datetime.now()

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -23,9 +23,6 @@ from stsci.tools import logutil
 from stwcs import wcsutil
 
 __taskname__ = 'hapsequencer'
-
-log_level = logging.INFO
-
 MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout, 
@@ -288,8 +285,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         logname = 'svm_process.log'
     print("Trailer filename: {}".format(logname))
     # Initialize total trailer filename as temp logname
-    logging.basicConfig(filename=logname, filemode='w', level=log_level)
-
+    logging.basicConfig(filename=logname)
     # start processing
     starting_dt = datetime.datetime.now()
     log.info("Run start time: {}".format(str(starting_dt)))

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -69,10 +69,12 @@ def perform(input_filename, **kwargs):
         kwargs['log_level'] = logutil.logging.ERROR
     elif kwargs['log_level'] == "warning":
         kwargs['log_level'] = logutil.logging.WARNING
-    elif kwargs['log_level'] == "INFO":
+    elif kwargs['log_level'] == "info":
         kwargs['log_level'] = logutil.logging.INFO
-    else:
+    elif kwargs['log_level'] == "debug":
         kwargs['log_level'] = logutil.logging.DEBUG
+    else:
+        kwargs['log_level'] = logutil.logging.INFO
 
     return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
     return return_value

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -66,20 +66,21 @@ def perform(input_filename, **kwargs):
         run
     """
     # set up log_level as an input to hapsequencer.run_hap_processing().
-    if kwargs['log_level'] == "critical":
-        kwargs['log_level'] = logutil.logging.CRITICAL
-    elif kwargs['log_level'] == "error":
-        kwargs['log_level'] = logutil.logging.ERROR
-    elif kwargs['log_level'] == "warning":
-        kwargs['log_level'] = logutil.logging.WARNING
-    elif kwargs['log_level'] == "info":
-        kwargs['log_level'] = logutil.logging.INFO
-    elif kwargs['log_level'] == "debug":
-        kwargs['log_level'] = logutil.logging.DEBUG
+    log_level_dict = {"critical": logutil.logging.CRITICAL,
+                      "error": logutil.logging.ERROR,
+                      "warning": logutil.logging.WARNING,
+                      "info": logutil.logging.INFO,
+                      "debug": logutil.logging.DEBUG}
+    kwargs['log_level'] = kwargs['log_level'].lower()
+    if kwargs['log_level'] in log_level_dict.keys():
+        kwargs['log_level'] = log_level_dict[kwargs['log_level']]
     else:
+        print("Log level set to default level 'log.info'.")
         kwargs['log_level'] = logutil.logging.INFO
 
+    # execute hapsequencer.run_hap_processing()
     return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
+
     return return_value
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -16,7 +16,7 @@ Python USAGE:
 """
 # Import standard Python modules
 import argparse
-
+import pdb
 import sys
 import logging
 
@@ -63,6 +63,17 @@ def perform(input_filename, **kwargs):
         run
     """
 
+    # if kwargs['log_level'] == "critical":
+    #     kwargs['log_level'] = logutil.logging.CRITICAL
+    # elif kwargs['log_level'] == "error":
+    #     kwargs['log_level'] = logutil.logging.ERROR
+    # elif kwargs['log_level'] == "warning":
+    #     kwargs['log_level'] = logutil.logging.WARNING
+    # elif kwargs['log_level'] == "INFO":
+    #     kwargs['log_level'] = logutil.logging.INFO
+    # else:
+    #     kwargs['log_level'] = logutil.logging.DEBUG
+    # log = logutil.create_logger('runsinglehap', level=kwargs['log_level'], stream=sys.stdout)
     log.info("Starting single-visit processing of {}".format(input_filename))
     return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
     return return_value

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -33,7 +33,7 @@ __version_date__ = "(16-Oct-2019)"
 #
 # These lines (or something similar) will be needed in the HAP processing code
 #
-log = logutil.create_logger('runsinglehap', level=logutil.logging.INFO, stream=sys.stdout)
+log = logutil.create_logger('runsinglehap', stream=sys.stdout)
 # Any module which uses 'util.with_logging' should be added separately here...
 # logging.getLogger('astrodrizzle').addHandler(log)
 # logging.getLogger('alignimages').addHandler(log)
@@ -62,19 +62,18 @@ def perform(input_filename, **kwargs):
         a simple status value. '0' for a successful run and '1' for a failed
         run
     """
+    # set up log_level as an input to hapsequencer.run_hap_processing().
+    if kwargs['log_level'] == "critical":
+        kwargs['log_level'] = logutil.logging.CRITICAL
+    elif kwargs['log_level'] == "error":
+        kwargs['log_level'] = logutil.logging.ERROR
+    elif kwargs['log_level'] == "warning":
+        kwargs['log_level'] = logutil.logging.WARNING
+    elif kwargs['log_level'] == "INFO":
+        kwargs['log_level'] = logutil.logging.INFO
+    else:
+        kwargs['log_level'] = logutil.logging.DEBUG
 
-    # if kwargs['log_level'] == "critical":
-    #     kwargs['log_level'] = logutil.logging.CRITICAL
-    # elif kwargs['log_level'] == "error":
-    #     kwargs['log_level'] = logutil.logging.ERROR
-    # elif kwargs['log_level'] == "warning":
-    #     kwargs['log_level'] = logutil.logging.WARNING
-    # elif kwargs['log_level'] == "INFO":
-    #     kwargs['log_level'] = logutil.logging.INFO
-    # else:
-    #     kwargs['log_level'] = logutil.logging.DEBUG
-    # log = logutil.create_logger('runsinglehap', level=kwargs['log_level'], stream=sys.stdout)
-    log.info("Starting single-visit processing of {}".format(input_filename))
     return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
     return return_value
 

--- a/drizzlepac/runsinglehap.py
+++ b/drizzlepac/runsinglehap.py
@@ -53,12 +53,16 @@ def perform(input_filename, **kwargs):
     debug : Boolean
         display all tracebacks, and debug information?
 
+    log_level : string
+        The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+
     Updates
     -------
     return_value : list
         a simple status value. '0' for a successful run and '1' for a failed
         run
     """
+
     log.info("Starting single-visit processing of {}".format(input_filename))
     return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
     return return_value
@@ -76,10 +80,17 @@ def main():
                         'sourcelists greatly reduces overall run time. If the pickle file does not exist, the program '
                         'will generate new sourcelists and save them in a pickle file named after the first input '
                         'file.')
+    parser.add_argument('-l', '--log_level', required=False, default='info',
+                        choices=['critical', 'error', 'warning', 'info', 'debug'], help='The desired level of '
+                        'verboseness in the log statements displayed on the screen and written to the .log file. The '
+                        'level of verboseness from left to right, and includes all log statements with a log_level '
+                        'left of the specified level. Specifying "critical" will only record/display "critical" log '
+                        'statements, and specifying "error" will record/display both "error" and "critical" log '
+                        'statements, and so on.')
     user_args = parser.parse_args()
 
     print("Single-visit processing started for: {}".format(user_args.input_filename))
-    rv = perform(user_args.input_filename, debug=user_args.debug)
+    rv = perform(user_args.input_filename, debug=user_args.debug, log_level = user_args.log_level)
     print("Return Value: ", rv)
     return rv
 


### PR DESCRIPTION
- This PR allows the user to specify the logging level (CRITICAL/ERROR/ Etc...) as a command-line input to runsinglehap.py. (See issue #501)
The runsinglehap.perform() subroutine and the the main logging definition at the top of the code were modified to accommodate a user-specified log level.
- The hapsequencer.run_hap_processing()  subroutine and the the main logging definition at the top of the code were modified to accommodate a user-specified log level.
- Fellow Burgundy team members can now use log_level for their work towards issue #502.