### PR TITLE
Remove duplicate function; refer to correct fit_info values

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -398,7 +398,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                         alignment_table.reset_group_id(len(reference_catalog))
 
                         # execute the correct fitting/matching algorithm
-                        imglist = alignment_table.perform_fit(algorithm_name, catalog_name, reference_catalog)
+                        alignment_table.imglist = alignment_table.perform_fit(algorithm_name, catalog_name, reference_catalog)
 
                         # determine the quality of the fit
                         fit_rms, fit_num, fit_quality, filtered_table, fit_status_dict = \
@@ -414,7 +414,6 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                             table_fit = alignment_table.fit_dict[(catalog_name, algorithm_name)]
                             table_fit[imglist_ctr].meta['fit method'] = algorithm_name
                             table_fit[imglist_ctr].meta['fit quality'] = fit_quality
-                        #print(alignment_table.fit_dict[(catalog_name, algorithm_name)][0].meta)
 
                         # populate fit_info_dict
                         fit_info_dict["{} {}".format(catalog_name, algorithm_name)] = \
@@ -628,7 +627,6 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, print_fit
             * fit compromised status (Boolean)
             * reason fit is considered 'compromised' (only populated if "compromised" field is "True")
     """
-    tweakwcs_info_keys = OrderedDict(imglist[0].meta['fit_info']).keys()
     max_rms_val = 1e9
     num_xmatches = 0
     fit_status_dict = {}
@@ -841,56 +839,6 @@ def generate_astrometric_catalog(imglist, **pars):
     return(out_catalog)
 
 # ----------------------------------------------------------------------------------------------------------------------
-
-def update_headerlet_phdu(tweakwcs_item, headerlet):
-    """Update the primary header data unit keywords of a headerlet object in-place
-
-    Parameters
-    ==========
-    tweakwcs_item :
-        Basically the output from tweakwcs which contains the cross match and fit information for every chip
-        of every valid input image.
-
-    headerlet : headerlet object
-        object containing WCS information
-    """
-
-    # Get the data to be used as values for FITS keywords
-    rms_ra = tweakwcs_item.meta['fit_info']['RMS_RA'].value
-    rms_dec = tweakwcs_item.meta['fit_info']['RMS_DEC'].value
-    fit_rms = tweakwcs_item.meta['fit_info']['FIT_RMS']
-    nmatch = tweakwcs_item.meta['fit_info']['nmatches']
-    catalog = tweakwcs_item.meta['fit_info']['catalog']
-    fit_method = tweakwcs_item.meta['fit method']
-
-    x_shift = (tweakwcs_item.meta['fit_info']['shift'])[0]
-    y_shift = (tweakwcs_item.meta['fit_info']['shift'])[1]
-    rot = tweakwcs_item.meta['fit_info']['rot']
-    scale = tweakwcs_item.meta['fit_info']['scale'][0]
-    skew = tweakwcs_item.meta['fit_info']['skew']
-
-    log.info("Headerlet being updated with RMS_RA={},  RMS_DEC={}".format(rms_ra, rms_dec))
-    # Update the existing FITS keywords
-    primary_header = headerlet[0].header
-    primary_header['RMS_RA'] = rms_ra
-    primary_header['RMS_DEC'] = rms_dec
-    primary_header['NMATCH'] = nmatch
-    primary_header['CATALOG'] = catalog
-    primary_header['FITMETH'] = fit_method
-
-    # Create a new FITS keyword
-    primary_header['FIT_RMS'] = (fit_rms, 'RMS (mas) of the 2D fit of the headerlet solution')
-
-    # Create the set of HISTORY keywords
-    primary_header['HISTORY'] = '~~~~~ FIT PARAMETERS ~~~~~'
-    primary_header['HISTORY'] = '{:>15} : {:9.4f} "/pixels'.format('platescale', tweakwcs_item.wcs.pscale)
-    primary_header['HISTORY'] = '{:>15} : {:9.4f} pixels'.format('x_shift', x_shift)
-    primary_header['HISTORY'] = '{:>15} : {:9.4f} pixels'.format('y_shift', y_shift)
-    primary_header['HISTORY'] = '{:>15} : {:9.4f} degrees'.format('rotation', rot)
-    primary_header['HISTORY'] = '{:>15} : {:9.4f}'.format('scale', scale)
-    primary_header['HISTORY'] = '{:>15} : {:9.4f}'.format('skew', skew)
-
-
 
 def get_default_pars(instrument, detector, step='alignment',
                      condition=['filter_basic']):

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -240,8 +240,8 @@ class AlignmentTable:
                 self.filtered_table[index]['fit_rms'] = item.meta['fit_info']['FIT_RMS']
                 self.filtered_table[index]['total_rms'] = item.meta['fit_info']['TOTAL_RMS']
                 self.filtered_table[index]['offset_x'], self.filtered_table[index]['offset_y'] = item.meta['fit_info']['shift']
-                self.filtered_table[index]['scale'] = item.meta['fit_info']['scale'][0]
-                self.filtered_table[index]['rotation'] = item.meta['fit_info']['<rot>']
+                self.filtered_table[index]['scale'] = item.meta['fit_info']['<scale>']
+                self.filtered_table[index]['rotation'] = item.meta['fit_info']['rot'][1]
             else:
                 self.filtered_table = None
                 # self.filtered_table[index]['fit_method'] = None
@@ -822,7 +822,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
         hdulist[sci_extn].header['CRDER2'] = item.meta['fit_info']['RMS_DEC'].value
         hdulist[sci_extn].header['NMATCHES'] = len(item.meta['fit_info']['ref_mag'])
         hdulist[sci_extn].header['HDRNAME'] = "{}_{}".format(image_name.rstrip(".fits"), wcs_name)
-        
+
         if chipctr == num_sci_ext:
             # Close updated flc.fits or flt.fits file
             hdulist.flush()
@@ -877,8 +877,8 @@ def update_headerlet_phdu(tweakwcs_item, headerlet):
 
     x_shift = (tweakwcs_item.meta['fit_info']['shift'])[0]
     y_shift = (tweakwcs_item.meta['fit_info']['shift'])[1]
-    rot = tweakwcs_item.meta['fit_info']['<rot>']
-    scale = tweakwcs_item.meta['fit_info']['scale'][0]
+    rot = tweakwcs_item.meta['fit_info']['rot'][1]  # report rotation of Y axis only
+    scale = tweakwcs_item.meta['fit_info']['<scale>']
     skew = tweakwcs_item.meta['fit_info']['skew']
 
     # Update the existing FITS keywords


### PR DESCRIPTION
This simply insures that the correct values are being pulled from the fit_info structure after being revised in tweakwcs v0.6.0.  Duplicate functions were also removed from align.py as well to prevent any further confusion. 