### PR TITLE
Add rms to headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,15 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-3.1.0 (unreleased)
+3.1.5 (unreleased)
+==================
+
+- Update calibrated (FLC/FLT) files with RMS and NMATCH keywords when it successfully
+  aligns the data to GAIA using the a posteriori fit.  Headerlet files for this fit
+  which already have these keywords are now retained and provided as the final output
+  headerlets as well.  [#554]
+
+3.1.3 (5-Dec-2019)
 ==================
 
 - Fixed a bug in the ``updatehdr.update_from_shiftfile()`` function that would
@@ -28,10 +36,9 @@ of the list).
 
 - Implementation of grid definition interface to support returning SkyCell
   objects that overlap a mosaic footprint. [#425]
-  
-- Complete rewrite of ``runastrodriz`` for pipeline processing to include
-  multi-level verification of alignment.  [#440]  
 
+- Complete rewrite of ``runastrodriz`` for pipeline processing to include
+  multi-level verification of alignment.  [#440]
 
 3.0.2 (15-Jul-2019)
 ====================

--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -227,7 +227,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
             log.warning("WARNING: Unable to display Git repository revision information.")
 
     try:
-        # Initialize key variables 
+        # Initialize key variables
         filtered_table = None
 
         # 1: Interpret input data and optional parameters
@@ -863,6 +863,7 @@ def update_headerlet_phdu(tweakwcs_item, headerlet):
     scale = tweakwcs_item.meta['fit_info']['scale'][0]
     skew = tweakwcs_item.meta['fit_info']['skew']
 
+    log.info("Headerlet being updated with RMS_RA={},  RMS_DEC={}".format(rms_ra, rms_dec))
     # Update the existing FITS keywords
     primary_header = headerlet[0].header
     primary_header['RMS_RA'] = rms_ra

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -349,7 +349,7 @@ class HAPImage:
         log.info("Looking for sample PSF in {}".format(self.rootname))
         log.debug("  based on RMS of {}".format(threshold_rms.mean()))
         fwhm = fwhmpsf / self.pscale
-        
+
         k, self.kernel_fwhm = amutils.build_auto_kernel(self.data - bkg,
                                                         self.wht_image,
                                                         threshold=threshold_rms,
@@ -362,7 +362,7 @@ class HAPImage:
             log.info("Looking for sample PSF in {}".format(self.rootname))
             log.debug("  based on RMS of {}".format(threshold_rms.mean()))
             fwhm = fwhmpsf / self.pscale
-            
+
             k, self.kernel_fwhm = amutils.build_auto_kernel(self.data - bkg,
                                                             self.wht_image,
                                                             threshold=threshold_rms,
@@ -808,9 +808,14 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
                 sci_ext_dict["{}".format(sci_ext_ctr)] = fileutil.findExtname(hdulist, 'sci', extver=sci_ext_ctr)
 
         # update header with new WCS info
-        updatehdr.update_wcs(hdulist, sci_ext_dict["{}".format(item.meta['chip'])], item.wcs,
-                             wcsname=wcs_name,
-                             reusename=True)
+        sci_extn = sci_ext_dict["{}".format(item.meta['chip'])]
+        updatehdr.update_wcs(hdulist, sci_extn, item.wcs, wcsname=wcs_name, reusename=True)
+        hdulist[sci_extn].header['RMS_RA'] = item.meta['fit_info']['RMS_RA'].value
+        hdulist[sci_extn].header['RMS_DEC'] = item.meta['fit_info']['RMS_DEC'].value
+        hdulist[sci_extn].header['CRDER1'] = item.meta['fit_info']['RMS_RA'].value
+        hdulist[sci_extn].header['CRDER2'] = item.meta['fit_info']['RMS_DEC'].value
+        hdulist[sci_extn].header['NMATCHES'] = len(item.meta['fit_info']['ref_mag'])
+
         if chipctr == num_sci_ext:
             # Close updated flc.fits or flt.fits file
             hdulist.flush()

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -551,7 +551,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         # Generate headerlets for each updated FLT image
         hlet_msg = _timestamp("Writing Headerlets started")
         for fname in _calfiles:
-            print("Creating new headerlet from {}".format(fname))
+            hlet_msg += "Creating new headerlet from {}".format(fname)
             frootname = fileutil.buildNewRootname(fname)
             hname = "%s_flt_hlet.fits" % frootname
             # Write out headerlet file used by astrodrizzle, however,
@@ -632,14 +632,12 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
         _trlmsg = _timestamp('astrodrizzle started ')
         _trlmsg += __trlmarker__
         _trlmsg += '%s: Processing %s with astrodrizzle Version %s\n' % (_getTime(), infile, pyver)
-
+        print(_trlmsg)
         _updateTrlFile(trlfile, _trlmsg)
 
         _pyd_err = trlfile.replace('.tra', '_pydriz.stderr')
 
         try:
-            print("Running AstroDrizzle on: {}".format(infile))
-
             drizzlepac.astrodrizzle.AstroDrizzle(input=infile, configobj=None,
                                                  **pipeline_pars)
             util.end_logging(drizlog)

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -362,7 +362,8 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             5. Remove all processing sub-directories
         """
         inst_mode = "{}/{}".format(infile_inst, infile_det)
-        adriz_pars = mdzhandler.getMdriztabParameters(_calfiles)
+        _good_images = [f for f in _calfiles if fits.getval(f, 'exptime') > 0.]
+        adriz_pars = mdzhandler.getMdriztabParameters(_good_images)
         adriz_pars.update(pipeline_pars)
         adriz_pars['mdriztab'] = False
         adriz_pars['final_fillval'] = "INDEF"
@@ -550,6 +551,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         # Generate headerlets for each updated FLT image
         hlet_msg = _timestamp("Writing Headerlets started")
         for fname in _calfiles:
+            print("Creating new headerlet from {}".format(fname))
             frootname = fileutil.buildNewRootname(fname)
             hname = "%s_flt_hlet.fits" % frootname
             # Write out headerlet file used by astrodrizzle, however,
@@ -636,6 +638,8 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
         _pyd_err = trlfile.replace('.tra', '_pydriz.stderr')
 
         try:
+            print("Running AstroDrizzle on: {}".format(infile))
+
             drizzlepac.astrodrizzle.AstroDrizzle(input=infile, configobj=None,
                                                  **pipeline_pars)
             util.end_logging(drizlog)
@@ -727,6 +731,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                      alignment_mode=None, force_alignment=False,
                      **pipeline_pars):
 
+    headerlet_files = []
     for infile in inlist:
         asndict, ivmlist, drz_product = processInput.process_input(infile, updatewcs=False,
                                                     preserve=False,
@@ -829,7 +834,6 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                 shutil.copy(alignlog, alignlog_copy)
                 _appendTrlFile(trlfile, alignlog_copy)
 
-
             _trlmsg = ""
             # Check to see whether there are any additional input files that need to
             # be aligned (namely, FLT images)
@@ -841,6 +845,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                     if headerlet_file != "None":
                         headerlet.apply_headerlet_as_primary(fltfile, headerlet_file,
                                                             attach=True, archive=True)
+                        headerlet_files.append(headerlet_file)
                         # append log file contents to _trlmsg for inclusion in trailer file
                         _trlstr = "Applying headerlet {} as Primary WCS to {}\n"
                         _trlmsg += _trlstr.format(headerlet_file, fltfile)
@@ -943,7 +948,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
             if calfiles_flc:
                 _ = [shutil.copy(f, parent_dir) for f in calfiles_flc]
             # Copy drizzle products to parent directory to replace 'less aligned' versions
-            _ = [shutil.copy(f, parent_dir) for f in drz_products]
+            _ = [shutil.copy(f, parent_dir) for f in drz_products + headerlet_files]
 
         _trlmsg += _timestamp('Verification of alignment completed ')
         _updateTrlFile(trlfile, _trlmsg)


### PR DESCRIPTION
The RMS_RA, RMS_DEC, and NMATCHES keywords were being added to the headerlets created during the a posteriori alignment step of runastrodriz.  However, those headerlets were not getting copied over from the aposteriori processing sub-directory for use as the final headerlet.  

These changes insure that the headerlets get copied as the working headerlets.  In addition, the aposteriori aligned FLC/FLT images get updated with the values of these keywords as well with these code changes.  Between the two sets of changes, all critical fit information finally makes it into the outputs generated and used by the pipeline.  

This addresses #554.