### PR TITLE
Close open files in align upon error

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -303,6 +303,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                 alignment_table.filtered_table[:]['status'] = 1
                 alignment_table.filtered_table[:]['processMsg'] = "No sources found"
                 log.info(make_label('Processing time of [STEP 4]', starting_dt))
+                alignment_table.close()
                 return
 
             # The catalog of observable sources must have at least MIN_OBSERVABLE_THRESHOLD entries to be useful
@@ -318,6 +319,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                 alignment_table.filtered_table[:]['status'] = 1
                 alignment_table.filtered_table[:]['processMsg'] = "Not enough sources found"
                 log.info(make_label('Processing time of [STEP 4]', starting_dt))
+                alignment_table.close()
                 return
         log.info("SUCCESS")
         log.info(make_label('Processing time of [STEP 4]', starting_dt))
@@ -339,6 +341,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         best_fit_rms = -99999.0
         best_fit_status_dict = {}
         best_fit_qual = 5
+        best_fit_label = [None, None]
         # create pristine copy of imglist that will be used to restore imglist back so it always starts exactly the same
         # for each run.
         orig_imglist = copy.deepcopy(imglist)
@@ -543,6 +546,8 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
 
     finally:
+        # Always make sure that all file handles are closed
+        alignment_table.close()
 
         # Now update the result with the filtered_table contents
         if result:

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -208,9 +208,14 @@ class AlignmentTable:
 
     def select_fit(self, catalog_name, method_name):
         """Select the fit that has been identified as 'best'"""
+        if catalog_name is None:
+            self.selected_fit = None
+            return
+
         imglist = self.selected_fit = self.fit_dict[(catalog_name, method_name)]
         if imglist[0].meta['fit_info']['status'].startswith("FAILED"):
             self.selected_fit = None
+            return
 
         # Protect the writing of the table within the best_fit_rms
         info_keys = OrderedDict(imglist[0].meta['fit_info']).keys()
@@ -238,7 +243,8 @@ class AlignmentTable:
                 self.filtered_table[index]['scale'] = item.meta['fit_info']['scale'][0]
                 self.filtered_table[index]['rotation'] = item.meta['fit_info']['rot']
             else:
-                self.filtered_table[index]['fit_method'] = None
+                self.filtered_table = None
+                # self.filtered_table[index]['fit_method'] = None
 
 
     def apply_fit(self, headerlet_filenames=None, fit_label=None):

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -816,6 +816,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                         trlstr = "Could not align {} to absolute astrometric frame\n"
                         trlmsg += trlstr.format(row['imageName'])
                         print(trlmsg)
+                        _updateTrlFile(trlfile, trlmsg)
                         return None
             except Exception:
                 # Something went wrong with alignment to GAIA, so report this in

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -71,7 +71,7 @@ from collections import OrderedDict
 import datetime
 try:
     from psutil import Process
-except:
+except ImportError:
     Process = None
 
 # THIRD-PARTY
@@ -624,6 +624,7 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
                                                         overwrite=False)
         del ivmlist
         calfiles = asndict['original_file_names'] if asndict is not None else calfiles
+
         drz_products.append(drz_product)
 
         # Create trailer marker message for start of astrodrizzle processing
@@ -795,6 +796,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                         sat_flags = 256 + 2048
                 else:
                     sat_flags = 256 + 2048 + 4096 + 8192
+
                 align_table = align.perform_align(alignfiles, update_hdr_wcs=True, runfile=alignlog,
                                                   clobber=False, output=debug, sat_flags=sat_flags)
                 if align_table is None:
@@ -813,12 +815,14 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                     else:
                         trlstr = "Could not align {} to absolute astrometric frame\n"
                         trlmsg += trlstr.format(row['imageName'])
+                        print(trlmsg)
                         return None
             except Exception:
                 # Something went wrong with alignment to GAIA, so report this in
                 # trailer file
                 _trlmsg = "EXCEPTION encountered in align...\n"
                 _trlmsg += "   No correction to absolute astrometric frame applied!\n"
+                print(_trlmsg)
                 _updateTrlFile(trlfile, _trlmsg)
                 traceback.print_exc()
                 return None


### PR DESCRIPTION
Errors in the alignment can often cause the a posteriori alignment to exit before determining a fit; sometimes as the result of an Exception, sometimes as a result of the data (too few sources,...).  Processing in the pipeline, though, requires that all open files be closed before exiting the a posteriori alignment step.  This includes both logging files as well as any open input or output files.  

The changes here explicitly close all the input files anytime the alignment code returns before full completion (an oversight in the original implementation).  There are also changes to define default values upon returning early to avoid subsequent Exceptions as well due to lack of a "best fit".  

These changes were tested using the singleton `ibbq01n0q` as reported by DSB during their nightly auto tests of this code in preparation for operational testing.  