### PR TITLE
Implement v1.0 of single fit for entire visit

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -26,7 +26,6 @@
 import datetime
 import glob
 import os
-import pdb
 import sys
 import traceback
 import logging
@@ -39,6 +38,8 @@ from drizzlepac.devutils.comparison_tools.read_hla import read_hla_catalog
 from drizzlepac.hlautils import config_utils
 from drizzlepac.hlautils import hla_flag_filter
 from drizzlepac.hlautils import poller_utils
+from drizzlepac.hlautils import product
+
 from drizzlepac.hlautils import processing_utils as proc_utils
 from stsci.tools import logutil
 from stwcs import wcsutil
@@ -108,7 +109,7 @@ def correct_hla_classic_ra_dec(orig_hla_classic_sl_name, cattype, log_level):
         cat.write(mod_sl_name, format="ascii.csv")
         return mod_sl_name
 
-    except:
+    except Exception:
         log.warning("There was a problem converting the RA and Dec values. Using original uncorrected HLA Classic sourcelist instead.")
         log.warning("Comparisons may be of questionable quality.")
         return orig_hla_classic_sl_name
@@ -386,7 +387,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         # where its FilterProduct is distinguished by the filter in use, and the ExposureProduct
         # is the atomic exposure data.
         log.info("Parse the poller and determine what exposures need to be combined into separate products.\n")
-        obs_info_dict, total_list = poller_utils.interpret_obset_input(input_filename,log_level)
+        obs_info_dict, total_list = poller_utils.interpret_obset_input(input_filename, log_level)
 
         # Generate the name for the manifest file which is for the entire visit.  It is fine
         # to use only one of the Total Products to generate the manifest name as the name is not
@@ -423,37 +424,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
                                                                   output_custom_pars_file=output_custom_pars_file)
         log.info("The configuration parameters have been read and applied to the drizzle objects.")
 
-        # Run align.py on images on a filter-by-filter basis.
-        # Process each filter object which contains a list of exposure objects/products.
-        log.info("\n{}: Align the images on a filter-by-filter basis.".format(str(datetime.datetime.now())))
-        for tot_obj in total_list:
-            for filt_obj in tot_obj.fdp_list:
-                align_table, filt_exposures = filt_obj.align_to_gaia(output=diagnostic_mode)
-
-                # Report results and track the output files
-                if align_table:
-                    log.info("ALIGN_TABLE: {}".format(align_table.filtered_table))
-                    for row in align_table.filtered_table:
-                        log.info(row['status'])
-                        if row['status'] == 0:
-                            log.info("Successfully aligned {} to {} astrometric frame\n".format(row['imageName'], row['catalog']))
-
-                        # Alignment did not work for this particular image
-                        # If alignment did not work for an image, image still has WCS so continue processing.
-                        else:
-                            log.info("Could not align {} to absolute astrometric frame\n".format(row['imageName']))
-
-                    hdrlet_list = align_table.filtered_table['headerletFile'].tolist()
-                    product_list += hdrlet_list
-                    product_list += filt_exposures
-
-                    # Remove reference catalogs created for alignment of each filter product
-                    for catalog_name in align_table.reference_catalogs:
-                        log.info("Looking to clean up reference catalog: {}".format(catalog_name))
-                        if os.path.exists(catalog_name):
-                            os.remove(catalog_name)
-                else:
-                    log.warning("Step to align the images has failed. No alignment table has been generated.")
+        run_align_to_gaia(total_list, product_list, log_level=log_level, diagnostic_mode=diagnostic_mode)
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))
@@ -478,7 +449,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
         # 9: Compare results to HLA classic counterparts (if possible)
         if diagnostic_mode:
-            run_sourcelist_comparision(total_list,log_level=log_level)
+            run_sourcelist_comparision(total_list, log_level=log_level)
         # Write out manifest file listing all products generated during processing
         log.info("Creating manifest file {}.".format(manifest_name))
         log.info("  The manifest contains the names of products generated during processing.")
@@ -512,9 +483,93 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         return return_value
 
 
+# ------------------------------------------------------------------------------------------------------------
+
+def run_align_to_gaia(total_list, product_list, log_level=logutil.logging.INFO, diagnostic_mode=False):
+
+        # Run align.py on images on a filter-by-filter basis.
+        # Process each filter object which contains a list of exposure objects/products.
+        log.info("\n{}: Align the images on a filter-by-filter basis.".format(str(datetime.datetime.now())))
+        for tot_obj in total_list:
+            for filt_obj in tot_obj.fdp_list:
+                align_table, filt_exposures = filt_obj.align_to_gaia(output=diagnostic_mode)
+                # Retain output results as attributes of each filter object for use in aligning across filters
+                filt_obj.align_table = align_table
+                filt_obj.filt_exposures = filt_exposures
+
+                # Report results and track the output files
+                if align_table:
+                    log.info("ALIGN_TABLE: {}".format(align_table.filtered_table))
+                    for row in align_table.filtered_table:
+                        log.info(row['status'])
+                        if row['status'] == 0:
+                            log.info("Successfully aligned {} to {} astrometric frame\n".format(row['imageName'], row['catalog']))
+
+                        # Alignment did not work for this particular image
+                        # If alignment did not work for an image, image still has WCS so continue processing.
+                        else:
+                            log.info("Could not align {} to absolute astrometric frame\n".format(row['imageName']))
+
+                    hdrlet_list = align_table.filtered_table['headerletFile'].tolist()
+                    product_list += hdrlet_list
+                    product_list += filt_exposures
+
+                    # Remove reference catalogs created for alignment of each filter product
+                    for catalog_name in align_table.reference_catalogs:
+                        log.info("Looking to clean up reference catalog: {}".format(catalog_name))
+                        if os.path.exists(catalog_name):
+                            os.remove(catalog_name)
+                else:
+                    log.warning("Step to align the images has failed. No alignment table has been generated.")
+
+        # Run align.py on all input images sorted by overlap with GAIA bandpass
+        log.info("\n{}: Align the all filters to GAIA with the same fit".format(str(datetime.datetime.now())))
+        gaia_obj = None
+        # Start by creating a FilterProduct instance which includes ALL input exposures
+        for tot_obj in total_list:
+            for exp_obj in tot_obj.edp_list:
+                    if gaia_obj is None:
+                        prod_list = exp_obj.info.split("_")
+                        prod_list[4] = "metawcs"
+                        gaia_obj = product.FilterProduct(prod_list[0], prod_list[1], prod_list[2],
+                                                         prod_list[3], prod_list[4], prod_list[5],
+                                                         prod_list[6], log_level)
+                        gaia_obj.configobj_pars = tot_obj.configobj_pars
+                    gaia_obj.add_member(exp_obj)
+
+        log.info("\n{}: Combined all filter objects in gaia_obj".format(str(datetime.datetime.now())))
+        # Now, perform alignment to GAIA with 'match_relative_fit' across all inputs
+        # Need to start with one filt_obj.align_table instance as gaia_obj.align_table
+        #  - append imglist from each filt_obj.align_table to the gaia_obj.align_table.imglist
+        #  - reset group_id for all members of gaia_obj.align_table.imglist to the unique incremental values
+        #  - run gaia_obj.align_table.perform_fit() with 'match_relative_fit' only
+        #  - migrate updated WCS solutions to exp_obj instances, if necessary (probably not?)
+        #  - re-run tot_obj.generate_metawcs() method to recompute total object meta_wcs based on updated
+        #    input exposure's WCSs
+        gaia_align_table = None
+        for tot_obj in total_list:
+            for filt_obj in tot_obj.fdp_list:
+                if gaia_align_table is None:
+                    gaia_align_table = filt_obj.align_table
+                else:
+                    gaia_align_table.imglist.extend(filt_obj.align_table.imglist)
+                    gaia_align_table.process_list.extend(filt_obj.align_table.process_list)
+
+        for group_id, img in enumerate(gaia_align_table.imglist):
+            img.meta['group_id'] = group_id
+        gaia_obj.align_to_gaia(align_table=gaia_align_table, fit_label='SVM')
+        for tot_obj in total_list:
+            tot_obj.generate_metawcs()
+        log.info("\n{}: Finished aligning gaia_obj to GAIA".format(str(datetime.datetime.now())))
+
+        #
+        # Composite WCS fitting should be done at this point so that all exposures have been fit to GAIA at
+        # the same time (on the same frame)
+        #
+
 # ----------------------------------------------------------------------------------------------------------------------
 
-def run_sourcelist_comparision(total_list,log_level=logutil.logging.INFO):
+def run_sourcelist_comparision(total_list, log_level=logutil.logging.INFO):
     """ This subroutine automates execution of drizzlepac/devutils/comparison_tools/compare_sourcelist_flagging.py to
     compare HAP-generated filter catalogs with their HLA classic counterparts.
 
@@ -636,19 +691,19 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_lev
         drz_root_dir = os.getcwd()
         log.info("Run source list flagging on catalog file {}.".format(catalog_name))
         filter_product_catalogs.catalogs[cat_type].source_cat = hla_flag_filter.run_source_list_flagging(drizzled_image,
-                                                                                                         flt_list,
-                                                                                                         param_dict,
-                                                                                                         exptime,
-                                                                                                         plate_scale,
-                                                                                                         median_sky,
-                                                                                                         catalog_name,
-                                                                                                         catalog_data,
-                                                                                                         cat_type,
-                                                                                                         drz_root_dir,
-                                                                                                         filter_product_obj.hla_flag_msk,
-                                                                                                         ci_lookup_file_path,
-                                                                                                         output_custom_pars_file,
-                                                                                                         log_level,
-                                                                                                         diagnostic_mode)
+                                                     flt_list,
+                                                     param_dict,
+                                                     exptime,
+                                                     plate_scale,
+                                                     median_sky,
+                                                     catalog_name,
+                                                     catalog_data,
+                                                     cat_type,
+                                                     drz_root_dir,
+                                                     filter_product_obj.hla_flag_msk,
+                                                     ci_lookup_file_path,
+                                                     output_custom_pars_file,
+                                                     log_level,
+                                                     diagnostic_mode)
 
     return filter_product_catalogs

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -61,6 +61,7 @@ class AlignmentTable:
                           plot=False, vmax=None, deblend=False
         """
         log.setLevel(log_level)
+
         # Register fit methods with the class
         self.fit_methods = {'relative': match_relative_fit,
                             '2dhist': match_2dhist_fit,
@@ -193,6 +194,9 @@ class AlignmentTable:
 
     def perform_fit(self, method_name, catalog_name, reference_catalog):
         """Perform fit using specified method, then determine fit quality"""
+        inputs = [img.meta['name'] for img in self.imglist]
+        log.info("Performing {} astrometric fit to {} for: \n    {}".format(method_name,
+                                                                            reference_catalog, inputs))
         imglist = self.fit_methods[method_name](self.imglist, reference_catalog,
                                                 **self.fit_pars[method_name])
 
@@ -496,10 +500,10 @@ class HAPImage:
         # from one image to a single source in the
         # other or vice-versa.
         # Create temp DQ mask containing all pixels flagged with any value EXCEPT 256
-        non_sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=256+2048)
+        non_sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=256 + 2048)
 
         # Create temp DQ mask containing saturated pixels ONLY
-        sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=~(256+2048))
+        sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=~(256 + 2048))
 
         # Ignore sources where only a couple of pixels are flagged as saturated
         sat_mask = ndimage.binary_erosion(sat_mask, iterations=1)
@@ -562,6 +566,8 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     log.info("{} (match_relative_fit) Cross matching and fitting {}".format("-" * 20, "-" * 27))
     # 0: Specify matching algorithm to use
     match = tweakwcs.TPMatch(**fit_pars)
+    log.debug("Relative fit configured with: \n  {}".format(fit_pars))
+
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
     #                          tolerance=100, use2dhist=False)
 

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -499,20 +499,9 @@ class HAPImage:
         # source match algorithm from trying to match multiple sources
         # from one image to a single source in the
         # other or vice-versa.
-        # Create temp DQ mask containing all pixels flagged with any value EXCEPT 256
-        non_sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=256 + 2048)
+        # Create temp DQ mask containing all pixels flagged with any value EXCEPT 512 (bad ref pixel)
+        dqmask = bitfield_to_boolean_mask(dqarr, ignore_flags=512)
 
-        # Create temp DQ mask containing saturated pixels ONLY
-        sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=~(256 + 2048))
-
-        # Ignore sources where only a couple of pixels are flagged as saturated
-        sat_mask = ndimage.binary_erosion(sat_mask, iterations=1)
-
-        # Grow out saturated pixels by a few pixels in every direction
-        grown_sat_mask = ndimage.binary_dilation(sat_mask, iterations=5)
-
-        # combine the two temporary DQ masks into a single composite DQ mask.
-        dqmask = np.bitwise_or(non_sat_mask, grown_sat_mask)
         return dqmask
 
     def find_alignment_sources(self, output=True, dqname='DQ', **alignment_pars):

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -494,11 +494,6 @@ class HAPImage:
         else:
             dqarr = np.concatenate([self.imghdu[('DQ', i + 1)].data for i in range(self.num_sci)])
 
-        # "grow out" regions in DQ mask flagged as saturated by several
-        # pixels in every direction to prevent the
-        # source match algorithm from trying to match multiple sources
-        # from one image to a single source in the
-        # other or vice-versa.
         # Create temp DQ mask containing all pixels flagged with any value EXCEPT 512 (bad ref pixel)
         dqmask = bitfield_to_boolean_mask(dqarr, ignore_flags=512)
 

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -710,9 +710,9 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                 # the center of the PSF (saturated and streaked along the Y axis)
                 max_row = np.where(seg_table['peak'] == seg_table['peak'].max())[0][0]
 
-                # Add logic to remove sources which have more than 8 pixels
+                # Add logic to remove sources which have more than 3 pixels
                 # within 10% of the max value in the source segment, a situation
-                # which would indicate bleeding from a saturated source
+                # which would indicate the presence of a saturated source
                 if (detection_img > detection_img.max() * 0.9).sum() > 3:
 
                     # Revert to segmentation photometry for sat. source posns

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -89,7 +89,7 @@ FOCUS_DICT = {'exp': [], 'prod': [], 'stats': {},
               'exp_pos': None, 'prod_pos': None,
               'alignment_verified': False, 'alignment_quality': -1,
               'expnames': "", 'prodname': ""}
-              
+
 EXP_LIMIT = 0.05  # hard-limit of exptime weighting for comparing images
 EXP_RATIO = 0.2
 
@@ -457,7 +457,7 @@ def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
     if peaks is None or (peaks is not None and len(peaks) == 0):
         peaks = photutils.detection.find_peaks(kern_img, threshold=threshold,
                                               box_size=isolation_size)
-        
+
     # Sort based on peak_value to identify brightest sources for use as a kernel
     peaks.sort('peak_value', reverse=True)
 
@@ -674,6 +674,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
 
         for indx in src_brightest:
             segment = segm.segments[indx]
+
         # for segment in segm.segments:
             # check needed for photutils <= 0.6; it can be removed when
             # the drizzlepac depends on photutils >= 0.7
@@ -700,6 +701,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
             # Pick out brightest source only
             if src_table is None and seg_table:
                 # Initialize final master source list catalog
+                log.debug("Defining initial src_table based on: {}".format(seg_table.colnames))
                 src_table = Table(names=seg_table.colnames,
                                   dtype=[dt[1] for dt in seg_table.dtype.descr])
 
@@ -707,31 +709,41 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                 # This logic will eliminate saturated sources, where the max pixel value is not
                 # the center of the PSF (saturated and streaked along the Y axis)
                 max_row = np.where(seg_table['peak'] == seg_table['peak'].max())[0][0]
-                peak_posx = int(seg_table[max_row]['xcentroid'] + 0.5)
-                peak_posy = int(seg_table[max_row]['ycentroid'] + 0.5)
-                delta = (source_box - 1) // 2
-                min_x = peak_posx - delta if peak_posx - delta > 0 else 0
-                max_x = peak_posx + delta + 1 if peak_posx + delta + 1 < seg_slice[1].stop else seg_slice[1].stop
-                min_y = peak_posy - delta if peak_posy - delta > 0 else 0
-                max_y = peak_posy + delta + 1 if peak_posy + delta + 1 < seg_slice[0].stop else seg_slice[0].stop
-                peak_region = detection_img[min_y:max_y, min_x:max_x]
 
-                if np.isclose(peak_region, seg_table['peak'].max()).any():
-                    # Add row for detected source to master catalog
-                    # apply offset to slice to convert positions into full-frame coordinates
-                    seg_table['xcentroid'] += seg_xoffset
-                    seg_table['ycentroid'] += seg_yoffset
-                    src_table.add_row(seg_table[max_row])
+                # Add logic to remove sources which have more than 8 pixels
+                # within 10% of the max value in the source segment, a situation
+                # which would indicate bleeding from a saturated source
+                if (detection_img > detection_img.max() * 0.9).sum() > 3:
+
+                    # Revert to segmentation photometry for sat. source posns
+                    segment_properties = source_properties(detection_img, segment.data)
+                    sat_table = segment_properties.to_table()
+                    seg_table['flux'][max_row] = sat_table['source_sum'][0]
+                    seg_table['peak'][max_row] = sat_table['max_value'][0]
+                    seg_table['xcentroid'][max_row] = sat_table['xcentroid'][0].value
+                    seg_table['ycentroid'][max_row] = sat_table['ycentroid'][0].value
+                    seg_table['npix'][max_row] = sat_table['area'][0].value
+                    sky = sat_table['background_mean'][0]
+                    seg_table['sky'][max_row] = sky.value if sky is not None and not np.isnan(sky) else 0.0
+                    seg_table['mag'][max_row] = -2.5 * np.log10(sat_table['source_sum'][0])
+
+                # Add row for detected source to master catalog
+                # apply offset to slice to convert positions into full-frame coordinates
+                seg_table['xcentroid'] += seg_xoffset
+                seg_table['ycentroid'] += seg_yoffset
+                src_table.add_row(seg_table[max_row])
 
             # If we have accumulated the desired number of sources, stop looking for more...
             if nlargest is not None and src_table is not None and len(src_table) == nlargest:
                 break
     else:
+        log.debug("Determining source properties as src_table...")
         cat = source_properties(img, segm)
         src_table = cat.to_table()
         # Make column names consistent with IRAFStarFinder column names
         src_table.rename_column('source_sum', 'flux')
         src_table.rename_column('source_sum_err', 'flux_err')
+        src_table.rename_column('max_value', 'peak')
 
     if src_table is not None:
         log.info("Total Number of detected sources: {}".format(len(src_table)))
@@ -1710,7 +1722,7 @@ def max_overlap_diff(total_mask, singlefiles, prodfile, sigma=2.0, scale=1):
         sfile_arr = sfile_region[yslice, xslice]
 
         # The number of sources detected is subject to crowding/blending of sources
-        # as well as noise from the background (if too low 
+        # as well as noise from the background (if too low
         #  a background value is used)
         drzlabels, drznum = detect_point_sources(drz_arr, scale=scale)
         slabels, snum = detect_point_sources(sfile_arr, scale=scale, exp_weight=exp_weight)

--- a/drizzlepac/hlautils/cell_utils.py
+++ b/drizzlepac/hlautils/cell_utils.py
@@ -636,3 +636,199 @@ def compute_band_height(wcs):
 
     edge_sky = wcs.pixel_to_world_values(edges)
     return min(edge_sky[:, 1]), max(edge_sky[:, 1])
+
+
+#
+#
+# CKmeans implementation from github/llimllib/ckmeans
+#
+#
+import numpy as np
+
+def ssq(j, i, sum_x, sum_x_sq):
+    if (j > 0):
+        muji = (sum_x[i] - sum_x[j-1]) / (i - j + 1)
+        sji = sum_x_sq[i] - sum_x_sq[j-1] - (i - j + 1) * muji ** 2
+    else:
+        sji = sum_x_sq[i] - sum_x[i] ** 2 / (i+1)
+
+    return 0 if sji < 0 else sji
+
+def fill_row_k(imin, imax, k, S, J, sum_x, sum_x_sq, N):
+    if imin > imax: return
+
+    i = (imin+imax) // 2
+    S[k][i] = S[k-1][i-1]
+    J[k][i] = i
+
+    jlow = k
+
+    if imin > k:
+        jlow = int(max(jlow, J[k][imin-1]))
+    jlow = int(max(jlow, J[k-1][i]))
+
+    jhigh = i-1
+    if imax < N-1:
+        jhigh = int(min(jhigh, J[k][imax+1]))
+
+    for j in range(jhigh, jlow-1, -1):
+        sji = ssq(j, i, sum_x, sum_x_sq)
+
+        if sji + S[k-1][jlow-1] >= S[k][i]: break
+
+        # Examine the lower bound of the cluster border
+        # compute s(jlow, i)
+        sjlowi = ssq(jlow, i, sum_x, sum_x_sq)
+
+        SSQ_jlow = sjlowi + S[k-1][jlow-1]
+
+        if SSQ_jlow < S[k][i]:
+            S[k][i] = SSQ_jlow
+            J[k][i] = jlow
+
+        jlow += 1
+
+        SSQ_j = sji + S[k-1][j-1]
+        if SSQ_j < S[k][i]:
+            S[k][i] = SSQ_j
+            J[k][i] = j
+
+    fill_row_k(imin, i-1, k, S, J, sum_x, sum_x_sq, N)
+    fill_row_k(i+1, imax, k, S, J, sum_x, sum_x_sq, N)
+
+def fill_dp_matrix(data, S, J, K, N):
+    sum_x = np.zeros(N, dtype=np.float_)
+    sum_x_sq = np.zeros(N, dtype=np.float_)
+
+    # median. used to shift the values of x to improve numerical stability
+    shift = data[N//2]
+
+    for i in range(N):
+        if i == 0:
+            sum_x[0] = data[0] - shift
+            sum_x_sq[0] = (data[0] - shift) ** 2
+        else:
+            sum_x[i] = sum_x[i-1] + data[i] - shift
+            sum_x_sq[i] = sum_x_sq[i-1] + (data[i] - shift) ** 2
+
+        S[0][i] = ssq(0, i, sum_x, sum_x_sq)
+        J[0][i] = 0
+
+    for k in range(1, K):
+        if (k < K-1):
+            imin = max(1, k)
+        else:
+            imin = N-1
+
+        fill_row_k(imin, N-1, k, S, J, sum_x, sum_x_sq, N)
+
+def ckmeans(data, n_clusters):
+    if n_clusters <= 0:
+        raise ValueError("Cannot classify into 0 or less clusters")
+    if n_clusters > len(data):
+        raise ValueError("Cannot generate more classes than there are data values")
+
+    # if there's only one value, return it; there's no sensible way to split
+    # it. This means that len(ckmeans([data], 2)) may not == 2. Is that OK?
+    unique = len(set(data))
+    if unique == 1:
+        return [data]
+
+    data.sort()
+    n = len(data)
+
+    S = np.zeros((n_clusters, n), dtype=np.float_)
+
+    J = np.zeros((n_clusters, n), dtype=np.uint64)
+
+    fill_dp_matrix(data, S, J, n_clusters, n)
+
+    clusters = []
+    cluster_right = n-1
+
+    for cluster in range(n_clusters-1, -1, -1):
+        cluster_left = int(J[cluster][cluster_right])
+        clusters.append(data[cluster_left:cluster_right+1])
+
+        if cluster > 0:
+            cluster_right = cluster_left - 1
+
+    return list(reversed(clusters))
+
+##
+## HELPER CODE FOR TESTS
+##
+
+# partition recipe modified from
+# http://wordaligned.org/articles/partitioning-with-python
+from itertools import chain, combinations
+
+def sliceable(xs):
+    '''Return a sliceable version of the iterable xs.'''
+    try:
+        xs[:0]
+        return xs
+    except TypeError:
+        return tuple(xs)
+
+def partition_n(iterable, n):
+    s = sliceable(iterable)
+    l = len(s)
+    b, mid, e = [0], list(range(1, l)), [l]
+    getslice = s.__getitem__
+    splits = (d for i in range(l) for d in combinations(mid, n-1))
+    return [[s[sl] for sl in map(slice, chain(b, d), chain(d, e))]
+            for d in splits]
+
+def squared_distance(part):
+    mean = sum(part)/len(part)
+    return sum((x-mean)**2 for x in part)
+
+# given a partition, return the sum of the squared distances of each part
+def sum_of_squared_distances(partition):
+    return sum(squared_distance(part) for part in partition)
+
+# brute force the correct answer by testing every partition.
+def min_squared_distance(data, n):
+    return min((sum_of_squared_distances(partition), partition)
+                for partition in partition_n(data, n))
+
+
+# if __name__ == "__main__":
+def ckmeans_test():
+    try:
+        ckmeans([], 10)
+        1/0
+    except ValueError:
+        pass
+
+    tests = [
+        (([1], 1),                    [[1]]),
+        (([0,3,4], 2),                [[0], [3,4]]),
+        (([-3,0,4], 2),               [[-3,0], [4]]),
+        (([1,1,1,1], 1),              [[1,1,1,1]]),
+        (([1,2,3], 3),                [[1], [2], [3]]),
+        (([1,2,2,3], 3),              [[1], [2,2], [3]]),
+        (([1,2,2,3,3], 3),            [[1], [2,2], [3,3]]),
+        (([1,2,3,2,3], 3),            [[1], [2,2], [3,3]]),
+        (([3,2,3,2,1], 3),            [[1], [2,2], [3,3]]),
+        (([3,2,3,5,2,1], 3),          [[1,2,2], [3,3], [5]]),
+        (([0,1,2,100,101,103], 2),    [[0,1,2], [100,101,103]]),
+        (([0,1,2,50,100,101,103], 3), [[0,1,2], [50], [100,101,103]]),
+        (([-1,2,-1,2,4,5,6,-1,2,-1], 3),
+            [[-1, -1, -1, -1], [2, 2, 2], [4, 5, 6]]),
+    ]
+
+    for test in tests:
+        args, expected = test
+        try:
+            result = ckmeans(*args)
+        except:
+            print("✗ {}, {}".format(args[0], args[1], result))
+            raise
+        errormsg = "✗ ckmeans({}) = {} != {}\n{} > {}".format(
+                args, result, expected,
+                sum_of_squared_distances(result),
+                sum_of_squared_distances(expected))
+        assert np.array_equal(result, expected), errormsg
+        print("✓ {}".format(result))

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -38,7 +38,7 @@
     {
       "searchrad": 100,
       "separation": 0.1,
-      "tolerance": 2,
+      "tolerance": 0.5,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -37,8 +37,8 @@
   "match_relative_fit":
     {
       "searchrad": 100,
-      "separation": 0.1,
-      "tolerance": 0.5,
+      "separation": 4.0,
+      "tolerance": 2.0,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -37,8 +37,8 @@
   "match_relative_fit":
     {
       "searchrad": 75,
-      "separation": 0.1,
-      "tolerance": 0.5,
+      "separation": 4.0,
+      "tolerance": 2.0,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -38,7 +38,7 @@
     {
       "searchrad": 75,
       "separation": 0.1,
-      "tolerance": 2,
+      "tolerance": 0.5,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -38,7 +38,7 @@
       {
         "searchrad": 100,
         "separation": 0.1,
-        "tolerance": 2,
+        "tolerance": 0.5,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -37,8 +37,8 @@
     "match_relative_fit":
       {
         "searchrad": 100,
-        "separation": 0.1,
-        "tolerance": 0.5,
+        "separation": 4.0,
+        "tolerance": 2.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -38,7 +38,7 @@
       {
         "searchrad": 75,
         "separation": 0.1,
-        "tolerance": 2,
+        "tolerance": 0.5,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -37,8 +37,8 @@
     "match_relative_fit":
       {
         "searchrad": 75,
-        "separation": 0.1,
-        "tolerance": 0.5,
+        "separation": 4.0,
+        "tolerance": 2.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -38,7 +38,7 @@
       {
         "searchrad": 75,
         "separation": 0.1,
-        "tolerance": 2,
+        "tolerance": 0.5,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -37,8 +37,8 @@
     "match_relative_fit":
       {
         "searchrad": 75,
-        "separation": 0.1,
-        "tolerance": 0.5,
+        "separation": 4.0,
+        "tolerance": 2.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -38,7 +38,7 @@
     {
       "searchrad": 100,
       "separation": 0.1,
-      "tolerance": 2,
+      "tolerance": 0.5,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -37,8 +37,8 @@
   "match_relative_fit":
     {
       "searchrad": 100,
-      "separation": 0.1,
-      "tolerance": 0.5,
+      "separation": 4.0,
+      "tolerance": 2.0,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -37,8 +37,8 @@
   "match_relative_fit":
     {
       "searchrad": 75,
-      "separation": 0.1,
-      "tolerance": 0.5,
+      "separation": 4.0,
+      "tolerance": 2.0,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -38,7 +38,7 @@
     {
       "searchrad": 75,
       "separation": 0.1,
-      "tolerance": 2,
+      "tolerance": 0.5,
       "use2dhist": true
     },
   "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -38,7 +38,7 @@
       {
         "searchrad": 100,
         "separation": 0.1,
-        "tolerance": 2,
+        "tolerance": 0.5,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -37,8 +37,8 @@
     "match_relative_fit":
       {
         "searchrad": 100,
-        "separation": 0.1,
-        "tolerance": 0.5,
+        "separation": 4.0,
+        "tolerance": 2.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -38,7 +38,7 @@
       {
         "searchrad": 75,
         "separation": 0.1,
-        "tolerance": 2,
+        "tolerance": 0.5,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -37,8 +37,8 @@
     "match_relative_fit":
       {
         "searchrad": 75,
-        "separation": 0.1,
-        "tolerance": 0.5,
+        "separation": 4.0,
+        "tolerance": 2.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -37,8 +37,8 @@
     "match_relative_fit":
       {
         "searchrad": 25,
-        "separation": 0.1,
-        "tolerance": 0.5,
+        "separation": 4.0,
+        "tolerance": 2.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -36,9 +36,9 @@
       },
     "match_relative_fit":
       {
-        "searchrad": 75,
+        "searchrad": 25,
         "separation": 0.1,
-        "tolerance": 2,
+        "tolerance": 0.5,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -36,7 +36,7 @@
       },
     "match_relative_fit":
       {
-        "searchrad": 25,
+        "searchrad": 75,
         "separation": 4.0,
         "tolerance": 2.0,
         "use2dhist": true

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -511,6 +511,7 @@ def interpret_wcsname_type(wcsname):
     wcstype = ''
     fit_terms = {'REL': 'relatively aligned to {}',
                  'IMG': 'aligned image-by-image to {}',
+                 'EVM': 'aligned by visit-exposures to {}',
                  'SVM': 'aligned by visit to {}'}
     post_fit = 'a posteriori solution '
     default_fit = 'a priori solution based on {}'


### PR DESCRIPTION
This implements the initial version of a single WCS fit for all exposures in a single visit for a single instrument (across all detectors used for the visit) as described in #521.  This does NOT implement the actual input exposure sorting described in #521 that will be expected by this PR.  

- User values and default values for tolerance for 'match_relative_fit' were lowered to 0.5.  This relies on the assumption that the errors in the proper motions for the GAIA sources are going to be within 20-25 mas depending on the time of the observation for enough sources to get a good alignment to GAIA. 
-  The fit uses the 'relative' fit method to align all exposures to each other THEN perform a single uniform fit to GAIA for the entire mosaic and relies on background and source determinations performed for image-to-image alignment.  Image-to-image alignment retained in order to serve as the default alignment of the visit. 
- A new label has been defined (EVM) to indicate that only an image-to-image alignment could be performed and that the final fit to GAIA was unsuccessful.  
- The alignment code was pulled into it's own function that gets called by hapsequencer to try to isolate any further changes to alignment processing. 
- Fixes logging for align_utils as it needed to be set upon getting called by `product.py`.  

`
NOTE:
In addition to these alignment based changes, 'hlautils/cell_utils' was updated to include an implementation of the Ckmeans algorithm for experimentation with grouping exposures by date for use in the multi-visit processing. 
`

This code successfully aligned all the data from ib4606 (both UVIS and IR) into a single alignment to GAIA.  