### PR TITLE
Fix empty drz naming problem (HSTSDP-851)

### DIFF
--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -961,10 +961,10 @@ def buildEmptyDRZ(input, output):
             oname = 'final'
         output = fileutil.buildNewRootname(oname, extn='_drz.fits')
     else:
-        if 'drz' not in output:
+        if '_drz' not in output:
             output = fileutil.buildNewRootname(output, extn='_drz.fits')
 
-    log.info('Setting up output name: %s' % output)
+    print('Building emtpy DRZ file with output name: %s' % output)
 
     # Open the first image (of the excludedFileList?) to use as a template to build
     # the DRZ file.


### PR DESCRIPTION
The drizzle processing code not only generates default output names determined from the ASN file, but it can also support user-provided output names.  Unfortunately, as a result, it was looking to see whether a valid output name was provided to determine how much work it needs to do to create it's own valid output name; in this case, valid meaning something that ends in _drz.fits.  The previous logic was only looking for 'drz' in the output name.  😉  These datasets have 'drz' in the middle of the rootname, so the logic in the code said it had a valid output name as input and did not make sure the filename ENDED in _drz.fits. 

This fix looks for the more specific '_drz' instead to build the final output name for the empty drz product.  It has been tested using jdrz2m010. 