### PR TITLE
Insure blank images are actually blank

### DIFF
--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -1805,13 +1805,14 @@ def reduce_diff_region(arr, scale=1, background=None, nsigma=4,
         bkg = sigma_clipped_stats(rebin_arr, sigma=sigma, maxiters=maxiters)
         bkg_total = bkg[0] + nsigma * bkg[2]  # mean + 4 * sigma
         log.debug("sigma clipped background value: {}".format(bkg_total))
-        blank_image = True if bkg[1] < bkg[2] else False
+        blank_image = True if (bkg[1] < bkg[2] and bkg[1] < 1.0) else False
 
     elif isinstance(background, Background2D):
         bkg_total = background.background + nsigma * background.background_rms
         log.debug("background: max={}, mean={}".format(bkg_total.max(),
                     bkg_total.mean()))
-        blank_image = True if background.median < background.median_rms else False
+        blank_image = True if (background.median < background.median_rms and
+                               background.median < 1.0) else False
 
     if blank_image:
         # median filter image to limit noise-induced variations into overlap differences


### PR DESCRIPTION
The logic which checks to see whether images are blank when computing the overlap differences could have been skewed by crowded fields or large extended sources.  Therefore, an additional condition based was implemented to insure the logic does not get fooled by (too many) crowded field/extended source images.  