### PR TITLE
Segmented Catalog Updates

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -175,9 +175,11 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
         for cat_type in total_product_catalogs.catalogs.keys():
             sources_dict[cat_type] = {}
             sources_dict[cat_type]['sources'] = total_product_catalogs.catalogs[cat_type].sources
-            # FIX MDD Remove?
+            # For the segmentation source finding, both the segmentation image AND the segmentation catalog 
+            # computed for the total object need to be provided to the filter objects
             if cat_type == "segment":
                 sources_dict['segment']['kernel'] = total_product_catalogs.catalogs['segment'].kernel
+                sources_dict['segment']['source_cat'] = total_product_catalogs.catalogs['segment'].source_cat
 
         log.info("Generating filter product source catalogs")
         for filter_product_obj in total_product_obj.fdp_list:

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -225,6 +225,9 @@ def parse_obset_tree(det_tree, log_level):
                 obset_products[sep] = {'info': prod_info,
                                        'files': [filename[1]]}
 
+                # Clean up the filter name
+                # filt = determine_filter_name(prod_list[5])
+
                 # Create a single exposure product object
                 prod_list = prod_info.split(" ")
                 sep_obj = ExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -225,9 +225,6 @@ def parse_obset_tree(det_tree, log_level):
                 obset_products[sep] = {'info': prod_info,
                                        'files': [filename[1]]}
 
-                # Clean up the filter name
-                # filt = determine_filter_name(prod_list[5])
-
                 # Create a single exposure product object
                 prod_list = prod_info.split(" ")
                 sep_obj = ExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -274,9 +274,11 @@ class FilterProduct(HAPProduct):
             # Report a problem with the alignment
             log.warning("EXCEPTION encountered in align_to_gaia for the FilteredProduct.\n")
             log.warning("No correction to absolute astrometric frame applied.\n")
-            exc_type, exc_value, exc_tb = sys.exc_info()
-            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
-            logging.exception("message")
+            log.warning("Proceeding with previous best solution.\n")
+
+            # Only write out the traceback if in "debug" mode since not being able to
+            # align the data to an absolute astrometric frame is not actually a failure.
+            log.debug(traceback.format_exc())
             align_table = None
 
             # If the align_table is None, it is necessary to clean-up reference catalogs


### PR DESCRIPTION
Modified the segmented catalog to address bugs, make improvements, and to align better with the way the Point catalog is produced.
- Use option "columns" on to_table() method so only desired values are computed.
- Need to provide both the segmented image, as well as the total detection catalog to
  the filter product object.
- Change some methods to modify the passed table parameter object as if "passed by
  reference" rather than return a new table.
- Use list indices for addressing column "good" or "bad" rows.
- Put X-/Y-centroids and RA/Dec coordinates, as captured from the total detection
  table, for corresponding segments in the filter catalog which could not be measured.
- Create columns of the output filter table and fill values with nans.  For any
  measurments that cannot be made, a nan will be present.
