### PR TITLE
Add hdrname to hdulist

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,7 @@ are available.
    updatehdr
    mapreg
    photeq
+   pixreplace
 
 Coordinate Transformation Tasks
 -------------------------------
@@ -95,7 +96,6 @@ distorted and drizzled images.
    pixtopix
    pixtosky
    skytopix
-
 
 
 ACS Header Update Task

--- a/doc/source/pixreplace.rst
+++ b/doc/source/pixreplace.rst
@@ -1,0 +1,14 @@
+.. _pixreplace:
+
+*******************************************************************
+pixreplace: Replace pixels which have one value with another value
+*******************************************************************
+This task allows a user to replace pixels in an image or set of images
+which have one value with a new value; for example, replace all NaNs
+with a value of -999.9.
+
+.. moduleauthor:: Warren Hack <help@stsci.edu>
+
+.. automodule:: drizzlepac.pixreplace
+
+.. autofunction:: replace

--- a/drizzlepac/__init__.py
+++ b/drizzlepac/__init__.py
@@ -85,6 +85,7 @@ drizzlepac:
       imagefindpars - sub-task containing parameters to find point sources used by tweakreg to build source catalogs for each tweakreg input image
           tweakback - apply an updated WCS solution created by tweakreg for a drizzled image to the constituent distorted (flt.fits) images
              mapreg - task to map a DS9 region file to multiple images based on the WCS information of each image.
+           pixreplace - task to replace pixel values such as NaNs in images with another value
            pixtopix - task to convert pixel positions from an input image to pixel positions in an output WCS or image
            pixtosky - task to convert pixel positions from an input image to sky coordinates with full distortion correction as appropriate
            photeq   - task to equalize sensitivities of images across chips and epochs

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -811,6 +811,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
         hdulist[sci_extn].header['CRDER1'] = item.meta['fit_info']['RMS_RA'].value
         hdulist[sci_extn].header['CRDER2'] = item.meta['fit_info']['RMS_DEC'].value
         hdulist[sci_extn].header['NMATCHES'] = len(item.meta['fit_info']['ref_mag'])
+        hdulist[sci_extn].header['HDRNAME'] = "{}_{}".format(image_name.rstrip(".fits"), wcs_name)
 
         if chipctr == num_sci_ext:
             # Close updated flc.fits or flt.fits file


### PR DESCRIPTION
This simple change explicitly updates the aligned FLT/FLC files with the HDRNAME associated with the new WCS solution (based on WCSNAME).  This change will insure that the HDRNAME and WCSNAME keywords in the FLT/FLC files stay in sync, something which was not happening during HSTDP 2019.5.1. regression testing. 

In addition, the docs were updated to document the 'pixreplace' task which has been a part of the drizzlepac package since 2015.  Only the docs were updated, and no code was changed for this task.