### PR TITLE
Fixed bug in generating the manifest list

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -24,6 +24,7 @@
     directory called 'hla_classic'.
 """
 import datetime
+import fnmatch
 import glob
 import os
 import sys
@@ -123,13 +124,13 @@ def correct_hla_classic_ra_dec(orig_hla_classic_sl_name, cattype, log_level):
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-def create_catalog_products(total_list, log_level, diagnostic_mode=False, phot_mode='both'):
+def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, phot_mode='both'):
     """This subroutine utilizes hlautils/catalog_utils module to produce photometric sourcelists for the specified
     total drizzle product and it's associated child filter products.
 
     Parameters
     ----------
-    total_list : drizzlepac.hlautils.Product.TotalProduct
+    total_obj_list : drizzlepac.hlautils.Product.TotalProduct
         total drizzle product that will be processed by catalog_utils. catalog_utils will also create photometric
         sourcelists for the child filter products of this total product.
 
@@ -150,7 +151,7 @@ def create_catalog_products(total_list, log_level, diagnostic_mode=False, phot_m
     """
     product_list = []
     log.info("Generating total product source catalogs")
-    for total_product_obj in total_list:
+    for total_product_obj in total_obj_list:
         # Instantiate filter catalog product object
         total_product_catalogs = HAPCatalogs(total_product_obj.drizzle_filename,
                                              total_product_obj.configobj_pars.get_pars('catalog generation'),
@@ -242,13 +243,13 @@ def create_catalog_products(total_list, log_level, diagnostic_mode=False, phot_m
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-def create_drizzle_products(total_list):
+def create_drizzle_products(total_obj_list):
     """
-    Run astrodrizzle to produce products specified in the total_list.
+    Run astrodrizzle to produce products specified in the total_obj_list.
 
     Parameters
     ----------
-    total_list: list
+    total_obj_list: list
         List of TotalProduct objects, one object per instrument/detector combination is
         a visit.  The TotalProduct objects are comprised of FilterProduct and ExposureProduct
         objects.
@@ -269,7 +270,7 @@ def create_drizzle_products(total_list):
     # For each detector (as the total detection product are instrument- and detector-specific),
     # create the drizzle-combined filtered image, the drizzled exposure (aka single) images,
     # and finally the drizzle-combined total detection image.
-    for total_obj in total_list:
+    for total_obj in total_obj_list:
         log.info("~" * 118)
         # Get the common WCS for all images which are part of a total detection product,
         # where the total detection product is detector-dependent.
@@ -291,6 +292,8 @@ def create_drizzle_products(total_list):
                 log.info("CREATE SINGLE DRIZZLED IMAGE: {}".format(exposure_obj.drizzle_filename))
                 exposure_obj.wcs_drizzle_product(meta_wcs)
                 product_list.append(exposure_obj.drizzle_filename)
+                product_list.append(exposure_obj.full_filename)
+                product_list.append(exposure_obj.headerlet_filename)
                 product_list.append(exposure_obj.trl_filename)
 
         # Create drizzle-combined total detection image after the drizzle-combined filter image and
@@ -303,10 +306,10 @@ def create_drizzle_products(total_list):
     # Ensure that all drizzled products have headers that are to specification
     try:
         log.info("Updating these drizzle products for CAOM compatibility:")
-        fits_files = [file for file in product_list if "fits" in file]
+        fits_files = fnmatch.filter(product_list, "*dr?.fits")
         for filename in fits_files:
             log.info("    {}".format(filename))
-            proc_utils.refine_product_headers(filename, total_list)
+            proc_utils.refine_product_headers(filename, total_obj_list)
     except Exception:
         log.critical("Trouble updating drizzle products for CAOM.")
         exc_type, exc_value, exc_tb = sys.exc_info()
@@ -383,7 +386,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
     # start processing
     starting_dt = datetime.datetime.now()
     log.info("Run start time: {}".format(str(starting_dt)))
-    total_list = []
+    total_obj_list = []
     product_list = []
     try:
         # Parse the poller file and generate the the obs_info_dict, as well as the total detection
@@ -393,13 +396,13 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         # where its FilterProduct is distinguished by the filter in use, and the ExposureProduct
         # is the atomic exposure data.
         log.info("Parse the poller and determine what exposures need to be combined into separate products.\n")
-        obs_info_dict, total_list = poller_utils.interpret_obset_input(input_filename, log_level)
+        obs_info_dict, total_obj_list = poller_utils.interpret_obset_input(input_filename, log_level)
 
         # Generate the name for the manifest file which is for the entire visit.  It is fine
         # to use only one of the Total Products to generate the manifest name as the name is not
         # dependent on the detector.
         # Example: instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
-        manifest_name = total_list[0].manifest_name
+        manifest_name = total_obj_list[0].manifest_name
         log.info("\nGenerate the manifest name for this visit.")
         log.info("The manifest will contain the names of all the output products.")
 
@@ -407,7 +410,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         product_list = []
 
         # Update all of the product objects with their associated configuration information.
-        for total_item in total_list:
+        for total_item in total_obj_list:
             log.info("Preparing configuration parameter values for total product {}".format(total_item.drizzle_filename))
             total_item.configobj_pars = config_utils.HapConfig(total_item,
                                                                log_level=log_level,
@@ -430,17 +433,17 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
                                                                   output_custom_pars_file=output_custom_pars_file)
         log.info("The configuration parameters have been read and applied to the drizzle objects.")
 
-        run_align_to_gaia(total_list, product_list, log_level=log_level, diagnostic_mode=diagnostic_mode)
+        run_align_to_gaia(total_obj_list, product_list, log_level=log_level, diagnostic_mode=diagnostic_mode)
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))
-        driz_list = create_drizzle_products(total_list)
+        driz_list = create_drizzle_products(total_obj_list)
         product_list += driz_list
 
         # Create source catalogs from newly defined products (HLA-204)
         log.info("{}: Create source catalog from newly defined product.\n".format(str(datetime.datetime.now())))
         if "total detection product 00" in obs_info_dict.keys():
-            catalog_list = create_catalog_products(total_list, log_level,
+            catalog_list = create_catalog_products(total_obj_list, log_level,
                                                    diagnostic_mode=diagnostic_mode,
                                                    phot_mode=phot_mode)
             product_list += catalog_list
@@ -478,8 +481,8 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         log.info("Return condition {}".format(return_value))
         logging.shutdown()
         # Append total trailer file (from astrodrizzle) to all total log files
-        if total_list:
-            for tot_obj in total_list:
+        if total_obj_list:
+            for tot_obj in total_obj_list:
                 proc_utils.append_trl_file(tot_obj.trl_filename, logname, clean=False)
         # Now remove single temp log file
         if os.path.exists(logname):
@@ -491,12 +494,12 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
 # ------------------------------------------------------------------------------------------------------------
 
-def run_align_to_gaia(total_list, product_list, log_level=logutil.logging.INFO, diagnostic_mode=False):
+def run_align_to_gaia(total_obj_list, product_list, log_level=logutil.logging.INFO, diagnostic_mode=False):
         # Run align.py on all input images sorted by overlap with GAIA bandpass
         log.info("\n{}: Align the all filters to GAIA with the same fit".format(str(datetime.datetime.now())))
         gaia_obj = None
         # Start by creating a FilterProduct instance which includes ALL input exposures
-        for tot_obj in total_list:
+        for tot_obj in total_obj_list:
             for exp_obj in tot_obj.edp_list:
                     if gaia_obj is None:
                         prod_list = exp_obj.info.split("_")
@@ -519,7 +522,7 @@ def run_align_to_gaia(total_list, product_list, log_level=logutil.logging.INFO, 
         #    input exposure's WCSs
         align_table, filt_exposures = gaia_obj.align_to_gaia(output=diagnostic_mode, fit_label='SVM')
 
-        for tot_obj in total_list:
+        for tot_obj in total_obj_list:
             tot_obj.generate_metawcs()
         log.info("\n{}: Finished aligning gaia_obj to GAIA".format(str(datetime.datetime.now())))
 
@@ -544,7 +547,7 @@ def run_sourcelist_comparision(total_list, diagnostic_mode = False, log_level=lo
 
     Parameters
     ----------
-    total_list: list
+    total_obj_list: list
         List of TotalProduct objects, one object per instrument/detector combination is
         a visit.  The TotalProduct objects are comprised of FilterProduct and ExposureProduct
         objects.

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -505,8 +505,8 @@ def run_align_to_gaia(total_obj_list, product_list, log_level=logutil.logging.IN
                         prod_list = exp_obj.info.split("_")
                         prod_list[4] = "metawcs"
                         gaia_obj = product.FilterProduct(prod_list[0], prod_list[1], prod_list[2],
-                                                         prod_list[3], prod_list[4], prod_list[5],
-                                                         prod_list[6], log_level)
+                                                         prod_list[3], prod_list[4], "all",
+                                                         prod_list[5][0:3], log_level)
                         gaia_obj.configobj_pars = tot_obj.configobj_pars
                     gaia_obj.add_member(exp_obj)
 

--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -1036,7 +1036,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
         # Capture specified filter columns in order to append to the total detection table
         self.subset_filter_source_cat = self.source_cat["ID", "MagAp2", "CI", "Flags"]
-        self.subset_filter_source_cat.rename_column("MagAp2", "MagAp2_" + filter_name)
+        self.subset_filter_source_cat.rename_column("MagAp2", "MagAP2_" + filter_name)
         self.subset_filter_source_cat.rename_column("CI", "CI_" + filter_name)
         self.subset_filter_source_cat.rename_column("Flags", "Flags_" + filter_name)
 

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -195,10 +195,15 @@ class FilterProduct(HAPProduct):
         super().__init__(prop_id, obset_id, instrument, detector, filename, filetype, log_level)
 
         self.info = '_'.join([prop_id, obset_id, instrument, detector, filename, filters, filetype])
-        self.exposure_name = filename[0:6]
+        if filename[0:7].lower() != "metawcs":
+            self.exposure_name = filename[0:6]
+            self.product_basename = self.basename + "_".join(map(str, [filters, self.exposure_name]))
+        else:
+            self.exposure_name = "metawcs"
+            self.product_basename = self.basename + "_".join(map(str, [filetype, self.exposure_name, filters]))
+
         self.filters = filters
 
-        self.product_basename = self.basename + "_".join(map(str, [filters, self.exposure_name]))
         # Trailer names .txt or .log
         self.trl_logname = self.product_basename + "_trl.log"
         self.trl_filename = self.product_basename + "_trl.txt"
@@ -276,6 +281,11 @@ class FilterProduct(HAPProduct):
             # created for alignment of each filter product here.
             if refname and os.path.exists(refname):
                 os.remove(refname)
+
+        # Clean up under nominal circumstances unless output=True
+        if not output and refname and os.path.exists(refname):
+                os.remove(refname)
+
 
         # Return a table which contains data regarding the alignment, as well as the
         # list of the flt/flc exposures which were part of the alignment process


### PR DESCRIPTION
Fixed bug  so only the drizzle FITS files have their headers modified as the output product list now also includes the headerlet and FLT/FLC FITS files.  Changed variable name: total_list to total_obj_list.  Corrected name of column in Segment catalog from MagAp to MagAP.