### PR TITLE
Fix HSTDP 2019.5.1 bugs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-3.1.5 (unreleased)
+3.1.7 (unreleased)
 ==================
 
 - Fix a crash in ``tweakreg`` when ``2dhist`` is enabled and ``numpy``
@@ -24,6 +24,14 @@ of the list).
   aligns the data to GAIA using the a posteriori fit.  Headerlet files for this fit
   which already have these keywords are now retained and provided as the final output
   headerlets as well.  [#554]
+
+- Fix problems found in processing data with NGOODPIX==0, DRC files not getting
+  generated for singletons, alignment trying to use a source too near the chip edge,
+  catch the case were all inputs have zero exposure time, lazily remove alignment
+  sub-directories, fixed a bug in overlap computation that showed up in oblong mosaics,
+  recast an input to histogram2d as int,  defined default values for tables when no
+  sources were found. [#593]
+
 
 3.1.3 (5-Dec-2019)
 ==================

--- a/drizzlepac/hlautils/analyze.py
+++ b/drizzlepac/hlautils/analyze.py
@@ -144,8 +144,8 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
 
     # Initialize the column entries which will be populated in successive
     # processing steps
-    fit_method = None  # Fit algorithm used for alignment
-    catalog = None     # Astrometric catalog used for alignment
+    fit_method = ""  # Fit algorithm used for alignment
+    catalog = ""     # Astrometric catalog used for alignment
     catalog_sources = 0  # No. of astrometric catalog sources found based on coordinate overlap with image
     found_sources = 0   # No. of sources detected in images
     match_sources = 0   # No. of sources cross matched between astrometric catalog and detected in image
@@ -161,10 +161,10 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
     date_obs = None     # Human readable date
     mjdutc = -1.0      # MJD UTC start of exposure
     fgslock = None
-    process_msg = None
+    process_msg = ""
     status = 9999
     compromised = 0
-    headerlet_file = None
+    headerlet_file = ""
     fit_qual = -1
 
     fit_rms = -1.0
@@ -312,7 +312,7 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
                               rot, scale, rms_x, rms_y, rms_ra, rms_dec, completed, fit_rms,
                               total_rms, dataset_key, status, fit_qual, headerlet_file,
                               compromised])
-        process_msg = None
+        process_msg = ""
 
     return output_table
 

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -767,7 +767,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         tbl['flux'].info.format = '.10f'
         if not outroot.endswith('.cat'):
             outroot += '.cat'
-        tbl.write(outroot, format='ascii.commented_header')
+        tbl.write(outroot, format='ascii.commented_header', overwrite=True)
         log.info("Wrote source catalog: {}".format(outroot))
 
     if plot and plt is not None:

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -896,7 +896,7 @@ def generate_source_catalog(image, dqname="DQ", output=False, fwhm=3.0,
             photmode = None
 
         imgarr = image['sci', chip].data
-        wcs = wcsutil.HSTWCS(image, ext=('sci',chip))
+        wcs = wcsutil.HSTWCS(image, ext=('sci', chip))
         def_fwhm = def_fwhmpsf / wcs.pscale
 
         # apply any DQ array, if available
@@ -1605,7 +1605,7 @@ def evaluate_focus(focus_dict, tolerance=0.8):
 
     return alignment_verified
 
-def get_align_fwhm(focus_dict, default_fwhm, src_size=32):
+def get_align_fwhm(focus_dict, default_fwhm, src_size=11):
     """Determine FWHM based on position of sharpest focus in the product"""
     pimg = fits.open(focus_dict['prodname'])
     posy, posx = focus_dict['prod_pos']
@@ -1679,6 +1679,7 @@ def max_overlap_diff(total_mask, singlefiles, prodfile, sigma=2.0, scale=1):
 
     exptimes = np.array([fits.getval(s, 'exptime') for s in singlefiles])
     exp_weights = exptimes / exptimes.max()
+    log.info("Computing diffs for: {}".format(singlefiles))
 
     diff_dict = {}
     for sfile, exp_weight in zip(singlefiles, exp_weights):
@@ -1784,7 +1785,7 @@ def reduce_diff_region(arr, scale=1, background=None, nsigma=4,
                 sigma = 3.
             else:
                 pass
-        maxiters = int(np.log10(rebin_arr.max()/2)+0.5)
+        maxiters = int(np.log10(rebin_arr.max() / 2) + 0.5)
 
         # Use simple constant background to avoid problems with nebulosity
         bkg = sigma_clipped_stats(rebin_arr, sigma=sigma, maxiters=maxiters)

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -1688,6 +1688,18 @@ def max_overlap_diff(total_mask, singlefiles, prodfile, sigma=2.0, scale=1):
 
         # Create exposure mask corresponding to pixels with drizzled data
         smask = sdata > 0
+        if smask.sum() == 0:
+            # In some error cases (e.g., jcx552010), blank images get to this point, so treat them as blank
+            log.info("Overlap difference for {}: (No valid data)".format(sfile))
+            diff_dict[sfile] = {"distance": -1, "xslice": None, "yslice": None}
+            diff_dict[sfile]['product_num_sources'] = 0
+            diff_dict[sfile]['num_sources'] = 0
+            diff_dict[sfile]['focus'] = 0.0
+            diff_dict[sfile]['focus_pos'] = (None, None)
+            diff_dict[sfile]['product_focus'] = 0.0
+            diff_dict[sfile]['product_focus_pos'] = (None, None)
+            log.debug("Overlap differences for {} found to be: \n{}".format(sfile, diff_dict[sfile]))
+            continue
 
         # Trim mask down to only include region where the most exposures overlap
         soverlap = smask * max_overlap

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -669,6 +669,8 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
             src_brightest = np.flip(np.argsort(src_fluxes))
             large_labels = src_labels[src_brightest]
             log.debug("Brightest sources in segments: \n{}".format(large_labels))
+        else:
+            src_brightest = np.arange(len(segm.labels))
 
         log.info("Looking for sources in {} segments".format(len(segm.labels)))
 
@@ -1728,7 +1730,7 @@ def max_overlap_diff(total_mask, singlefiles, prodfile, sigma=2.0, scale=1):
         #  (modulo slicing limits)
         yr, xr = np.where(soverlap > 0)
         yslice = slice(yr.min(), yr.max(), 1)
-        xslice = slice(xr.min(), yr.max(), 1)
+        xslice = slice(xr.min(), xr.max(), 1)
         log.debug("overlap region: xslice {}, yslice {}".format(xslice, yslice))
 
         drz_arr = drz_region[yslice, xslice]

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -1603,6 +1603,7 @@ def _xy_2dhist(imgxy, refxy, r):
     # It is about 5-8 times slower than the C version.
     dx = np.subtract.outer(imgxy[:, 0], refxy[:, 0]).ravel()
     dy = np.subtract.outer(imgxy[:, 1], refxy[:, 1]).ravel()
+    r = int(np.ceil(r))
     idx = np.where((dx < r + 0.5) & (dx >= -r - 0.5) &
                    (dy < r + 0.5) & (dy >= -r - 0.5))
     r = int(np.ceil(r))
@@ -1661,10 +1662,11 @@ def _estimate_2dhist_shift(imgxy, refxy, searchrad=3.0):
     maxval = zpmat.max()
     zpmat_mask = (zpmat > 0) & (zpmat < maxval)
 
+    sig = 0.0
     if np.any(zpmat_mask):
         bkg = zpmat[zpmat_mask].mean()
         sig = maxval / np.sqrt(bkg)
-
+    
     flux = int(zpmat[fit_sl].sum())
     print("Found initial X and Y shifts of {:.4g}, {:.4g} "
           "with significance of {:.4g} and {:d} matches"

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -1666,7 +1666,7 @@ def _estimate_2dhist_shift(imgxy, refxy, searchrad=3.0):
     if np.any(zpmat_mask):
         bkg = zpmat[zpmat_mask].mean()
         sig = maxval / np.sqrt(bkg)
-    
+
     flux = int(zpmat[fit_sl].sum())
     print("Found initial X and Y shifts of {:.4g}, {:.4g} "
           "with significance of {:.4g} and {:d} matches"

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -173,6 +173,19 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             raise ValueError(msg)
 
         os.environ[envvar_old_apriori_name] = envvar_dict[val]
+    else:
+        # Insure os.environ ALWAYS contains an entry for envvar_new_apriori_name
+        # and it will default to being 'on'
+        if envvar_old_apriori_name in os.environ:
+            val = os.environ[envvar_old_apriori_name].lower()
+        else:
+            val = 'on'
+        os.environ[envvar_new_apriori_name] = val
+
+    align_with_apriori = True
+    if envvar_new_apriori_name in os.environ:
+        val = os.environ[envvar_new_apriori_name].lower()
+        align_with_apriori = envvar_bool_dict[val]
 
     if headerlets or align_to_gaia:
         from stwcs.wcsutil import headerlet
@@ -299,7 +312,8 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             _infile_flc = fileutil.buildRootname(_cal_prodname, ext=['_flc.fits'])
 
             _cal_prodname = _infile
-            _inlist = _calfiles = [_infile]
+            _calfiles = [_infile] 
+            _inlist = [_infile, _infile_flc]
             print("_calfiles initialized as: {}".format(_calfiles))
             if len(_calfiles) == 1 and "_raw" in _calfiles[0]:
                 _verify = False
@@ -363,6 +377,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         """
         inst_mode = "{}/{}".format(infile_inst, infile_det)
         _good_images = [f for f in _calfiles if fits.getval(f, 'exptime') > 0.]
+        _good_images = [f for f in _good_images if fits.getval(f, 'ngoodpix', ext=("SCI", 1)) > 0.]
         if len(_good_images) == 0:
             _good_images = _calfiles
         adriz_pars = mdzhandler.getMdriztabParameters(_good_images)
@@ -389,77 +404,80 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         _trlmsg += __trlmarker__
         _updateTrlFile(_trlfile, _trlmsg)
 
-        # Generate initial default products and perform verification
-        align_dicts = verify_alignment(_inlist,
-                                         _calfiles, _calfiles_flc,
-                                         _trlfile,
-                                         tmpdir=None, debug=debug,
-                                         force_alignment=force_alignment,
-                                         find_crs=True, **adriz_pars)
-
-        _trlmsg = _timestamp('Starting alignment with a priori solutions')
-        _trlmsg += __trlmarker__
-        if align_dicts is not None:
-            find_crs = not align_dicts[0]['alignment_verified']
-        else:
-            find_crs = False
-
-        # run updatewcs with use_db=True to insure all products have
-        # have a priori solutions as extensions
-        updatewcs.updatewcs(_calfiles)
-        _trlmsg += verify_gaia_wcsnames(_calfiles)
-        if _calfiles_flc:
-            updatewcs.updatewcs(_calfiles_flc)
-            _trlmsg += verify_gaia_wcsnames(_calfiles_flc)
-
-        # Check for the case where no update was performed due to all inputs
-        # having EXPTIME==0 (for example) and apply updatewcs anyway to allow
-        # for successful creation of updated headerlets for this data.
-        force_updatewcs = False
-        for cfile in _calfiles:
-            # If any file in the input list was NOT updated, force update with use_db now...
-            with fits.open(cfile) as img0:
-                if 'wcsname' not in img0[1].header:
-                    force_updatewcs = True
-                    _trlmsg += "Forcing reference file update for WCS for: {}".format(_calfiles)
-                    break
-        if force_updatewcs:
-            updatewcs.updatewcs(_calfiles, checkfiles=False)
-            if _calfiles_flc:
-                updatewcs.updatewcs(_calfiles_flc, checkfiles=False)
-
-        try:
-            tmpname = "_".join([_trlroot, 'apriori'])
-            sub_dirs.append(tmpname)
+        if align_with_apriori or force_alignment or align_to_gaia:
             # Generate initial default products and perform verification
-            align_apriori = verify_alignment(_inlist,
+            align_dicts = verify_alignment(_inlist,
                                              _calfiles, _calfiles_flc,
                                              _trlfile,
-                                             tmpdir=tmpname, debug=debug,
-                                             good_bits=focus_pars[inst_mode]['good_bits'],
-                                             alignment_mode='apriori',
+                                             tmpdir=None, debug=debug,
                                              force_alignment=force_alignment,
-                                             find_crs=find_crs,
-                                             **adriz_pars)
-        except Exception:
-            # Reset to state prior to applying a priori solutions
-            updatewcs.updatewcs(_calfiles, use_db=False)
+                                             find_crs=True, **adriz_pars)
+
+        if align_with_apriori:
+            _trlmsg = _timestamp('Starting alignment with a priori solutions')
+            _trlmsg += __trlmarker__
+            if align_dicts is not None:
+                find_crs = not align_dicts[0]['alignment_verified']
+            else:
+                find_crs = False
+
+            # run updatewcs with use_db=True to insure all products have
+            # have a priori solutions as extensions
+            updatewcs.updatewcs(_calfiles)
+            _trlmsg += verify_gaia_wcsnames(_calfiles)
             if _calfiles_flc:
-                updatewcs.updatewcs(_calfiles_flc, use_db=False)
+                print("Adding apriori WCS solutions to {}".format(_calfiles_flc))
+                updatewcs.updatewcs(_calfiles_flc)
+                _trlmsg += verify_gaia_wcsnames(_calfiles_flc)
 
-            traceback.print_exc()
-            align_apriori = None
-            _trlmsg += "ERROR in applying a priori solution.\n"
+            # Check for the case where no update was performed due to all inputs
+            # having EXPTIME==0 (for example) and apply updatewcs anyway to allow
+            # for successful creation of updated headerlets for this data.
+            force_updatewcs = False
+            for cfile in _calfiles:
+                # If any file in the input list was NOT updated, force update with use_db now...
+                with fits.open(cfile) as img0:
+                    if 'wcsname' not in img0[1].header:
+                        force_updatewcs = True
+                        _trlmsg += "Forcing reference file update for WCS for: {}".format(_calfiles)
+                        break
+            if force_updatewcs:
+                updatewcs.updatewcs(_calfiles, checkfiles=False)
+                if _calfiles_flc:
+                    updatewcs.updatewcs(_calfiles_flc, checkfiles=False)
 
-        if align_apriori:
-            align_dicts = align_apriori
-            if align_dicts[0]['alignment_quality'] == 0:
-                _trlmsg += 'A priori alignment SUCCESSFUL.\n'
-            if align_dicts[0]['alignment_quality'] == 1:
-                _trlmsg += 'A priori alignment potentially compromised.  Please review final product!\n'
-            if align_dicts[0]['alignment_quality'] > 1:
-                _trlmsg += 'A priori alignment FAILED! No a priori astrometry correction applied.\n'
-        _updateTrlFile(_trlfile, _trlmsg)
+            try:
+                tmpname = "_".join([_trlroot, 'apriori'])
+                sub_dirs.append(tmpname)
+                # Generate initial default products and perform verification
+                align_apriori = verify_alignment(_inlist,
+                                                 _calfiles, _calfiles_flc,
+                                                 _trlfile,
+                                                 tmpdir=tmpname, debug=debug,
+                                                 good_bits=focus_pars[inst_mode]['good_bits'],
+                                                 alignment_mode='apriori',
+                                                 force_alignment=force_alignment,
+                                                 find_crs=find_crs,
+                                                 **adriz_pars)
+            except Exception:
+                # Reset to state prior to applying a priori solutions
+                updatewcs.updatewcs(_calfiles, use_db=False)
+                if _calfiles_flc:
+                    updatewcs.updatewcs(_calfiles_flc, use_db=False)
+
+                traceback.print_exc()
+                align_apriori = None
+                _trlmsg += "ERROR in applying a priori solution.\n"
+
+            if align_apriori:
+                align_dicts = align_apriori
+                if align_dicts[0]['alignment_quality'] == 0:
+                    _trlmsg += 'A priori alignment SUCCESSFUL.\n'
+                if align_dicts[0]['alignment_quality'] == 1:
+                    _trlmsg += 'A priori alignment potentially compromised.  Please review final product!\n'
+                if align_dicts[0]['alignment_quality'] > 1:
+                    _trlmsg += 'A priori alignment FAILED! No a priori astrometry correction applied.\n'
+            _updateTrlFile(_trlfile, _trlmsg)
 
 
         if align_to_gaia:
@@ -595,12 +613,21 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
 
     if debug and Process is not None:
         print("Files still open for this process include: ")
-        print(Process().open_files())
+        print([ofile.path for ofile in Process().open_files()])
 
     if not debug:
-        # Remove all temp sub-directories now that we are done
-        for sd in sub_dirs:
-            if os.path.exists(sd): rmtree2(sd)
+        try:
+            # Remove all temp sub-directories now that we are done
+            for sd in sub_dirs:
+                if os.path.exists(sd): rmtree2(sd)
+        except Exception:
+            # If we are unable to remove any of these sub-directories,
+            # leave them for the user or calling routine/pipeline to clean up.
+            print("WARNING: Unable to remove any or all of these sub-directories: \n{}\n".format(sub_dirs))
+            if Process is not None:
+                print("Files still open at this time include: ")
+                print([ofile.path for ofile in Process().open_files()])
+            pass
 
     # Append final timestamp to trailer file...
     _final_msg = '%s: Finished processing %s \n' % (_getTime(), inFilename)
@@ -695,19 +722,19 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
         else:
             focus_dicts = None
 
-        # Now, append comments created by PyDrizzle to CALXXX trailer file
-        print('Updating trailer file %s with astrodrizzle comments.' % trlfile)
-        drizlog_copy = drizlog.replace('.log', '_copy.log')
-        if os.path.exists(drizlog):
-            shutil.copy(drizlog, drizlog_copy)
-        _appendTrlFile(trlfile, drizlog_copy)
-        # clean up log files
-        if os.path.exists(drizlog):
-            os.remove(drizlog)
-        # Clean up intermediate files generated by astrodrizzle
-        if not debug:
-            for ftype in ['*mask*.fits']:
-                [os.remove(file) for file in glob.glob(ftype)]
+    # Now, append comments created by PyDrizzle to CALXXX trailer file
+    print('Updating trailer file %s with astrodrizzle comments.' % trlfile)
+    drizlog_copy = drizlog.replace('.log', '_copy.log')
+    if os.path.exists(drizlog):
+        shutil.copy(drizlog, drizlog_copy)
+    _appendTrlFile(trlfile, drizlog_copy)
+    # clean up log files
+    if os.path.exists(drizlog):
+        os.remove(drizlog)
+    # Clean up intermediate files generated by astrodrizzle
+    if not debug:
+        for ftype in ['*mask*.fits']:
+            [os.remove(file) for file in glob.glob(ftype)]
 
     return drz_products, focus_dicts, diff_dicts
 
@@ -886,6 +913,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
             det_pars = align.get_default_pars(inst, det)['generate_source_catalogs']
             default_fwhm = det_pars['fwhmpsf'] / pscale
             align_fwhm = amutils.get_align_fwhm(align_focus, default_fwhm)
+
             if align_fwhm:
                 _trlmsg += "align_fwhm: {}[{},{}]={:0.4f}pix\n".format(align_focus['prodname'],
                                                             align_focus['prod_pos'][1],


### PR DESCRIPTION
These commits fix numerous bugs reported as a result of initial reprocessing after installing HSTDP 2019.5.1 (quick-fix).   Multiple bugs will be addressed starting with:

- **jcwr03030** : Processing encountered recursion error (exceeded maximum limit) caused by FWHM being measured for 'sharpest' focus object in field that was too close to the edge of a chip.  
- **j8uw01020** : One (of the 2) exposures in the association had NGOODPIX=0, yet it was still being passed to AstroDrizzle() as if it was valid, causing the wrong parameters to be set for processing and resulting in 'too many pixels rejected' error. 

The datasets listed with each error not only the datasets reported in reprocessing as having errors, but were also used to demonstrate the original problem for debugging and used to verify that the problem was corrected by the code changes.  Additional bug fixes will be included in this PR in later commits as they are developed for the known list of error cases from reprocessing.  