### PR TITLE
Adjust where the reference catalogs are cleaned up

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -351,13 +351,13 @@ def run_hap_processing(input_filename, debug=False, use_defaults_configs=True,
                     product_list += hdrlet_list
                     product_list += filt_exposures
 
+                    # Remove reference catalogs created for alignment of each filter product
+                    for catalog_name in align_table.reference_catalogs:
+                        log.info("Looking to clean up reference catalog: {}".format(catalog_name))
+                        if os.path.exists(catalog_name):
+                            os.remove(catalog_name)
                 else:
                     log.warning("Step to align the images has failed. No alignment table has been generated.")
-                # Remove reference catalogs created for alignment of each filter product
-                for catalog_name in align_table.reference_catalogs:
-                    log.info("Looking to clean up reference catalog: {}".format(catalog_name))
-                    if os.path.exists(catalog_name):
-                        os.remove(catalog_name)
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -4,6 +4,7 @@
     drizzle products.
 """
 import sys
+import os
 import traceback
 import shutil
 
@@ -230,6 +231,11 @@ class FilterProduct(HAPProduct):
             traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
             log.info("No correction to absolute astrometric frame applied.\n")
             align_table = None
+
+            # If the align_table is None, it is necessary to clean-up reference catalogs 
+            # created for alignment of each filter product here.
+            if os.path.exists(refname):
+                os.remove(refname)
 
         # Return a table which contains data regarding the alignment, as well as the
         # list of the flt/flc exposures which were part of the alignment process


### PR DESCRIPTION
Change the place in code where the reference catalogs are cleaned up to avoid the following issue:

    Not enough reference sources for absolute alignment...
    INFO: EXCEPTION encountered in align_to_gaia for the FilteredProduct.

       Traceback (most recent call last):
          File "/internal/hladata/dev_repos/drizzlepac/drizzlepac/hlautils/product.py", line 224, in align_to_gaia
            raise ValueError
        ValueError
        INFO: No correction to absolute astrometric frame applied.

    WARNING: Step to align the images has failed. No alignment table has been generated.
    INFO: 
    Traceback (most recent call last):
      File "/internal/hladata/dev_repos/drizzlepac/drizzlepac/hapsequencer.py", line 357, in run_hap_processing
        for catalog_name in align_table.reference_catalogs:
    AttributeError: 'NoneType' object has no attribute 'reference_catalogs'
    INFO: Processing completed at 2019-11-15 17:13:04.609197
