### PR TITLE
Modified SkyFootprint build method 

### DIFF
--- a/drizzlepac/hlautils/cell_utils.py
+++ b/drizzlepac/hlautils/cell_utils.py
@@ -160,7 +160,7 @@ class SkyFootprint(object):
                 ImageDraw.Draw(img).polygon(polygon, outline=1, fill=1)
                 blank = np.array(img)
 
-            self.total_mask += blank.astype(np.int16)
+                self.total_mask += blank.astype(np.int16)
 
     # Methods with 'find' compute values
     # Methods with 'get' return values


### PR DESCRIPTION
In module cell_utils.py, the build method of the SkyFootprint class had been updated, and subsequently, broke the code which computes the mask used by the Segment Catalog to distinguish between illuminated and non-illuminated portions of the input image.  In the old version of the code, the variable `blank` was appended each time through the inner `for` loop.  As such, the variable `self.total_mask` just needed to be updated for each new file examined.  In the new implementation, the variable `blank` is essentially reset each time through the `for` loop, so the variable `self.total_mask` needs to be updated every pass of the inner `for` loop.  

This PR addresses Issue #546.