### PR TITLE
Make hla_flag_filter.py concentration index limits user-definable

### DIFF
--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -230,7 +230,7 @@ def ci_filter(drizzled_image, catalog_name, catalog_data, proc_type, param_dict,
     ci_lower_limit = float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit'])
     ci_upper_limit = float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit'])
     snr = float(param_dict['quality control']['ci filter'][proc_type]['bthresh'])
-
+par_dict = param_dict['quality control']['ci filter'][proc_type]
     if param_dict['quality control']['ci filter'][proc_type]['lookup_ci_limits_from_table']:
         # replace CI limits with values from table if possible
         cidict = ci_table.get_ci_from_file(drizzled_image, ci_lookup_file_path, log_level,

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -231,38 +231,40 @@ def ci_filter(drizzled_image, catalog_name, catalog_data, proc_type, param_dict,
     ci_upper_limit = float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit'])
     snr = float(param_dict['quality control']['ci filter'][proc_type]['bthresh'])
 
-    # replace CI limits with values from table if possible
-    cidict = ci_table.get_ci_from_file(drizzled_image, ci_lookup_file_path, log_level,
-                                       diagnostic_mode=diagnostic_mode, ci_lower=ci_lower_limit,
-                                       ci_upper=ci_upper_limit)  # TODO: add values for ACS/SBC
-    ci_lower_limit = cidict['ci_lower_limit']
-    ci_upper_limit = cidict['ci_upper_limit']
+    if param_dict['quality control']['ci filter'][proc_type]['lookup_ci_limits_from_table']:
+        # replace CI limits with values from table if possible
+        cidict = ci_table.get_ci_from_file(drizzled_image, ci_lookup_file_path, log_level,
+                                           diagnostic_mode=diagnostic_mode, ci_lower=ci_lower_limit,
+                                           ci_upper=ci_upper_limit)  # TODO: add values for ACS/SBC
+        ci_lower_limit = cidict['ci_lower_limit']
+        ci_upper_limit = cidict['ci_upper_limit']
 
-    # if an output custom param file was created and the CI values were updated by ci_table.get_ci_from_file,
-    # update output custom param file with new CI values
-    if output_custom_pars_file:
-        if ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']) or \
-                ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
-            log.info("CI limits updated.")
-            with open(output_custom_pars_file) as f:
-                json_data = json.load(f)
-            if ci_lookup_file_path.startswith("default"):
-                param_set = "default_values"
-            else:
-                param_set = "parameters"
+        # if an output custom param file was created and the CI values were updated by ci_table.get_ci_from_file,
+        # update output custom param file with new CI values
+        if output_custom_pars_file:
+            if ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']) or \
+                    ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
+                log.info("CI limits updated.")
+                with open(output_custom_pars_file) as f:
+                    json_data = json.load(f)
+                if ci_lookup_file_path.startswith("default"):
+                    param_set = "default_values"
+                else:
+                    param_set = "parameters"
 
-            if ci_lower_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']):
-                json_data[drizzled_image[:-9]][param_set]["quality control"]["ci filter"][proc_type]["ci_lower_limit"]\
-                    = ci_lower_limit
+                if ci_lower_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']):
+                    json_data[drizzled_image[:-9]][param_set]["quality control"]["ci filter"][proc_type]["ci_lower_limit"]\
+                        = ci_lower_limit
 
-            if ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
-                json_data[drizzled_image[:-9]][param_set]["quality control"]["ci filter"][proc_type]["ci_upper_limit"]\
-                    = ci_upper_limit
+                if ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
+                    json_data[drizzled_image[:-9]][param_set]["quality control"]["ci filter"][proc_type]["ci_upper_limit"]\
+                        = ci_upper_limit
 
-            with open(output_custom_pars_file, 'w') as f:
-                json.dump(json_data, f, indent=4)
-            log.info("Updated custom pars file {}".format(output_custom_pars_file))
-
+                with open(output_custom_pars_file, 'w') as f:
+                    json.dump(json_data, f, indent=4)
+                log.info("Updated custom pars file {}".format(output_custom_pars_file))
+    else:
+        log.info("Using existing concentration index limits from parameter file")
     log.info(' ')
     log.info('ci limits for {}'.format(drizzled_image))
     log.info('ci_lower_limit = {}'.format(ci_lower_limit))

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -242,7 +242,7 @@ def ci_filter(drizzled_image, catalog_name, catalog_data, proc_type, param_dict,
         # if an output custom param file was created and the CI values were updated by ci_table.get_ci_from_file,
         # update output custom param file with new CI values
         if output_custom_pars_file:
-            if ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']) or \
+            if ci_lower_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']) or \
                     ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
                 log.info("CI limits updated.")
                 with open(output_custom_pars_file) as f:

--- a/drizzlepac/hlautils/hla_flag_filter.py
+++ b/drizzlepac/hlautils/hla_flag_filter.py
@@ -227,11 +227,12 @@ def ci_filter(drizzled_image, catalog_name, catalog_data, proc_type, param_dict,
         drizzled filter product catalog data with updated flag values
     """
     catalog_name_root = catalog_name.split('.')[0]
-    ci_lower_limit = float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit'])
-    ci_upper_limit = float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit'])
-    snr = float(param_dict['quality control']['ci filter'][proc_type]['bthresh'])
-par_dict = param_dict['quality control']['ci filter'][proc_type]
-    if param_dict['quality control']['ci filter'][proc_type]['lookup_ci_limits_from_table']:
+    par_dict = param_dict['quality control']['ci filter'][proc_type]
+    ci_lower_limit = float(par_dict['ci_lower_limit'])
+    ci_upper_limit = float(par_dict['ci_upper_limit'])
+    snr = float(par_dict['bthresh'])
+
+    if par_dict['lookup_ci_limits_from_table']:
         # replace CI limits with values from table if possible
         cidict = ci_table.get_ci_from_file(drizzled_image, ci_lookup_file_path, log_level,
                                            diagnostic_mode=diagnostic_mode, ci_lower=ci_lower_limit,
@@ -242,8 +243,8 @@ par_dict = param_dict['quality control']['ci filter'][proc_type]
         # if an output custom param file was created and the CI values were updated by ci_table.get_ci_from_file,
         # update output custom param file with new CI values
         if output_custom_pars_file:
-            if ci_lower_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']) or \
-                    ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
+            if ci_lower_limit != float(par_dict['ci_lower_limit']) or \
+                    ci_upper_limit != float(par_dict['ci_upper_limit']):
                 log.info("CI limits updated.")
                 with open(output_custom_pars_file) as f:
                     json_data = json.load(f)
@@ -252,11 +253,11 @@ par_dict = param_dict['quality control']['ci filter'][proc_type]
                 else:
                     param_set = "parameters"
 
-                if ci_lower_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_lower_limit']):
+                if ci_lower_limit != float(par_dict['ci_lower_limit']):
                     json_data[drizzled_image[:-9]][param_set]["quality control"]["ci filter"][proc_type]["ci_lower_limit"]\
                         = ci_lower_limit
 
-                if ci_upper_limit != float(param_dict['quality control']['ci filter'][proc_type]['ci_upper_limit']):
+                if ci_upper_limit != float(par_dict['ci_upper_limit']):
                     json_data[drizzled_image[:-9]][param_set]["quality control"]["ci filter"][proc_type]["ci_upper_limit"]\
                         = ci_upper_limit
 

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.6
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.6
       }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.15,
         "ci_upper_limit": 0.45
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.15,
         "ci_upper_limit": 0.45
       }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 1.5,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.23
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.23
       }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.25,
         "ci_upper_limit": 0.55
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.25,
         "ci_upper_limit": 0.55
       }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.75,
         "ci_upper_limit": 1.00
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.75,
         "ci_upper_limit": 1.00
       }

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.6
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.6
       }

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.15,
         "ci_upper_limit": 0.45
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.15,
         "ci_upper_limit": 0.45
       }

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 1.5,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.23
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.23
       }

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.25,
         "ci_upper_limit": 0.55
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.25,
         "ci_upper_limit": 0.55
       }

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_quality_control_all.json
@@ -2,11 +2,13 @@
     "ci filter": {
       "aperture": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.75,
         "ci_upper_limit": 1.00
       },
       "segment": {
         "bthresh": 5.0,
+        "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.75,
         "ci_upper_limit": 1.00
       }


### PR DESCRIPTION
**Summary**
Up to this point, there was no way hla_flag_filter.py to use user-specified ci limits from the parameter files. The values for ci_lower_limit and ci_upper_limit were determined by the  ci_table.get_ci_from_file() subroutine even though ci limits are explicitly set in the quality_control_all.json parameter files. The 
This PR addresses that issue by simply adding a new parameter the quality_control_all.files called "lookup_ci_limits_from_table", and wrapping the call to ci_table.get_ci_from_file() in some logic. Now, if lookup_ci_limits_from_table is set to "true", ci_table.get_ci_from_file() is executed. However, if lookup_ci_limits_from_table is set to "false", ci_table.get_ci_from_file() is not executed, and the existing values for ci_lower_limit and ci_upper_limit from the quality_control_all.json file are used instead.

**Impacted Files**
* drizzlepac/hlautils/hla_flag_filter.py: Added logic to hla_flag_filter.run_source_list_flagging() to execute ci_table.get_ci_from_file() and optionally update output param file _only_ if param_dict['quality control']['ci filter'][proc_type]['lookup_ci_limits_from_table'] == True. Otherwise, use existing input parameter file ci limits.
* _ALL_ *_quality_control_all.json files: Added two new parameters: 
     * ci_filter.aperture.lookup_ci_limits_from_table = true
     * ci_filter.segment.lookup_ci_limits_from_table = true
