### PR TITLE
Add automated HLA classic sourcelist comparison

### DIFF
--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -90,8 +90,13 @@ from drizzlepac.devutils.comparison_tools import starmatch_hist
 from drizzlepac import util
 from stsci.tools import logutil
 
-log = logutil.create_logger('compare_sourcelists', level=logutil.logging.INFO, stream=sys.stdout)
-#-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+__taskname__ = 'compare_sourcelists'
+
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
+# -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 
 def check_match_quality(matched_x_list, matched_y_list):
     """Creates region file to check quality of source matching.
@@ -123,7 +128,7 @@ def check_match_quality(matched_x_list, matched_y_list):
     log.info("Wrote region file {}".format(out_filename))
 
 
-#-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+# -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 def computeFlagStats(matchedRA,plotGen,plot_title,verbose):
     """Compute and report statistics on the differences in flagging.
 

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -131,7 +131,7 @@ def check_match_quality(matched_x_list, matched_y_list):
 
 
 # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
-def computeFlagStats(matchedRA,plotGen,plot_title,verbose):
+def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
     """Compute and report statistics on the differences in flagging.
 
     Parameters
@@ -145,6 +145,9 @@ def computeFlagStats(matchedRA,plotGen,plot_title,verbose):
 
     plot_title : string
         text string that will be used in plot title.
+
+    plotfile_prefix : string
+        text string that will prepend the plot files generated if plots are written to files
 
     verbose : Boolean
         display verbose output?
@@ -217,6 +220,8 @@ def computeFlagStats(matchedRA,plotGen,plot_title,verbose):
         width = 0.35
         p1=plt.bar(idx - width/2,refFlagBreakdown,width,label='Reference')
         p2 = plt.bar(idx + width/2, compFlagBreakdown,width, label='Comparison')
+        fig = plt.figure()
+        ax1 = fig.add_subplot(111)
         plt.legend()
         plt.xticks(idx, x_title_list)
         plt.xlabel("Flag Bit Value")
@@ -236,6 +241,8 @@ def computeFlagStats(matchedRA,plotGen,plot_title,verbose):
         p_unchanged=plt.bar(idx,unchangedFlagBreakdown)
         p_offOn=plt.bar(idx,off_on_FlagFlips,bottom=unchangedFlagBreakdown)
         p_onOff=plt.bar(idx,on_off_FlagFlips,bottom=off_on_FlagFlips+unchangedFlagBreakdown)
+        fig = plt.figure()
+        ax1 = fig.add_subplot(111)
         plt.xticks(idx,x_title_list)
         plt.xlabel("Flag Bit Value")
         plt.ylabel("Number of matched sources")

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -273,7 +273,7 @@ def computeLinearStats(matchedRA,plotGen,diffMode,plot_title,plotfile_prefix,ver
         text string that will be used in plot title.
 
     plotfile_prefix : string
-        text string that will prepend the plot files geenrated if plots are written to files
+        text string that will prepend the plot files generated if plots are written to files
 
     verbose : Boolean
         display verbose output?
@@ -509,7 +509,7 @@ def getMatchedLists(slNames,imgNames,slLengths):
 
     return(matching_lines_ref,matching_lines_img)
 #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
-def makeVectorPlot(x,y,plotDest,binThresh = 10000,binSize=250):
+def makeVectorPlot(x,y,plotDest,plotfile_prefix,binThresh = 10000,binSize=250):
     """Generate vector plot of dx and dy values vs. reference (x,y) positions
 
     Parameters
@@ -524,6 +524,9 @@ def makeVectorPlot(x,y,plotDest,binThresh = 10000,binSize=250):
 
     plotDest : string
         plot destination; screen or file
+
+    plotfile_prefix : string
+        text string that will prepend the plot files generated if plots are written to files
 
     binThresh : int
         Minimum size of list *x* and *y* that will trigger generation of a binned vector plot. Default value = 10000.
@@ -587,6 +590,8 @@ def makeVectorPlot(x,y,plotDest,binThresh = 10000,binSize=250):
     plt_mean = np.mean(np.hypot(p_dx, p_dy))
     e = np.log10(5.0*plt_mean).round()
     plt_scaleValue=10**e
+    fig = plt.figure()
+    ax1 = fig.add_subplot(111)
     if len(dx) > binThresh: Q = plt.quiver(p_x, p_y, p_dx, p_dy,color=color_ra,units="xy")
     else: Q = plt.quiver(p_x, p_y, p_dx, p_dy)
     plt.quiverkey(Q, 0.75, 0.05, plt_scaleValue, r'%5.3f'%(plt_scaleValue), labelpos='S', coordinates='figure', color="k")
@@ -597,9 +602,17 @@ def makeVectorPlot(x,y,plotDest,binThresh = 10000,binSize=250):
     if plotDest == "screen":
         plt.show()
     if plotDest == "file":
-        plt.savefig("xy_vector_plot.pdf")
+
+        # Put timestamp and plotfile_prefix text string in lower left corner below plot
+        timestamp = "Generated {}".format(datetime.now().strftime("%m/%d/%Y %H:%M:%S"))
+        plt.text(0.0, -0.081, timestamp, horizontalalignment='left', verticalalignment='center', fontsize=5,
+                 transform=ax1.transAxes)
+        plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center', fontsize=5,
+                 transform=ax1.transAxes)
+        plotFileName = "{}_xy_vector_plot.pdf".format(plotfile_prefix, plot_title.replace(" ", "_"))
+        plt.savefig(plotFileName)
         plt.close()
-        log.info("Vector plot saved to file xy_vector_plot.pdf")
+        log.info("Vector plot saved to file {}".format(plotFileName))
 # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 def round2ArbatraryBase(value,direction,roundingBase):
     """Round value up or down to arbitrary base
@@ -690,7 +703,7 @@ def comparesourcelists(slNames,imgNames,plotGen=None,diffMode="pmean",plotfile_p
         colTitles.append("Y Position")
         matchedYValues = matched_values.copy()
         if plotGen != "none" and diffMode == "absolute":
-            makeVectorPlot(matchedXValues,matchedYValues,plotGen)
+            makeVectorPlot(matchedXValues,matchedYValues,plotGen,plotfile_prefix)
     if debugMode:
         check_match_quality(matchedXValues,matchedYValues)
     # 5: Compute and display statistics on RA position differences for matched sources

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -76,8 +76,9 @@ Classes and Functions
 ---------------------
 """
 import argparse
-import pdb
 from datetime import datetime
+import os
+import pdb
 import random
 import sys
 
@@ -496,7 +497,9 @@ def getMatchedLists(slNames,imgNames,slLengths):
         log.info("WARNING: Unable to fetch values for xref and yref from fits file headers. Using xref = 0.0 and yref = 0.0.")
         xref=0.0
         yref=0.0
-    log.info("source_list_dict: {}".format(source_list_dict))
+    log.info("Summary of input catalog lengths")
+    for source_list in source_list_dict.keys():
+        log.info("{}: {}".format(os.path.basename(source_list),source_list_dict[source_list]))
     out_dict = starmatch_hist.run(source_list_dict, xref=xref, yref=yref)
     matching_lines_ref = out_dict[slNames[0]]
     matching_lines_img = out_dict[slNames[1]]

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -496,6 +496,9 @@ def getMatchedLists(slNames,imgNames,slLengths,log_level):
     slLengths : list
         list of integer sourcelist lengths
 
+    log_level : int
+        The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+
     Returns
     -------
     matching_lines_ref : list

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -2,7 +2,7 @@
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4 ai :
 
 """This script compares two sourcelists and displays various measures of their differences. 3x3-sigma clipped mean,
-median and standard deviatnion, and  non-sigma clipped min and max values are computed for the following:
+median and standard deviation, and non-sigma clipped min and max values are computed for the following:
 
 * X position
 * Y position
@@ -12,6 +12,8 @@ median and standard deviatnion, and  non-sigma clipped min and max values are co
 * Flux (Outer Aperture)
 * Magnitude (Inner Aperture)
 * Magnitude (Outer Aperture)
+* Magnitude Error (Inner Aperture)
+* Magnitude Error (Outer Aperture)
 
 Bit-wise comparisons are also performed for the following item:
 
@@ -26,14 +28,14 @@ Regression Testing
 ------------------
 The following criteria must be met for the test to be declared "successful":
 
-* X position: The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Y position: The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Right Ascension: The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Declination: The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Flux (Inner Aperture): The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Flux (Outer Aperture): The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Magnitude (Inner Aperture): The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
-* Magnitude (Outer Aperture): The sigma-clipped mean of all comparision - reference difference values is less than 1 sigma from zero.
+* X position: The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Y position: The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Right Ascension: The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Declination: The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Flux (Inner Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Flux (Outer Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Magnitude (Inner Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Magnitude (Outer Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
 * Flag Value: The total number of differing flag bits is less than 5% of the total number of reference flag bits.
 
 .. note::
@@ -50,24 +52,33 @@ drizzlepac/drizzlepac/devutils/comparison_tools/starmatch_hist.py
 Inputs
 ------
 * Required input
-    1: *sourcelistNames*
-        * A space-separated pair of sourcelists to compare. The first sorucelist is assumed to be the reference sourcelist that the second is being compared to.
+    1. *sourcelistNames*
+        * A space-separated pair of sourcelists to compare. The first sourcelist is assumed to be the reference sourcelist that the second is being compared to.
 
 * Optional inputs:
-    1: -i *imageNames*
-        * A space-separated list of the fits images that were used to generate the input sourcelists. The first image corresponds to the first listed sourcelist, and so in. These will be used to imporove the sourcelist alignment and matching.
+    #. -d *debugMode*
+        * Perform additional match quality diagnostics
+        * Input choices: "True" or "False"
+        * Default value: False
 
-    2: -m *diffMode*
+    #. -i *imageNames*
+        * A space-separated list of the fits images that were used to generate the input sourcelists. The first image corresponds to the first listed sourcelist, and so in. These will be used to improve the sourcelist alignment and matching.
+
+    #. -m *diffMode*
         * How should the comp-ref difference be calculated? "absolute" is simply the straight comp-ref difference. "peman" is the mean percent difference ((C-R)/avg(R)) x 100. "pdynamic" is the dynamic percent difference ((C-R)/R) x 100
         * Input choices: "absolute", "pmean" or "pdynamic"
         * Default value: "pmean"
 
-    3: -p *plotGen*
+    #. -p *plotGen*
         * Generate plots?
         * Input choices: "True" or "False"
         * Default value: False
 
-    4: -p *verbose*
+    #. -s *plotfile_prefix_string*
+        * Text string that will prepend the plot files generated if plots are written to files ***REQUIRES the -p option set to 'file'***
+        * Default value: blank text string ('')
+
+    #. -v *verbose*
         * Display verbose output?
         * Input choices: "True" or "False"
         * Default value: True
@@ -123,7 +134,7 @@ def check_match_quality(matched_x_list, matched_y_list):
         index_list = random.sample(range(1, list_length), num_display)
     with open(out_filename,"w") as fout:
         for index_no in index_list:
-            fout.write("circle({},{},10)  # color=green\n".format(matched_x_list[0][index_no], matched_y_list[0][index_no])) # write ref source circlw
+            fout.write("circle({},{},10)  # color=green\n".format(matched_x_list[0][index_no], matched_y_list[0][index_no])) # write ref source circle
             fout.write("circle({},{},10) # color=red\n".format(matched_x_list[1][index_no], matched_y_list[1][index_no])) # write comp source circle
             fout.write("line({},{},{},{}) # color=blue\n".format(matched_x_list[0][index_no], matched_y_list[0][index_no], matched_x_list[1][index_no], matched_y_list[1][index_no])) # write line connecting the two
     log.info("Wrote region file {}".format(out_filename))
@@ -165,7 +176,7 @@ def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
     on_off_FlagFlips=np.zeros(9,dtype=int)
     off_on_FlagFlips=np.zeros(9,dtype=int)
     for refFlagVal, compFlagVal in zip(matchedRA[0], matchedRA[1]):
-        #break down each flag value into componant bit values, add values to totals
+        #break down each flag value into component bit values, add values to totals
         refFlagRA=deconstruct_flag(refFlagVal)
         refFlagBreakdown += refFlagRA
         compFlagRA = deconstruct_flag(compFlagVal)
@@ -176,7 +187,7 @@ def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
             off_on_FlagFlips[np.where(diffFlagRA == 1)] += 1 #bits that are off in ref but on in comp
             on_off_FlagFlips[np.where(diffFlagRA == -1)] += 1 #bits that are on in ref but off in comp
             unchangedFlagBreakdown[np.where((refFlagRA ==1) & (compFlagRA ==1))] += 1 #takes care of the case were comp and ref have differing bits, but also have additional bits that are unchanged.
-        if np.array_equal(refFlagRA, compFlagRA): #if there are absolutly no differences
+        if np.array_equal(refFlagRA, compFlagRA): #if there are absolutely no differences
             unchangedFlagBreakdown+=refFlagRA
     regTestStatus = "OK     "
     pct_diff_refbits=(np.sum([off_on_FlagFlips,on_off_FlagFlips],dtype=float)/np.sum(refFlagBreakdown, dtype=float))*100.0
@@ -341,7 +352,7 @@ def computeLinearStats(matchedRA,plotGen,diffMode,plot_title,plotfile_prefix,ver
 
     out_stats="%11.7f %11.7f  %11.7f  %11.7f  %11.7f "%(clippedStats[0],clippedStats[1],clippedStats[2],pct_five,pct_1sig)
     if diffMode == "absolute":
-        if abs(clippedStats[0]) <= abs(clippedStats[2]): #success conditon: sigma clippped mean less then 1 sigma from Zero.
+        if abs(clippedStats[0]) <= abs(clippedStats[2]): #success condition: sigma clippped mean less then 1 sigma from Zero.
             regTestStatus = "OK      "
         else: regTestStatus = "FAILURE "
     else:
@@ -596,7 +607,7 @@ def makeVectorPlot(x,y,plotDest,plotfile_prefix,binThresh = 10000,binSize=250):
                 #get indicies of x and y withen bounding box
                 ix0 = np.where((x[0,:] >= xBinMin) & (x[0,:] < xBinMax) & (y[0,:] >= yBinMin) & (y[0,:] < yBinMax))
                 if len(dx[ix0]) > 0 and len(dy[ix0]) > 0: #ignore empty bins
-                    p_x=np.append(p_x, xBinCtr + 0.5 * binSize) #X and Y posotion at center of bin.
+                    p_x=np.append(p_x, xBinCtr + 0.5 * binSize) #X and Y position at center of bin.
                     p_y=np.append(p_y, yBinCtr + 0.5 * binSize)
                     mean_dx=np.mean(dx[ix0])
                     p_dx=np.append(p_dx, mean_dx) #compute mean dx, dy values
@@ -688,7 +699,7 @@ def comparesourcelists(slNames,imgNames,plotGen=None,diffMode="pmean",plotfile_p
         optional list of input images that starmatch_hist will use to improve sourcelist matching
 
     plotfile_prefix : string
-        text string that will prepend the plot files geenrated if plots are written to files
+        text string that will prepend the plot files generated if plots are written to files
 
     plotGen : Boolean
         Generate plots and display them to the screen (True/False)?
@@ -713,7 +724,7 @@ def comparesourcelists(slNames,imgNames,plotGen=None,diffMode="pmean",plotfile_p
         plotfile_prefix = ""
     regressionTestResults={}
     colTitles=[]
-    # 1: Read in sourcelists fiels into astropy table or 2-d array so that individual columns from each sourcelist can be easily accessed later in the code.
+    # 1: Read in sourcelists files into astropy table or 2-d array so that individual columns from each sourcelist can be easily accessed later in the code.
     refData,compData=slFiles2dataTables(slNames)
     log.info("Valid reference data columns:   {}".format(list(refData.keys())))
     log.info("Valid comparision data columns: {}".format(list(compData.keys())))
@@ -968,12 +979,12 @@ def slFiles2dataTables(slNames):
 if __name__ == "__main__":
     PARSER = argparse.ArgumentParser(description='Compare Sourcelists')
     # required positional input arguments
-    PARSER.add_argument('sourcelistNames', nargs=2,help='A space-separated pair of sourcelists to compare. The first sorucelist is assumed to be the reference sourcelist that the second is being compared to.')
+    PARSER.add_argument('sourcelistNames', nargs=2,help='A space-separated pair of sourcelists to compare. The first sourcelist is assumed to be the reference sourcelist that the second is being compared to.')
     # optional input arguments
     PARSER.add_argument('-d', '--debugMode', required=False, choices=["True", "False"], default="False", help="Turn on debug mode? Default value is False.")
-    PARSER.add_argument('-i', '--imageNames', required = False, nargs=2,help='A space-seperated list of the fits images that were used to generate the input sourcelists. The first image corresponds to the first listed sourcelist, and so in. These will be used to imporove the sourcelist alignment and matching.')
+    PARSER.add_argument('-i', '--imageNames', required = False, nargs=2,help='A space-separated list of the fits images that were used to generate the input sourcelists. The first image corresponds to the first listed sourcelist, and so in. These will be used to improve the sourcelist alignment and matching.')
     PARSER.add_argument('-m', '--diffMode', required=False, choices=["absolute", "pmean","pdynamic"], default="pmean",
-                        help='How should the comp-ref difference be calculated? "absolute" is simply the stright comp-ref difference. "peman" is the mean percent difference ((C-R)/avg(R)) x 100. "pdynamic" is the dynamic percent difference ((C-R)/R) x 100. Default value is "pmean".')
+                        help='How should the comp-ref difference be calculated? "absolute" is simply the straight comp-ref difference. "peman" is the mean percent difference ((C-R)/avg(R)) x 100. "pdynamic" is the dynamic percent difference ((C-R)/R) x 100. Default value is "pmean".')
     PARSER.add_argument('-p', '--plotGen', required=False, choices=["screen","file","none"], default="none",help='Generate Plots? "screen" displays plots on-screen. "file" saves them to a .pdf file, and "none" skips all plot generation.')
     PARSER.add_argument('-s', '--plotfile_prefix_string', required = False, default="", help="text string that will prepend the plot files generated if plots are written to files ***REQUIRES the -p option set to 'file'***")
     PARSER.add_argument('-v', '--verbose', required=False, choices=["True", "False"], default="True",

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -660,6 +660,9 @@ def comparesourcelists(slNames,imgNames,plotGen,diffMode,verbose,debugMode):
     # 2: Run starmatch_hist to get list of matched sources common to both input sourcelists
     slLengths=[len(refData['X']),len(compData['X'])]
     matching_lines_ref, matching_lines_img=getMatchedLists(slNames,imgNames,slLengths)
+    if len(matching_lines_ref) == 0  or len(matching_lines_img) == 0:
+        log.critical("*** Comparisons cannot be computed. No matching sources were found. ***")
+        return("ERROR")
     # 3: Compute and display statistics on X position differences for matched sources
     matched_values=extractMatchedLines("X",refData,compData,matching_lines_ref, matching_lines_img)
     if len(matched_values) >0:

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -239,6 +239,8 @@ def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
             plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center', fontsize=5,
                      transform=ax1.transAxes)
             plotFileName = "{}_{}.pdf".format(plotfile_prefix,fullPlotTitle.replace(" ","_"))
+            if plotFileName.startswith("_"):
+                plotFileName=plotFileName[1:]
             plt.savefig(plotFileName)
             plt.close()
             log.info("{} plot saved to file {}.".format(fullPlotTitle, plotFileName))
@@ -267,6 +269,8 @@ def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
                      fontsize=5,
                      transform=ax2.transAxes)
             plotFileName = "{}_{}.pdf".format(plotfile_prefix, fullPlotTitle.replace(" ", "_"))
+            if plotFileName.startswith("_"):
+                plotFileName=plotFileName[1:]
             plt.savefig(plotFileName)
             plt.close()
             log.info("{} plot saved to file {}.".format(fullPlotTitle, plotFileName))
@@ -406,6 +410,8 @@ def computeLinearStats(matchedRA,plotGen,diffMode,plot_title,plotfile_prefix,ver
             plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center', fontsize=5,
                      transform=ax1.transAxes)
             plotFileName = "{}_{}.pdf".format(plotfile_prefix,plot_title.replace(" ","_"))
+            if plotFileName.startswith("_"):
+                plotFileName=plotFileName[1:]
             plt.savefig(plotFileName)
             plt.close()
             log.info("{} plot saved to file {}.".format(fullPlotTitle, plotFileName))
@@ -633,6 +639,8 @@ def makeVectorPlot(x,y,plotDest,plotfile_prefix,binThresh = 10000,binSize=250):
         plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center', fontsize=5,
                  transform=ax1.transAxes)
         plotFileName = "{}_xy_vector_plot.pdf".format(plotfile_prefix, plot_title.replace(" ", "_"))
+        if plotFileName.startswith("_"):
+            plotFileName = plotFileName[1:]
         plt.savefig(plotFileName)
         plt.close()
         log.info("Vector plot saved to file {}".format(plotFileName))

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -959,6 +959,7 @@ if __name__ == "__main__":
     PARSER.add_argument('-m', '--diffMode', required=False, choices=["absolute", "pmean","pdynamic"], default="pmean",
                         help='How should the comp-ref difference be calculated? "absolute" is simply the stright comp-ref difference. "peman" is the mean percent difference ((C-R)/avg(R)) x 100. "pdynamic" is the dynamic percent difference ((C-R)/R) x 100. Default value is "pmean".')
     PARSER.add_argument('-p', '--plotGen', required=False, choices=["screen","file","none"], default="none",help='Generate Plots? "screen" displays plots on-screen. "file" saves them to a .pdf file, and "none" skips all plot generation.')
+    PARSER.add_argument('-s', '--plotfile_prefix_string', required = False, default="", help="text string that will prepend the plot files generated if plots are written to files ***REQUIRES the -p option set to 'file'***")
     PARSER.add_argument('-v', '--verbose', required=False, choices=["True", "False"], default="True",
                         help='Display verbose output? Default value is "True".')
     ARGS = PARSER.parse_args()
@@ -972,7 +973,7 @@ if __name__ == "__main__":
         ARGS.debugMode = True
     else: ARGS.debugMode = False
 
-    runStatus=comparesourcelists(ARGS.sourcelistNames,ARGS.imageNames,plotGen=ARGS.plotGen,diffMode=ARGS.diffMode,verbose=ARGS.verbose,debugMode=ARGS.debugMode,plotfile_prefix="hst_14606_10_acs_wfc_f850lp_jd9510_point")
+    runStatus=comparesourcelists(ARGS.sourcelistNames,ARGS.imageNames,plotGen=ARGS.plotGen,diffMode=ARGS.diffMode,verbose=ARGS.verbose,debugMode=ARGS.debugMode,plotfile_prefix=ARGS.plotfile_prefix_string)
 
 # TODO: reformat docstrings
 # TODO: fix PEP 8 violations

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -378,12 +378,12 @@ def computeLinearStats(matchedRA,plotGen,diffMode,plot_title,plotfile_prefix,ver
         if plotGen == "screen":
             plt.show()
         if plotGen == "file":
-            # Put plotfile_prefix text string in lower right corner below plot
-            plt.text(1.0, -0.1, plotfile_prefix,horizontalalignment='right',verticalalignment='center',fontsize = 5,transform=ax1.transAxes)
-            # put time stamp in lower left corner below plot
+            # Put timestamp and plotfile_prefix text string in lower left corner below plot
             timestamp = "Generated {}".format(datetime.now().strftime("%m/%d/%Y %H:%M:%S"))
-            plt.text(0.0, -0.1, timestamp, horizontalalignment='left', verticalalignment='center',
-                     fontsize=5, transform=ax1.transAxes)
+            plt.text(0.0, -0.081, timestamp, horizontalalignment='left', verticalalignment='center', fontsize=5,
+                     transform=ax1.transAxes)
+            plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center', fontsize=5,
+                     transform=ax1.transAxes)
             plotFileName = "{}_{}.pdf".format(plotfile_prefix,plot_title.replace(" ","_"))
             plt.savefig(plotFileName)
             plt.close()

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -36,6 +36,8 @@ The following criteria must be met for the test to be declared "successful":
 * Flux (Outer Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
 * Magnitude (Inner Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
 * Magnitude (Outer Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Magnitude error (Inner Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
+* Magnitude error (Outer Aperture): The sigma-clipped mean of all comparison - reference difference values is less than 1 sigma from zero.
 * Flag Value: The total number of differing flag bits is less than 5% of the total number of reference flag bits.
 
 .. note::

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -627,7 +627,7 @@ def round2ArbatraryBase(value,direction,roundingBase):
     return rv
 #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 @util.with_logging
-def comparesourcelists(slNames,imgNames,plotGen,diffMode,verbose,debugMode):
+def comparesourcelists(slNames,imgNames,plotGen=None,diffMode="pmean",verbose=False,debugMode=False):
     """Main calling subroutine to compare sourcelists.
 
     Parameters
@@ -929,7 +929,7 @@ if __name__ == "__main__":
         ARGS.debugMode = True
     else: ARGS.debugMode = False
 
-    runStatus=comparesourcelists(ARGS.sourcelistNames,ARGS.imageNames,ARGS.plotGen,ARGS.diffMode,ARGS.verbose,ARGS.debugMode)
+    runStatus=comparesourcelists(ARGS.sourcelistNames,ARGS.imageNames,plotGen=ARGS.plotGen,diffMode=ARGS.diffMode,verbose=ARGS.verbose,debugMode=ARGS.debugMode)
 
 # TODO: reformat docstrings
 # TODO: fix PEP 8 violations

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -218,10 +218,10 @@ def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
 
         #plot flag breakdown by bit for all matched sources in the reference and comparison sourcelists
         width = 0.35
-        p1=plt.bar(idx - width/2,refFlagBreakdown,width,label='Reference')
-        p2 = plt.bar(idx + width/2, compFlagBreakdown,width, label='Comparison')
         fig = plt.figure()
         ax1 = fig.add_subplot(111)
+        p1=plt.bar(idx - width/2,refFlagBreakdown,width,label='Reference')
+        p2 = plt.bar(idx + width/2, compFlagBreakdown,width, label='Comparison')
         plt.legend()
         plt.xticks(idx, x_title_list)
         plt.xlabel("Flag Bit Value")
@@ -232,28 +232,41 @@ def computeFlagStats(matchedRA,plotGen,plot_title,plotfile_prefix, verbose):
         if plotGen == "screen":
             plt.show()
         if plotGen == "file":
-            plotFileName = fullPlotTitle.replace(" ","_")+".pdf"
+            # Put timestamp and plotfile_prefix text string in lower left corner below plot
+            timestamp = "Generated {}".format(datetime.now().strftime("%m/%d/%Y %H:%M:%S"))
+            plt.text(0.0, -0.081, timestamp, horizontalalignment='left', verticalalignment='center', fontsize=5,
+                     transform=ax1.transAxes)
+            plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center', fontsize=5,
+                     transform=ax1.transAxes)
+            plotFileName = "{}_{}.pdf".format(plotfile_prefix,fullPlotTitle.replace(" ","_"))
             plt.savefig(plotFileName)
             plt.close()
             log.info("{} plot saved to file {}.".format(fullPlotTitle, plotFileName))
 
-        #plot flag changes brokeken down by bit
+        #plot flag changes broken down by bit
+        fig = plt.figure()
+        ax2 = fig.add_subplot(111)
         p_unchanged=plt.bar(idx,unchangedFlagBreakdown)
         p_offOn=plt.bar(idx,off_on_FlagFlips,bottom=unchangedFlagBreakdown)
         p_onOff=plt.bar(idx,on_off_FlagFlips,bottom=off_on_FlagFlips+unchangedFlagBreakdown)
-        fig = plt.figure()
-        ax1 = fig.add_subplot(111)
         plt.xticks(idx,x_title_list)
         plt.xlabel("Flag Bit Value")
         plt.ylabel("Number of matched sources")
         fullPlotTitle = "Flagging Differences by Bit"
         plt.title(fullPlotTitle)
         plt.legend((p_onOff[0],p_offOn,p_unchanged[0]),("On -> Off","Off -> On","Unchanged"))
-
         if plotGen == "screen":
             plt.show()
         if plotGen == "file":
-            plotFileName = fullPlotTitle.replace(" ","_")+".pdf"
+            # Put timestamp and plotfile_prefix text string in lower left corner below plot
+            timestamp = "Generated {}".format(datetime.now().strftime("%m/%d/%Y %H:%M:%S"))
+            plt.text(0.0, -0.081, timestamp, horizontalalignment='left', verticalalignment='center',
+                     fontsize=5,
+                     transform=ax2.transAxes)
+            plt.text(0.0, -0.105, plotfile_prefix, horizontalalignment='left', verticalalignment='center',
+                     fontsize=5,
+                     transform=ax2.transAxes)
+            plotFileName = "{}_{}.pdf".format(plotfile_prefix, fullPlotTitle.replace(" ", "_"))
             plt.savefig(plotFileName)
             plt.close()
             log.info("{} plot saved to file {}.".format(fullPlotTitle, plotFileName))
@@ -796,7 +809,7 @@ def comparesourcelists(slNames,imgNames,plotGen=None,diffMode="pmean",plotfile_p
     # 11: Compute and display statistics on differences in flag populations for matched sources
     matched_values=extractMatchedLines("FLAGS",refData,compData,matching_lines_ref, matching_lines_img)
     if len(matched_values) >0:
-        rt_status=computeFlagStats(matched_values,plotGen,"Source Flagging",verbose)
+        rt_status=computeFlagStats(matched_values,plotGen,"Source Flagging",plotfile_prefix,verbose)
         regressionTestResults["Source Flagging"]=rt_status
         colTitles.append("Source Flagging")
     overallStatus="OK"

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4 ai :
-
+# TODO: UPDATE main docstring.
 """This script compares two sourcelists and displays various measures of their differences. 3x3-sigma clipped mean,
 median and standard deviation, and non-sigma clipped min and max values are computed for the following:
 

--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -646,6 +646,7 @@ def makeVectorPlot(x,y,plotDest,plotfile_prefix,binThresh = 10000,binSize=250):
         plt.savefig(plotFileName)
         plt.close()
         log.info("Vector plot saved to file {}".format(plotFileName))
+        log.info("\n")
 # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 def round2ArbatraryBase(value,direction,roundingBase):
     """Round value up or down to arbitrary base

--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -30,11 +30,16 @@ from drizzlepac import util
 from drizzlepac.devutils.comparison_tools import infrot
 from stsci.tools import logutil
 
-log = logutil.create_logger('starmatch_hist', level=logutil.logging.INFO, stream=sys.stdout)
+__taskname__ = 'starmatch_hist'
+
+MSG_DATEFMT = '%Y%j%H%M%S'
+SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
+log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
+                            format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
 msgunit = sys.stdout
-@util.with_logging
-def run(source_list_dict, minimum_match=10, xref=0.0, yref=0.0, postarg=None):
+
+def run(source_list_dict, log_level,minimum_match=10, xref=0.0, yref=0.0, postarg=None):
     """
     Match source lists in x,y coordinates allowing for possible shift & rotation
 
@@ -50,6 +55,7 @@ def run(source_list_dict, minimum_match=10, xref=0.0, yref=0.0, postarg=None):
     :type postarg: dictionary
     :returns: dictionary of lists of matching sourcelist indicies indexed by coo filename.
     """
+    log.setLevel(log_level)
     out_dict={}
     ### assumes list with greatest number of sources should be the reference file
     (coo_ref,number)=max(iter(source_list_dict.items()), key=lambda x:x[1])

--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -44,11 +44,13 @@ def run(source_list_dict, log_level,minimum_match=10, xref=0.0, yref=0.0, postar
     Match source lists in x,y coordinates allowing for possible shift & rotation
 
     :param source_list_dict: dictionary indexed by coo filename with number of sources in each file as value
+    :param log_level: the desired level of verboseness in the log statements displayed on the screen and written to the .log file.
     :param minimum_match: minimum number of matches in peak. Default value = '10'.
     :param xref: X reference pixel in image (default 0, which is a very bad value if image rotates) 
     :param yref: Y reference pixel in image (default 0, which is a very bad value if image rotates) 
     :param postarg: dictionary indexed by coo filename with (dx, dy) in pixels for postarg (default is to read FITS headers)
     :type source_list_dict: dictionary
+    :type log_level: integer
     :type minimum_match: integer
     :type xref: float
     :type yref: float

--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -69,9 +69,9 @@ def run(source_list_dict, minimum_match=10, xref=0.0, yref=0.0, postarg=None):
         if len(matched_list) < minimum_match:
             matched_flag = False
             if coo_img == coo_ref:
-                log.info("\n %s is reference image, starmatch_hist leaving WCS alone\n" %(coo_img,))
+                log.info("\n %s is reference image, starmatch_hist leaving WCS alone\n" %(os.path.basename(coo_img),))
             else:
-                log.info("\n %s -> %s starmatch_hist failed! Leaving WCS alone\n" %(coo_img,coo_ref))
+                log.info("\n %s -> %s starmatch_hist failed! Leaving WCS alone\n" %(os.path(coo_img),coo_ref))
     return(out_dict)
 
 
@@ -133,10 +133,10 @@ def getpostarg(source_list_dict):
                 dy = sinpa*postarg1+cospa*postarg2
                 rv[coo_img] = (dx, dy)
             except:
-                log.info("Warning: unable to fetch POSTARG info for image {}. Using POSTARG=0".format(fitsfile))
+                log.info("Warning: unable to fetch POSTARG info for image {}. Using POSTARG=0".format(os.path.basename(fitsfile)))
                 rv[coo_img] = (0.0, 0.0)
         else:
-            log.info('FITS file %s not found, using POSTARG=0' % fitsfile)
+            log.info('FITS file %s not found, using POSTARG=0' % os.path.basename(fitsfile))
             rv[coo_img] = (0.0,0.0)
     return rv
 

--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -71,7 +71,7 @@ def run(source_list_dict, minimum_match=10, xref=0.0, yref=0.0, postarg=None):
             if coo_img == coo_ref:
                 log.info("\n %s is reference image, starmatch_hist leaving WCS alone\n" %(os.path.basename(coo_img),))
             else:
-                log.info("\n %s -> %s starmatch_hist failed! Leaving WCS alone\n" %(os.path(coo_img),coo_ref))
+                log.info("\n %s -> %s starmatch_hist failed! Leaving WCS alone\n" %(os.path.basename(coo_img),coo_ref))
     return(out_dict)
 
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -503,7 +503,11 @@ def run_sourcelist_comparision(total_list,log_level=logutil.logging.INFO):
                 else:
                     hla_classic_cat_type = "sex"
                     plotfile_prefix = filt_obj.product_basename + "_segment"
-                hla_sourcelist_name = "{}/logs/{}{}_{}phot.txt".format(hla_classic_path,filt_obj.basename, filt_obj.filters, hla_classic_cat_type)
+                if hla_classic_basepath and hla_build_ver and os.path.exists(hla_classic_basepath):
+                    hla_sourcelist_name = "{}/logs/{}{}_{}phot.txt".format(hla_classic_path,filt_obj.basename, filt_obj.filters, hla_classic_cat_type)
+                else:
+                    hla_sourcelist_name = "{}/{}{}_{}phot.txt".format(hla_classic_path, filt_obj.basename,
+                                                                           filt_obj.filters, hla_classic_cat_type)
                 if not os.path.exists(hap_sourcelist_name) or not os.path.exists(hla_sourcelist_name): # Skip catalog type if one or both of the catalogs can't be found
                     continue
                 log.info("HAP image:           {}".format(os.path.basename(hap_imgname)))

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -409,7 +409,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
         # 9: Compare results to HLA classic counterparts (if possible)
         if diagnostic_mode:
-            run_sourcelist_comparision(total_list)
+            run_sourcelist_comparision(total_list,log_level=log_level)
         # Write out manifest file listing all products generated during processing
         log.info("Creating manifest file {}.".format(manifest_name))
         log.info("  The manifest contains the names of products generated during processing.")
@@ -445,7 +445,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-def run_sourcelist_comparision(total_list):
+def run_sourcelist_comparision(total_list,log_level=logutil.logging.INFO):
     """ This subroutine automates execution of drizzlepac/devutils/comparison_tools/compare_sourcelist_flagging.py to
     compare HAP-generated filter catalogs with their HLA classic counterparts.
 
@@ -455,6 +455,10 @@ def run_sourcelist_comparision(total_list):
         List of TotalProduct objects, one object per instrument/detector combination is
         a visit.  The TotalProduct objects are comprised of FilterProduct and ExposureProduct
         objects.
+
+    log_level : int, optional
+        The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+        Default value is 20, or 'info'.
 
     RETURNS
     -------
@@ -492,7 +496,7 @@ def run_sourcelist_comparision(total_list):
                 log.info("HAP catalog:         {}".format(os.path.basename(hap_sourcelist_name)))
                 log.info("HLA Classic catalog: {}".format(os.path.basename(hla_sourcelist_name)))
                 # once all file exist checks are passed, execute sourcelist comparision
-                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix=plotfile_prefix, verbose=False, debugMode=False)
+                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix=plotfile_prefix, verbose=False,log_level=log_level, debugMode=False)
 
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -464,7 +464,7 @@ def run_sourcelist_comparision(total_list):
         # hla_classic_path = os.path.join(base_path.replace("INST",tot_obj.instrument),
         #                                 tot_obj.prop_id,
         #                                 tot_obj.prop_id+"_"+tot_obj.obset_id) # Generate path to HLA classic products
-        hla_classic_path = os.path.join(os.getcwd()+"hla_classic")
+        hla_classic_path = os.path.join(os.getcwd(),"hla_classic")
         log.info("HLA classic path: {}".format(hla_classic_path))
         if not os.path.exists(hla_classic_path):
             log.warning("HLA classic path not found. Skipping HAP-HLA classic comparisons.")

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -461,10 +461,10 @@ def run_sourcelist_comparision(total_list):
     from drizzlepac.devutils.comparison_tools import compare_sourcelists
     base_path = "/ifs/public/hst/hla/INST/V10.0"
     for tot_obj in total_list:
-        hla_classic_path = os.path.join(base_path.replace("INST",tot_obj.instrument),
-                                        tot_obj.prop_id,
-                                        tot_obj.prop_id+"_"+tot_obj.obset_id) # Generate path to HLA classic products
-
+        # hla_classic_path = os.path.join(base_path.replace("INST",tot_obj.instrument),
+        #                                 tot_obj.prop_id,
+        #                                 tot_obj.prop_id+"_"+tot_obj.obset_id) # Generate path to HLA classic products
+        hla_classic_path = os.path.join(os.path.getcwd()+"hla_classic")
         log.info("HLA classic path: {}".format(hla_classic_path))
         if not os.path.exists(hla_classic_path):
             log.warning("HLA classic path not found. Skipping HAP-HLA classic comparisons.")

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -495,7 +495,7 @@ def run_sourcelist_comparision(total_list,log_level=logutil.logging.INFO):
                 log.info("HAP catalog:         {}".format(os.path.basename(hap_sourcelist_name)))
                 log.info("HLA Classic catalog: {}".format(os.path.basename(hla_sourcelist_name)))
                 # once all file exist checks are passed, execute sourcelist comparision
-                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix=plotfile_prefix, verbose=False,log_level=log_level, debugMode=False)
+                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix=plotfile_prefix, verbose=True,log_level=log_level, debugMode=False)
 
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -14,6 +14,14 @@
     logger basically filters which messages are passed on to the handlers according the
     level chosen. The logger is acting as a gate on the messages which are allowed to be
     passed to the handlers.
+
+    NOTE: In order for step 9 (run_sourcelist_comparison()) to run, the following environment variables need to be set:
+    - HLA_CLASSIC_BASEPATH
+    - HLA_BUILD_VER
+
+    Alternatively, if the HLA classic path is unavailable, The comparison can be run using locally stored HLA classic
+    files. The relevant HLA classic imagery and sourcelist files must be placed in a subdirectory of the current working
+    directory called 'hla_classic'.
 """
 import datetime
 import glob
@@ -447,6 +455,14 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 def run_sourcelist_comparision(total_list,log_level=logutil.logging.INFO):
     """ This subroutine automates execution of drizzlepac/devutils/comparison_tools/compare_sourcelist_flagging.py to
     compare HAP-generated filter catalogs with their HLA classic counterparts.
+
+    NOTE: In order for this subroutine to run, the following environment variables need to be set:
+    - HLA_CLASSIC_BASEPATH
+    - HLA_BUILD_VER
+
+    Alternatively, if the HLA classic path is unavailable, The comparison can be run using locally stored HLA classic
+    files. The relevant HLA classic imagery and sourcelist files must be placed in a subdirectory of the current working
+    directory called 'hla_classic'.
 
     Parameters
     ----------

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -301,7 +301,6 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         logname = input_filename.replace('.out', '.log')
     else:
         logname = 'svm_process.log'
-    print("Trailer filename: {}".format(logname))
     # Initialize total trailer filename as temp logname
     logging.basicConfig(filename=logname, format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
     # start processing

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -487,10 +487,10 @@ def run_sourcelist_comparision(total_list):
                 hla_sourcelist_name = "{}/logs/{}{}_{}phot.txt".format(hla_classic_path,filt_obj.basename, filt_obj.filters, hla_classic_cat_type)
                 if not os.path.exists(hap_sourcelist_name) or not os.path.exists(hla_sourcelist_name): # Skip catalog type if one or both of the catalogs can't be found
                     continue
-                log.info("HAP image:           {}".format(hap_imgname.replace(hla_classic_basepath,"")))
-                log.info("HLA Classic image:   {}".format(hla_imgname.replace(hla_classic_basepath,"")))
-                log.info("HAP catalog:         {}".format(hap_sourcelist_name.replace(hla_classic_basepath,"")))
-                log.info("HLA Classic catalog: {}".format(hla_sourcelist_name.replace(hla_classic_basepath,"")))
+                log.info("HAP image:           {}".format(os.path.basename(hap_imgname)))
+                log.info("HLA Classic image:   {}".format(os.path.basename(hla_imgname)))
+                log.info("HAP catalog:         {}".format(os.path.basename(hap_sourcelist_name)))
+                log.info("HLA Classic catalog: {}".format(os.path.basename(hla_sourcelist_name)))
                 # once all file exist checks are passed, execute sourcelist comparision
                 return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix=plotfile_prefix, verbose=False, debugMode=False)
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -464,7 +464,7 @@ def run_sourcelist_comparision(total_list):
         # hla_classic_path = os.path.join(base_path.replace("INST",tot_obj.instrument),
         #                                 tot_obj.prop_id,
         #                                 tot_obj.prop_id+"_"+tot_obj.obset_id) # Generate path to HLA classic products
-        hla_classic_path = os.path.join(os.path.getcwd()+"hla_classic")
+        hla_classic_path = os.path.join(os.getcwd()+"hla_classic")
         log.info("HLA classic path: {}".format(hla_classic_path))
         if not os.path.exists(hla_classic_path):
             log.warning("HLA classic path not found. Skipping HAP-HLA classic comparisons.")

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -490,7 +490,7 @@ def run_sourcelist_comparision(total_list):
                 log.info("HAP catalog:         {}".format(hap_sourcelist_name))
                 log.info("HLA Classic catalog: {}".format(hla_sourcelist_name))
                 # once all file exist checks are passed, execute sourcelist comparision
-                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname], False, "absolute", False, False)
+                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname], "file", "absolute", False, False)
 
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -460,10 +460,12 @@ def run_sourcelist_comparision(total_list):
     -------
     Nothing.
     """
+    #get HLA classic path details from envroment variables
     hla_classic_basepath = os.getenv('HLA_CLASSIC_BASEPATH')
+    hla_build_ver = os.getenv("HLA_BUILD_VER")
     for tot_obj in total_list:
-        if hla_classic_basepath and os.path.exists(hla_classic_basepath):
-            hla_cassic_basepath = os.path.join(hla_classic_basepath,tot_obj.instrument,"V10.0")
+        if hla_classic_basepath and hla_build_ver and os.path.exists(hla_classic_basepath):
+            hla_cassic_basepath = os.path.join(hla_classic_basepath,tot_obj.instrument,hla_build_ver)
             hla_classic_path = os.path.join(hla_cassic_basepath,tot_obj.prop_id,tot_obj.prop_id+"_"+tot_obj.obset_id) # Generate path to HLA classic products
         elif os.path.exists(os.path.join(os.getcwd(),"hla_classic")): # For local testing
             hla_classic_basepath = os.path.join(os.getcwd(), "hla_classic")
@@ -478,8 +480,10 @@ def run_sourcelist_comparision(total_list):
             for hap_sourcelist_name in [filt_obj.point_cat_filename, filt_obj.segment_cat_filename]:
                 if hap_sourcelist_name.endswith("point-cat.ecsv"):
                     hla_classic_cat_type = "dao"
+                    plotfile_prefix=filt_obj.product_basename+"_point"
                 else:
                     hla_classic_cat_type = "sex"
+                    plotfile_prefix = filt_obj.product_basename + "_segment"
                 hla_sourcelist_name = "{}/logs/{}{}_{}phot.txt".format(hla_classic_path,filt_obj.basename, filt_obj.filters, hla_classic_cat_type)
                 if not os.path.exists(hap_sourcelist_name) or not os.path.exists(hla_sourcelist_name): # Skip catalog type if one or both of the catalogs can't be found
                     continue
@@ -488,7 +492,7 @@ def run_sourcelist_comparision(total_list):
                 log.info("HAP catalog:         {}".format(hap_sourcelist_name.replace(hla_classic_basepath,"")))
                 log.info("HLA Classic catalog: {}".format(hla_sourcelist_name.replace(hla_classic_basepath,"")))
                 # once all file exist checks are passed, execute sourcelist comparision
-                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix="***plotfile_prefix***", verbose=False, debugMode=False)
+                return_status = compare_sourcelists.comparesourcelists([hla_sourcelist_name,hap_sourcelist_name], [hla_imgname, hap_imgname],plotGen="file",diffMode="absolute",plotfile_prefix=plotfile_prefix, verbose=False, debugMode=False)
 
 # ----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
See issue #542.
This script adds an additional step in hapsequencer which attempts to locate the equivalent HLA classic filter product image and sourcelist for each HAP filter drizzled product image/source list pair, and then if the HLA classic files are found,  executes drizzlepac/devutils/comparison_tools/compare_sourcelists.py.

Highlights:
- Added subroutine _run_sourcelist_comparision_ to hapsequencer.py. This subroutine takes care of locating the relevant HLA classic image/sourcelist and the actual execution of compare_sourcelists.py
- Brought logging in compare_sourcelists.py and starmatch_hist.py up to HAP standards
- Sanitized all mentions of absolute paths in log messages in compare_sourcelists.py and starmatch_hist.py
- The filenames of all .pdf plot files generated by compare_sorucelists.py are now prepended with a text string containing filt_obj.product_basename and hap catalog type ("point" or "segment") information. This information, as well as the date/time of plot generation is also written to the lower left corner of every plot to eliminate any potential ambiguity concerning which catalog comparison the plot files go to.