### PR TITLE
Minimum changes in pipeline code needed to use new tweakwcs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,9 @@ of the list).
   recast an input to histogram2d as int,  defined default values for tables when no
   sources were found. [#593]
 
+- Updated to be compatible with tweakwcs v0.6.0 to correct chip-to-chip alignment issues
+  in aposteriori WCS solutions. [#596]
+
 
 3.1.3 (5-Dec-2019)
 ==================

--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -750,8 +750,9 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, print_fit
                                           num_xmatches))
         # print fit params to screen
         if print_fit_parameters:
-            log_info_keys = ['status', 'fitgeom', 'eff_minobj', 'matrix', 'shift', 'center', 'rot', 'proper',
-                'rotxy', 'scale', 'skew', 'rmse', 'mae', 'nmatches', 'FIT_RMS', 'TOTAL_RMS', 'NUM_FITS',
+            log_info_keys = ['status', 'fitgeom', 'eff_minobj', 'matrix', 'shift', 'center',
+                'proper_rot', 'proper',
+                '<rot>', '<scale>', 'skew', 'rmse', 'mae', 'nmatches', 'FIT_RMS', 'TOTAL_RMS', 'NUM_FITS',
                 'RMS_RA', 'RMS_DEC', 'catalog']
             log.info("{} FIT PARAMETERS {}".format("~" * 35, "~" * 34))
             log.info("image: {}".format(image_name))

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -61,7 +61,6 @@ class AlignmentTable:
                           plot=False, vmax=None, deblend=False
         """
         log.setLevel(log_level)
-
         # Register fit methods with the class
         self.fit_methods = {'relative': match_relative_fit,
                             '2dhist': match_2dhist_fit,
@@ -194,9 +193,6 @@ class AlignmentTable:
 
     def perform_fit(self, method_name, catalog_name, reference_catalog):
         """Perform fit using specified method, then determine fit quality"""
-        inputs = [img.meta['name'] for img in self.imglist]
-        log.info("Performing {} astrometric fit to {} for: \n    {}".format(method_name,
-                                                                            reference_catalog, inputs))
         imglist = self.fit_methods[method_name](self.imglist, reference_catalog,
                                                 **self.fit_pars[method_name])
 
@@ -245,7 +241,7 @@ class AlignmentTable:
                 self.filtered_table[index]['total_rms'] = item.meta['fit_info']['TOTAL_RMS']
                 self.filtered_table[index]['offset_x'], self.filtered_table[index]['offset_y'] = item.meta['fit_info']['shift']
                 self.filtered_table[index]['scale'] = item.meta['fit_info']['scale'][0]
-                self.filtered_table[index]['rotation'] = item.meta['fit_info']['rot']
+                self.filtered_table[index]['rotation'] = item.meta['fit_info']['<rot>']
             else:
                 self.filtered_table = None
                 # self.filtered_table[index]['fit_method'] = None
@@ -494,9 +490,25 @@ class HAPImage:
         else:
             dqarr = np.concatenate([self.imghdu[('DQ', i + 1)].data for i in range(self.num_sci)])
 
-        # Create temp DQ mask containing all pixels flagged with any value EXCEPT 512 (bad ref pixel)
-        dqmask = bitfield_to_boolean_mask(dqarr, ignore_flags=512)
+        # "grow out" regions in DQ mask flagged as saturated by several
+        # pixels in every direction to prevent the
+        # source match algorithm from trying to match multiple sources
+        # from one image to a single source in the
+        # other or vice-versa.
+        # Create temp DQ mask containing all pixels flagged with any value EXCEPT 256
+        non_sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=256+2048)
 
+        # Create temp DQ mask containing saturated pixels ONLY
+        sat_mask = bitfield_to_boolean_mask(dqarr, ignore_flags=~(256+2048))
+
+        # Ignore sources where only a couple of pixels are flagged as saturated
+        sat_mask = ndimage.binary_erosion(sat_mask, iterations=1)
+
+        # Grow out saturated pixels by a few pixels in every direction
+        grown_sat_mask = ndimage.binary_dilation(sat_mask, iterations=5)
+
+        # combine the two temporary DQ masks into a single composite DQ mask.
+        dqmask = np.bitwise_or(non_sat_mask, grown_sat_mask)
         return dqmask
 
     def find_alignment_sources(self, output=True, dqname='DQ', **alignment_pars):
@@ -550,8 +562,6 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     log.info("{} (match_relative_fit) Cross matching and fitting {}".format("-" * 20, "-" * 27))
     # 0: Specify matching algorithm to use
     match = tweakwcs.TPMatch(**fit_pars)
-    log.debug("Relative fit configured with: \n  {}".format(fit_pars))
-
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
     #                          tolerance=100, use2dhist=False)
 
@@ -812,7 +822,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
         hdulist[sci_extn].header['CRDER2'] = item.meta['fit_info']['RMS_DEC'].value
         hdulist[sci_extn].header['NMATCHES'] = len(item.meta['fit_info']['ref_mag'])
         hdulist[sci_extn].header['HDRNAME'] = "{}_{}".format(image_name.rstrip(".fits"), wcs_name)
-
+        
         if chipctr == num_sci_ext:
             # Close updated flc.fits or flt.fits file
             hdulist.flush()
@@ -867,7 +877,7 @@ def update_headerlet_phdu(tweakwcs_item, headerlet):
 
     x_shift = (tweakwcs_item.meta['fit_info']['shift'])[0]
     y_shift = (tweakwcs_item.meta['fit_info']['shift'])[1]
-    rot = tweakwcs_item.meta['fit_info']['rot']
+    rot = tweakwcs_item.meta['fit_info']['<rot>']
     scale = tweakwcs_item.meta['fit_info']['scale'][0]
     skew = tweakwcs_item.meta['fit_info']['skew']
 

--- a/setup.py
+++ b/setup.py
@@ -79,11 +79,11 @@ setup(
     ],
     python_requires='>=3.5',
     install_requires=[
-        'astropy>=3.1.2',
+        'astropy>=4.0.0',
         'fitsblender',
         'nictools',
         'nose',
-        'numpy>=1.16',
+        'numpy>=1.18',
         'scipy',
         'matplotlib',
         'acstools',
@@ -94,7 +94,7 @@ setup(
         'stsci.skypac',
         'stsci.stimage',
         'stwcs',
-        'tweakwcs>=0.5.0',
+        'tweakwcs>=0.6.0',
         'stregion',
         'requests',
         # HAP-pipeline specific:

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         'stsci.tools>=3.6',
         'stsci.image>=2.3.0',
         'stsci.imagestats',
-        'stsci.skypac',
+        'stsci.skypac>=1.0',
         'stsci.stimage',
         'stwcs',
         'tweakwcs>=0.6.0',


### PR DESCRIPTION
This includes the minimum set of code changes needed to use the new 'tweakwcs' (v0.6.0, when released).  See [tweakwcs PR 105](https://github.com/spacetelescope/tweakwcs/pull/105) for details on what changed in the API.  See [tweakwcs PR 106](https://github.com/spacetelescope/tweakwcs/pull/106) on details of bug fix for HST alignment problems.   