### PR TITLE
Catch case where all inputs have zero exptime

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -363,6 +363,8 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         """
         inst_mode = "{}/{}".format(infile_inst, infile_det)
         _good_images = [f for f in _calfiles if fits.getval(f, 'exptime') > 0.]
+        if len(_good_images) == 0:
+            _good_images = _calfiles
         adriz_pars = mdzhandler.getMdriztabParameters(_good_images)
         adriz_pars.update(pipeline_pars)
         adriz_pars['mdriztab'] = False


### PR DESCRIPTION
Logic for determining what MDRIZTAB reference file row should be used to set the correct parameters for the processing did not guard against all inputs having EXPTIME=0 and therefore not processed.  This change simply catches that case and reverts to assigning the MDRIZTAB row as if all were good when all inputs have EXPTIME=0.  This will not affect the generation of the actual output product, but does allow the code to run to completion (useful for the pipeline).