### PR TITLE
Insure background subtraction is consistently applied

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -226,28 +226,33 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         else:
             log.warning("WARNING: Unable to display Git repository revision information.")
 
+    # Initialize key variables
+    filtered_table = None
+
+    # 1: Interpret input data and optional parameters
+    log.info("{} STEP 1: Get data {}".format("-" * 20, "-" * 66))
+    zero_dt = starting_dt = datetime.datetime.now()
+    log.info(str(starting_dt))
+    imglist = check_and_get_data(input_list, archive=archive, clobber=clobber)
+    log.info("SUCCESS")
+
+    log.info(make_label('Processing time of [STEP 1]', starting_dt))
+    starting_dt = datetime.datetime.now()
+
+    # Get default alignment parameters if not provided by the user...
+    inst = fits.getval(imglist[0], 'instrume')
+    det = fits.getval(imglist[0], 'detector')
+    apars = get_default_pars(inst, det)
+    alignment_pars.update(apars)
+    
     try:
-        # Initialize key variables
-        filtered_table = None
-
-        # 1: Interpret input data and optional parameters
-        log.info("{} STEP 1: Get data {}".format("-" * 20, "-" * 66))
-        zero_dt = starting_dt = datetime.datetime.now()
-        log.info(str(starting_dt))
-        imglist = check_and_get_data(input_list, archive=archive, clobber=clobber)
-        log.info("SUCCESS")
-
-        log.info(make_label('Processing time of [STEP 1]', starting_dt))
-        starting_dt = datetime.datetime.now()
-
-        # Get default alignment parameters if not provided by the user...
-        inst = fits.getval(imglist[0], 'instrume')
-        det = fits.getval(imglist[0], 'detector')
-        apars = get_default_pars(inst, det)
-        alignment_pars.update(apars)
-
         # Instantiate AlignmentTable class with these input files
         alignment_table = align_utils.AlignmentTable(imglist, **alignment_pars)
+        if alignment_table.process_list is None:
+            log.warning("NO viable images to align.") 
+            alignment_table.close()
+            return None
+            
         process_list = alignment_table.process_list
 
         # Define fitting algorithm list in priority order
@@ -304,7 +309,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                 alignment_table.filtered_table[:]['processMsg'] = "No sources found"
                 log.info(make_label('Processing time of [STEP 4]', starting_dt))
                 alignment_table.close()
-                return
+                return None
 
             # The catalog of observable sources must have at least MIN_OBSERVABLE_THRESHOLD entries to be useful
             total_num_sources = 0
@@ -320,7 +325,8 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                 alignment_table.filtered_table[:]['processMsg'] = "Not enough sources found"
                 log.info(make_label('Processing time of [STEP 4]', starting_dt))
                 alignment_table.close()
-                return
+                return None
+                
         log.info("SUCCESS")
         log.info(make_label('Processing time of [STEP 4]', starting_dt))
         starting_dt = datetime.datetime.now()

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -78,6 +78,8 @@ class AlignmentTable:
         self.alignment_pars.update(alignment_pars['determine_fit_quality'])
 
         self.dqname = dqname
+        self.haplist = []
+        self.process_list = None
 
         self.zero_dt = starting_dt = datetime.datetime.now()
         log.info(str(starting_dt))
@@ -102,7 +104,7 @@ class AlignmentTable:
         default_fwhm_set = False
 
         try:
-            self.haplist = []
+
             for img in self.process_list:
                 catimg = HAPImage(img)
                 # Build image properties needed for alignment

--- a/drizzlepac/hlautils/astroquery_utils.py
+++ b/drizzlepac/hlautils/astroquery_utils.py
@@ -54,7 +54,7 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False):
 
     # Query MAST for the data with an observation type of either "science" or
     # "calibration"
-    obs_table = Observations.query_criteria(obs_id=obsid, obstype='all')
+    obs_table = Observations.query_criteria(obs_id=obsid)
     # Catch the case where no files are found for download
     if not obs_table:
         log.info("WARNING: Query for {} returned NO RESULTS!".format(obsid))

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1006,8 +1006,8 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                 _trlmsg += "Alignment appeared to SUCCEED based on similarity index of {:0.4f} \n".format(sim_indx)
             else:
                 _trlmsg += "Alignment appeared to FAIL based on similarity index of {:0.4f} \n".format(sim_indx)
-                _trlmsg += "  Reverting to previously determined WCS alignment.\n"
-                alignment_verified = False
+                # _trlmsg += "  Reverting to previously determined WCS alignment.\n"
+                # alignment_verified = False
                 alignment_quality += 3
 
         for fd in focus_dicts:

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -733,7 +733,7 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
             if not os.path.exists(sfile):
                 # Working with data where CR is turned off by default (ACS/SBC, for example)
                 # Reset astrodrizzle parameters to generate single_sci images
-                reset_mdriztab_nocr(pipeline_pars, good_bits)
+                reset_mdriztab_nocr(pipeline_pars, good_bits, pipeline_pars['skysub'])
 
                 drizzlepac.astrodrizzle.AstroDrizzle(input=infile, configobj=None,
                                                     **pipeline_pars)
@@ -774,13 +774,13 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
 
     return drz_products, focus_dicts, diff_dicts
 
-def reset_mdriztab_nocr(pipeline_pars, good_bits):
+def reset_mdriztab_nocr(pipeline_pars, good_bits, skysub):
     # Need to turn off MDRIZTAB if any other parameters are to be set
     pipeline_pars['mdriztab'] = False
     pipeline_pars['build'] = True
     pipeline_pars['resetbits'] = 0
     pipeline_pars['static'] = False
-    pipeline_pars['skysub'] = True
+    pipeline_pars['skysub'] = skysub
     pipeline_pars['driz_separate'] = True
     pipeline_pars['driz_sep_bits'] = good_bits
     pipeline_pars['driz_sep_fillval'] = 0.0
@@ -824,7 +824,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
     try:
         if not find_crs:
             # Need to turn off MDRIZTAB if any other parameters are to be set
-            reset_mdriztab_nocr(pipeline_pars, good_bits)
+            reset_mdriztab_nocr(pipeline_pars, good_bits, pipeline_pars['skysub'])
 
         if tmpdir:
             # Create tmp directory for processing
@@ -1002,10 +1002,10 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
             sim_indx = amutils.compute_similarity(alignprod, align_ref)
             align_sim_fail = sim_indx > 1
 
-        
             if not align_sim_fail and alignment_verified:
-                _trlmsg += "Alignment appeared to succeed based on similarity index of {:0.4f} \n".format(sim_indx)
+                _trlmsg += "Alignment appeared to SUCCEED based on similarity index of {:0.4f} \n".format(sim_indx)
             else:
+                _trlmsg += "Alignment appeared to FAIL based on similarity index of {:0.4f} \n".format(sim_indx)
                 _trlmsg += "  Reverting to previously determined WCS alignment.\n"
                 alignment_verified = False
                 alignment_quality += 3


### PR DESCRIPTION
It turned out that background subtraction was not being done consistently for each of the iterations of the drizzling during standard pipeline processing.  This led to images which are mostly blank to fail similarity comparison due to differing background levels resulting in many datasets not getting updated WCS solutions when they were appropriate.  

In addition, datasets which can not be aligned in the pipeline with an aposteriori solution (such as prism or grism datasets), were not being handled correctly and an unnecessary exception was being thrown.  This also prevented the apriori solution from being applied in some cases where it should have been.

These changes address both of these issues and were tested on ALL 209 datasets that only had pipeline default solutions (or NONE) from the 2020-03-19 test run, with a majority of them now getting improved WCS solutions.  