### PR TITLE
Improved the boolean mask creation for use with segmentation catalog

### DIFF
--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -165,6 +165,9 @@ class TotalProduct(HAPProduct):
         # ...and set parameters which are computed on-the-fly
         drizzle_pars["final_refimage"] = meta_wcs
         drizzle_pars["runfile"] = self.trl_logname
+        # Setting "preserve" to false so the OrIg_files directory is deleted as the purpose
+        # of this directory is now obsolete.
+        drizzle_pars["preserve"] = False
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "
                   "have been updated for the drizzle step of the total drizzle product."
                   .format(meta_wcs, self.trl_logname))
@@ -308,6 +311,9 @@ class FilterProduct(HAPProduct):
         # ...and set parameters which are computed on-the-fly
         drizzle_pars["final_refimage"] = meta_wcs
         drizzle_pars["runfile"] = self.trl_logname
+        # Setting "preserve" to false so the OrIg_files directory is deleted as the purpose
+        # of this directory is now obsolete.
+        drizzle_pars["preserve"] = False
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "
                   "have been updated for the drizzle step of the filter drizzle product."
                   .format(meta_wcs, self.trl_logname))
@@ -379,6 +385,9 @@ class ExposureProduct(HAPProduct):
         # ...and set parameters which are computed on-the-fly
         drizzle_pars["final_refimage"] = meta_wcs
         drizzle_pars["runfile"] = self.trl_logname
+        # Setting "preserve" to false so the OrIg_files directory is deleted as the purpose
+        # of this directory is now obsolete.
+        drizzle_pars["preserve"] = False
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "
                   "have been updated for the drizzle step of the exposure drizzle product."
                   .format(meta_wcs, self.trl_logname))


### PR DESCRIPTION
The boolean mask which is used to identify sources in the usable illuminated image region for the segmentation catalog has been improved.  When in diagnostic mode, a segmentation and possibly a deblended segmentation image will be created for debug purposes, the obsolete parameter, preserve, is set to False in the Product classes so no OrIg_files subdirectory will be created.