### PR TITLE
Fixed filenames in ACS/SBC JSON index file

### DIFF
--- a/drizzlepac/pars/hap_pars/acs_sbc_index.json
+++ b/drizzlepac/pars/hap_pars/acs_sbc_index.json
@@ -3,10 +3,10 @@
         "all": "acs/sbc/acs_sbc_alignment_all.json"
     },
     "astrodrizzle": {
-        "acs_sbc_any_n2": "acs/sbc/acs_sbc_any_n2.cfg",
-        "acs_sbc_any_n6": "acs/sbc/acs_sbc_any_n6.cfg",
-        "acs_sbc_blue_n2": "acs/sbc/acs_sbc_blue_n2.cfg",
-        "acs_sbc_blue_n6": "acs/sbc/acs_sbc_blue_n6.cfg",
+        "acs_sbc_any_n2": "acs/sbc/acs_sbc_astrodrizzle_any_n2.json",
+        "acs_sbc_any_n6": "acs/sbc/acs_sbc_astrodrizzle_any_n6.json",
+        "acs_sbc_blue_n2": "acs/sbc/acs_sbc_astrodrizzle_blue_n2.json",
+        "acs_sbc_blue_n6": "acs/sbc/acs_sbc_astrodrizzle_blue_n6.json",
         "any_n1": "any/any_astrodrizzle_n1.json",
         "filter_basic": "any/any_astrodrizzle_filter_hap_basic.json",
         "single_basic": "any/any_astrodrizzle_single_hap_basic.json",


### PR DESCRIPTION
Fixed a few typos in the ACS/SBC JSON index file for the astrodrizzle configuration filenames.  The files already exist, but the names in the index file were incorrect.