### PR TITLE
Write out alignment's selected fit in debug mode

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -475,6 +475,9 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         imglist = alignment_table.selected_fit
         filtered_table = alignment_table.filtered_table
 
+        if debug:
+            alignment_table.write()
+
         # Report processing time for this step
         log.info(make_label('Processing time of [STEP 5b]', starting_dt))
         starting_dt = datetime.datetime.now()

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -3,6 +3,7 @@ import datetime
 import copy
 import sys
 import traceback
+import pickle
 
 from collections import OrderedDict
 
@@ -274,7 +275,17 @@ class AlignmentTable:
             self.filtered_table[table_index]['headerletFile'] = headerlet_dict[
                 self.filtered_table[table_index]['imageName']]
 
-
+    def write(self, output=None):
+        """Write out selected fit to disk"""
+        if output is None:
+            rootname = self.selected_fit[0].meta['filename'][:6]        
+            output = "{}_selected_fit.pickle".format(rootname)
+        with open(output, 'wb') as pickle_file:
+            pickle.dump(self.selected_fit, pickle_file)
+            pickle_file.close()
+        log.info("Wrote {}".format(output))
+            
+            
 class HAPImage:
     """Core class defining interface for each input exposure/product
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -841,7 +841,8 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                     sat_flags = 256 + 2048 + 4096 + 8192
 
                 align_table = align.perform_align(alignfiles, update_hdr_wcs=True, runfile=alignlog,
-                                                  clobber=False, output=debug, sat_flags=sat_flags)
+                                                  clobber=False, output=debug, 
+                                                  debug=debug, sat_flags=sat_flags)
                 if align_table is None:
                     raise Exception
 


### PR DESCRIPTION
This adds a '.write()' method to the AlignmentTable class which dumps the 'selected_fit' list out to a pickle file for further analysis by the end-user/pipeline.  In addition, 'runastrodriz' and 'align.perform_align' were updated to call this when 'debug=True'.  

This pickle file supplements the GAIA catalog written out as 'ref_cat.ecsv' and 'refcatalog.cat' used for the alignment to provide a more complete view into what went into the fit which was deemed 'best' during pipeline processing. 