### PR TITLE
Fix logic for getting MDRIZTAB pars

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -363,6 +363,8 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         """
         inst_mode = "{}/{}".format(infile_inst, infile_det)
         _good_images = [f for f in _calfiles if fits.getval(f, 'exptime') > 0.]
+        if len(_good_images) == 0:
+            _good_images = _calfiles
         adriz_pars = mdzhandler.getMdriztabParameters(_good_images)
         adriz_pars.update(pipeline_pars)
         adriz_pars['mdriztab'] = False


### PR DESCRIPTION
This fixes a problem with the logic for determining the MDRIZTAB parameters to be used in pipeline processing when all inputs have EXPTIME=0 (and are rejected for processing).  The changes in this were separately delivered to HSTDP 2019.5.1 on branch 3.1.4x (#564), and this merges those changes into master.
