### PR TITLE
Modify existing WFC3/IR configuration files for SVM processing

### DIFF
--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
@@ -19,7 +19,7 @@
     "STEP 2: SKY SUBTRACTION": {
         "skysub": true,
         "skymethod": "match",
-        "skystat": "mode",
+        "skystat": "median",
         "skywidth": 0.1,
         "skylower": -100.0,
         "sky_bits": "16",


### PR DESCRIPTION
Changed "skystat" from "mode" to "median" in the "STEP 2: SKY SUBTRACTION" sections of the following astrodrizzle param files:

- drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
- drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
- drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
- drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
- drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
- drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
- drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
- drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json

See issue #525.
