### PR TITLE
Apply CR flagging every time WCS fails verification

### DIFF
--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -4,7 +4,7 @@ jobs:
     ${{ if eq(parameters.os, 'windows') }}:
       vmImage: windows-latest
     ${{ if eq(parameters.os, 'macos') }}:
-      vmImage: macOS-10.13
+      vmImage: macOS-10.14
     ${{ if eq(parameters.os, 'linux') }}:
       vmImage: ubuntu-16.04
 

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -843,7 +843,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
                     headerlet_filename = image_name.replace("flc", "flt_hlet")
                 if image_name.endswith("flt.fits"):
                     headerlet_filename = image_name.replace("flt", "flt_hlet")
-            out_headerlet.writeto(headerlet_filename, clobber=True)
+            out_headerlet.writeto(headerlet_filename, overwrite=True)
             log.info("Wrote headerlet file {}.\n\n".format(headerlet_filename))
             out_headerlet_dict[image_name] = headerlet_filename
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -847,6 +847,16 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
         alignfiles = calfiles_flc if calfiles_flc else calfiles
         align_update_files = calfiles if calfiles_flc else None
 
+        if find_crs:
+            trlmsg = _timestamp("Resetting CRs ")
+            # reset all DQ flags associated with CRs assuming previous attempts were inaccurate
+            for f in alignfiles:
+                trlmsg += "Resetting CR DQ bits for {}\n".format(f)
+                resetbits.reset_dq_bits(f, "4096,8192")
+                sat_flags = 256 + 2048
+        else:
+            sat_flags = 256 + 2048 + 4096 + 8192
+
         # Perform any requested alignment here...
         if alignment_mode == 'aposteriori':
             # Create trailer marker message for start of align_to_GAIA processing
@@ -856,14 +866,6 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
             alignlog = trlfile.replace('.tra', '_align.log')
             alignlog_copy = alignlog.replace('_align', '_align_copy')
             try:
-                if find_crs:
-                    # reset all DQ flags associated with CRs assuming previous attempts were inaccurate
-                    for f in alignfiles:
-                        trlmsg += "Resetting CR DQ bits for {}\n".format(f)
-                        resetbits.reset_dq_bits(f, "4096,8192")
-                        sat_flags = 256 + 2048
-                else:
-                    sat_flags = 256 + 2048 + 4096 + 8192
 
                 align_table = align.perform_align(alignfiles, update_hdr_wcs=True, runfile=alignlog,
                                                   clobber=False, output=debug,


### PR DESCRIPTION
This revision moves the code that performs CR flagging so that it is done anytime the verification of the alignment fails, as opposed to only doing it if apriori alignment failed to verify.  In addition, the parameters for computing sources in the overlap region was refined to return segmentation maps for the sources which are broader than before, allowing the overlap computation to be a little less sensitive to noise.  Also, an astropy deprecation warning was also resolved.  

This change was tested on these datasets: jcdm42010, idn117010, icw402010, j90o47zjq, ibsl31030, ib6w61050, and idhq04010.