### PR TITLE
Modified the handling of the filter values to accommodate SBC names

### DIFF
--- a/drizzlepac/hlautils/analyze.py
+++ b/drizzlepac/hlautils/analyze.py
@@ -246,6 +246,7 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
         no_proc_value = None
         do_process = True
         # Imaging vs spectroscopic or coronagraphic
+        print("******OBSTYPE: {}".format(obstype))
         if obstype != 'IMAGING':
             no_proc_key = OBSKEY
             no_proc_value = obstype
@@ -280,11 +281,12 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
             no_proc_key = CHINKEY
             no_proc_value = chinject
 
-        # Filter name which starts with "G" for Grism or "PR" for Prism
+        # Filter name which starts with "G" for Grism, "PR" for Prism, or
+        # "BLOCK" for internal calibration of SBC
         # The sfilter variable may be the concatenation of two filters (F160_CLEAR)
         split_sfilter = sfilter.split('_')
         for item in split_sfilter:
-            if item.startswith(('G', 'PR')):
+            if item.startswith(('G', 'PR', 'BLOCK')):
                 no_proc_key = FILKEY
                 no_proc_value = sfilter
 

--- a/drizzlepac/hlautils/analyze.py
+++ b/drizzlepac/hlautils/analyze.py
@@ -246,7 +246,6 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
         no_proc_value = None
         do_process = True
         # Imaging vs spectroscopic or coronagraphic
-        print("******OBSTYPE: {}".format(obstype))
         if obstype != 'IMAGING':
             no_proc_key = OBSKEY
             no_proc_value = obstype

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -320,16 +320,18 @@ def determine_filter_name(raw_filter):
         if 'clear' not in filt:
             output_filter_list.append(filt)
 
+    print(output_filter_list)
+
     if not output_filter_list:
-        filter_name = 'clear'
+        output_filter_list = ['clear']
     elif output_filter_list[0].startswith('pol'):
         output_filter_list.reverse()
     else:
         if output_filter_list[0].startswith('none'):
             output_filter_list.reverse()
 
-        delimiter = '-'
-        filter_name = delimiter.join(output_filter_list)
+    delimiter = '-'
+    filter_name = delimiter.join(output_filter_list)
 
     return filter_name
 

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -296,38 +296,32 @@ def determine_filter_name(raw_filter):
     - If there are two filters in use, then use 'filter1-filter2'.
     - If one filter is a polarizer ('pol*'), then always put the polarizer
       name second (e.g., 'f606w-pol60').
+    - If one filter is 'n/a' (as is the case for SBC), then use the other filter
+      name. NOTE: At this time (February 2020) the filter names for the SBC
+      detector of ACS have malformed names (e.g., F140LP;N/A;F140LP) where the
+      final token delimited by the ";" should not be present. Remove the final
+      delimiter and entry.  Unlike the other ACS detectors, SBC only uses a
+      single filter wheel.
+
     - NOTE: There should always be at least one filter name provided to
       this routine or this input is invalid.
-
-    - If one filter is 'n/a', then convert to 'none' (as the slash causes problems
-      on Linux-like systems) and always put this filter name second (e.g., 'pr130l-none').
-    - NOTE: At this time (February 2020) the filter names for the SBC detector of
-      ACS have malformed names (e.g., F140LP;N/A;F140LP) where the final token delimited by
-      the ";" should not be present. Remove the final delimiter and entry.
     """
 
     raw_filter = raw_filter.lower()
 
     # There might be multiple filters, so split the filter names into a list
-    # and only retain the first two entries
+    # and only retain the first two entries.  SBC has a bogus third entry.
     filter_list = raw_filter.split(';')[0:2]
     output_filter_list = []
 
     for filt in filter_list:
-        if filt == 'n/a':
-            filt = 'none'
-        # Get the names of the non-clear filters
-        if 'clear' not in filt:
+        if not any(x in filt for x in ['clear', 'n/a']):
             output_filter_list.append(filt)
-
-    print(output_filter_list)
 
     if not output_filter_list:
         output_filter_list = ['clear']
-    elif output_filter_list[0].startswith('pol'):
-        output_filter_list.reverse()
     else:
-        if output_filter_list[0].startswith('none'):
+        if output_filter_list[0].startswith('pol'):
             output_filter_list.reverse()
 
     delimiter = '-'


### PR DESCRIPTION
SBC filter names are currently malformed (e.g., "F140LP;N/A;F140LP" in the SVM poller manifests.  The third token delimited by ";" should not be present. Also, the "N/A" needs
to be replaced with "none" as the slash cannot be part of the output filename.  The code has been modified to handle this situation.