### PR TITLE
Fix fitmask exceptions for blank images 

### DIFF
--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -686,9 +686,11 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
     for group_id in group_ids:
         input_mag = None
         for item in tweakwcs_output:
+            tinfo = item.meta['fit_info']
             # When status = FAILED (fit failed) or REFERENCE (relative alignment done with first image
             # as the reference), skip to the beginning of the loop as there is no 'fit_info'.
-            if item.meta['fit_info']['status'] != 'SUCCESS':
+            if tinfo['status'] != 'SUCCESS' or (tinfo['status'] == 'SUCCESSS' and \
+                'fitmask' not in tinfo):
                 continue
             # Make sure to store data for any particular group_id only once.
             if item.meta['group_id'] == group_id and \
@@ -698,7 +700,6 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
 
                 log.debug("fit_info: {}".format(item.meta['fit_info']))
 
-                tinfo = item.meta['fit_info']
                 ref_idx = tinfo['matched_ref_idx']
                 fitmask = tinfo['fitmask']
                 group_dict[group_id]['ref_idx'] = ref_idx
@@ -737,7 +738,7 @@ def interpret_fit_rms(tweakwcs_output, reference_catalog):
     # Now, append computed results to tweakwcs_output
     for item in tweakwcs_output:
         group_id = item.meta['group_id']
-        fitmask = item.meta['fit_info']['fitmask']
+        fitmask = item.meta['fit_info'].get('fitmask', None)
         if group_id in group_dict:
             fit_rms = group_dict[group_id]['FIT_RMS']
             ra_rms = group_dict[group_id]['RMS_RA']

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -148,8 +148,10 @@ class AlignmentTable:
 
             # Allow user to decide when and how to write out catalogs to files
             if output:
-                # write out coord lists to files for diagnostic purposes. Protip: To display the sources in these files in DS9,
-                # set the "Coordinate System" option to "Physical" when loading the region file.
+                # write out coord lists to files for diagnostic purposes. 
+                # Protip: To display the sources in these files in DS9,
+                #         set the "Coordinate System" option to "Physical" 
+                #         when loading the region file.
                 imgroot = os.path.basename(img.imgname).split('_')[0]
                 for chip in range(1, img.num_sci + 1):
                     chip_cat = img.catalog_table[chip]

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -556,10 +556,11 @@ def extract_point_sources(img, dqmask=None, fwhm=3.0, kernel=None,
     # Now, use IRAFStarFinder to identify sources across chip
     starfind = IRAFStarFinder(threshold=bkg_thresh, fwhm=fwhm)
     srcs = starfind.find_stars(img, mask=dqmask)
-    if high_sn is not None and len(srcs) > high_sn:
+    if srcs is not None and high_sn is not None and len(srcs) > high_sn:
         # sort by flux, return high_sn srcs only...
         indx = np.argsort(srcs['flux'])[:high_sn]
         srcs = srcs[indx]
+    num_srcs = len(srcs) if srcs is not None else 0
     log.info("Found {} sources".format(len(srcs)))
 
     return srcs

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -61,7 +61,7 @@ from stsci.tools import parseinput
 from stsci.tools import logutil
 from stsci.tools.fileutil import countExtn
 
-from ..tweakutils import build_xy_zeropoint
+from ..tweakutils import build_xy_zeropoint, ndfind
 
 __taskname__ = 'astrometric_utils'
 
@@ -545,22 +545,30 @@ def find_fwhm(psf, default_fwhm):
     return fwhm
 
 def extract_point_sources(img, dqmask=None, fwhm=3.0, kernel=None,
-                            high_sn=1000,
-                            nsigma=5.0, sigma=3.0, source_box=7):
+                            nbright=1000,
+                            threshold=200.0, sigma=3.0, source_box=7):
     """Use photutils to replicate the IRAF point-source catalogs"""
 
     # Detect threshold using a relatively fast method and
     # subtract off that background.
+    nsigma = 5.0
     bkg_thresh, bkg = sigma_clipped_bkg(img, sigma=sigma, nsigma=nsigma)
 
+    sigma = np.sqrt(2.0 * np.abs(bkg[1]))
+    x, y, flux, src_id, sharp, round1, round2 = ndfind(img, 
+                                                     sigma*threshold, 
+                                                     fwhm, bkg[1],
+                                                     nbright=nbright)
+    srcs = Table([x,y,flux,src_id], names=['xcentroid', 'ycentroid', 'flux', 'id'])
+    
+    """   
     # Now, use IRAFStarFinder to identify sources across chip
-    starfind = IRAFStarFinder(threshold=bkg_thresh, fwhm=fwhm)
+    starfind = IRAFStarFinder(threshold=bkg[2]*nsigma, fwhm=fwhm)
     srcs = starfind.find_stars(img, mask=dqmask)
     if srcs is not None and high_sn is not None and len(srcs) > high_sn:
         # sort by flux, return high_sn srcs only...
         indx = np.argsort(srcs['flux'])[:high_sn]
         srcs = srcs[indx]
-    num_srcs = len(srcs) if srcs is not None else 0
     log.info("Found {} sources".format(len(srcs)))
 
     return srcs

--- a/drizzlepac/hlautils/quality_analysis.py
+++ b/drizzlepac/hlautils/quality_analysis.py
@@ -146,11 +146,6 @@ def extract_residuals(imglist):
 
         # store results in dict
         group_dict[group_name]['type'] = 'IMAGE'
-        group_dict[group_name].update(
-             {'xsh': fitinfo['shift'][0], 'ysh': fitinfo['shift'][1],
-             'rot': fitinfo['<rot>'], 'scale': fitinfo['<scale>'],
-             'rot_fit': fitinfo['rot'], 'scale_fit': fitinfo['scale'],
-             'nmatches': fitinfo['nmatches'], 'skew': fitinfo['skew']})
 
         if 'fitmask' in fitinfo:
             img_mask = fitinfo['fitmask']
@@ -162,6 +157,11 @@ def extract_residuals(imglist):
             cum_indx += max_indx
             # Extract X, Y for sources from reference image
             ref_x, ref_y = chip.world_to_tanp(ref_ra[ref_indx][chip_mask], ref_dec[ref_indx][chip_mask])
+            group_dict[group_name].update(
+                 {'xsh': fitinfo['shift'][0], 'ysh': fitinfo['shift'][1],
+                 'rot': fitinfo['<rot>'], 'scale': fitinfo['<scale>'],
+                 'rot_fit': fitinfo['rot'], 'scale_fit': fitinfo['scale'],
+                 'nmatches': fitinfo['nmatches'], 'skew': fitinfo['skew']})
 
             group_dict[group_name]['x'].extend(img_x)
             group_dict[group_name]['y'].extend(img_y)
@@ -170,6 +170,12 @@ def extract_residuals(imglist):
             group_dict[group_name]['rms_x'] = sigma_clipped_stats((img_x - ref_x))[-1]
             group_dict[group_name]['rms_y'] = sigma_clipped_stats((img_y - ref_y))[-1]
         else: 
+            group_dict[group_name].update(
+                     {'xsh': None, 'ysh': None,
+                     'rot': None, 'scale': None,
+                     'rot_fit': None, 'scale_fit': None,
+                     'nmatches': -1, 'skew': None})
+
             group_dict[group_name]['x'].extend([])
             group_dict[group_name]['y'].extend([])
             group_dict[group_name]['ref_x'].extend([])

--- a/drizzlepac/hlautils/quality_analysis.py
+++ b/drizzlepac/hlautils/quality_analysis.py
@@ -71,7 +71,7 @@ def determine_alignment_residuals(input, files, max_srcs=2000, fit_dict=None):
         img_cats = {}
         for chip in range(numsci):
             chip += 1
-            img_cats[chip] = amutils.extract_point_sources(hdu[("SCI", chip)].data, high_sn=max_srcs)
+            img_cats[chip] = amutils.extract_point_sources(hdu[("SCI", chip)].data, nbright=max_srcs)
             nums += len(img_cats[chip])
         num_srcs.append(nums)
         src_cats.append(img_cats)

--- a/drizzlepac/hlautils/quality_analysis.py
+++ b/drizzlepac/hlautils/quality_analysis.py
@@ -103,15 +103,17 @@ def determine_alignment_residuals(input, files, max_srcs=2000):
     if align_success:
         # extract results in the style of 'tweakreg'
         resids = extract_residuals(imglist)
-
-        # Define name for output JSON file...
-        resids_file = "{}_astrometry_resids.json".format(input[:9])
-        # Remove any previously computed results
-        if os.path.exists(resids_file):
-            os.remove(resids_file)
-        # Dump the results to a JSON file now...
-        with open(resids_file, 'w') as jfile:
-            json.dump(resids, jfile)
+        if resids is None:
+            resids_file = None
+        else:
+            # Define name for output JSON file...
+            resids_file = "{}_astrometry_resids.json".format(input[:9])
+            # Remove any previously computed results
+            if os.path.exists(resids_file):
+                os.remove(resids_file)
+            # Dump the results to a JSON file now...
+            with open(resids_file, 'w') as jfile:
+                json.dump(resids, jfile)
     else:
         resids_file = None
 
@@ -141,29 +143,39 @@ def extract_residuals(imglist):
             ref_dec = np.concatenate([ref_dec, rdec])
             continue
 
-        img_mask = fitinfo['fitmask']
-        ref_indx = fitinfo['matched_ref_idx'][img_mask]
-        img_indx = fitinfo['matched_input_idx'][img_mask]
-        # Extract X, Y for sources image being updated
-        img_x, img_y, max_indx, chip_mask = get_tangent_positions(chip, img_indx,
-                                                       start_indx=cum_indx)
-        cum_indx += max_indx
-        # Extract X, Y for sources from reference image
-        ref_x, ref_y = chip.world_to_tanp(ref_ra[ref_indx][chip_mask], ref_dec[ref_indx][chip_mask])
 
         # store results in dict
         group_dict[group_name]['type'] = 'IMAGE'
         group_dict[group_name].update(
              {'xsh': fitinfo['shift'][0], 'ysh': fitinfo['shift'][1],
              'rot': fitinfo['<rot>'], 'scale': fitinfo['<scale>'],
+             'rot_fit': fitinfo['rot'], 'scale_fit': fitinfo['scale'],
              'nmatches': fitinfo['nmatches'], 'skew': fitinfo['skew']})
 
-        group_dict[group_name]['x'].extend(img_x)
-        group_dict[group_name]['y'].extend(img_y)
-        group_dict[group_name]['ref_x'].extend(ref_x)
-        group_dict[group_name]['ref_y'].extend(ref_y)        
-        group_dict[group_name]['rms_x'] = sigma_clipped_stats((img_x - ref_x))[-1]
-        group_dict[group_name]['rms_y'] = sigma_clipped_stats((img_y - ref_y))[-1]
+        if 'fitmask' in fitinfo:
+            img_mask = fitinfo['fitmask']
+            ref_indx = fitinfo['matched_ref_idx'][img_mask]
+            img_indx = fitinfo['matched_input_idx'][img_mask]
+            # Extract X, Y for sources image being updated
+            img_x, img_y, max_indx, chip_mask = get_tangent_positions(chip, img_indx,
+                                                           start_indx=cum_indx)
+            cum_indx += max_indx
+            # Extract X, Y for sources from reference image
+            ref_x, ref_y = chip.world_to_tanp(ref_ra[ref_indx][chip_mask], ref_dec[ref_indx][chip_mask])
+
+            group_dict[group_name]['x'].extend(img_x)
+            group_dict[group_name]['y'].extend(img_y)
+            group_dict[group_name]['ref_x'].extend(ref_x)
+            group_dict[group_name]['ref_y'].extend(ref_y)        
+            group_dict[group_name]['rms_x'] = sigma_clipped_stats((img_x - ref_x))[-1]
+            group_dict[group_name]['rms_y'] = sigma_clipped_stats((img_y - ref_y))[-1]
+        else: 
+            group_dict[group_name]['x'].extend([])
+            group_dict[group_name]['y'].extend([])
+            group_dict[group_name]['ref_x'].extend([])
+            group_dict[group_name]['ref_y'].extend([])        
+            group_dict[group_name]['rms_x'] = -1
+            group_dict[group_name]['rms_y'] = -1
 
 
     return group_dict

--- a/drizzlepac/hlautils/quality_analysis.py
+++ b/drizzlepac/hlautils/quality_analysis.py
@@ -39,7 +39,7 @@ from . import astrometric_utils as amutils
 from .. import tweakutils
 
 
-def determine_alignment_residuals(input, files, max_srcs=2000):
+def determine_alignment_residuals(input, files, max_srcs=2000, fit_dict=None):
     """Determine the relative alignment between members of an association.
 
     Parameters
@@ -201,9 +201,9 @@ def get_tangent_positions(chip, indices, start_indx=0):
 
 # -------------------------------------------------------------------------------
 # Simple interface for running all the analysis functions defined for this package
-def run_all(input, files):
+def run_all(input, files, fit_dict=None):
 
-    json_file = determine_alignment_residuals(input, files)
+    json_file = determine_alignment_residuals(input, files, fit_dict=fit_dict)
 
     return json_file
 

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -26,7 +26,7 @@
         "num_sources": 250,
         "deblend": false,
         "fwhmpsf": 0.13,
-        "classify": true,
+        "classify": false,
         "threshold": -1.1
       },
     "generate_astrometric_catalog":

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -669,7 +669,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     if qa_switch:
         # Generate quality statistics for astrometry if specified
         calfiles = _calfiles_flc if _calfiles_flc else _calfiles
-        json_file = qa.run_all(inFile, calfiles)
+        json_file = qa.run_all(inFile, calfiles, fit_dict=align_dicts)
 
         print("Generated quality statistics as {}".format(json_file))
 


### PR DESCRIPTION
This addresses problems seen in extended testing of 1000 datasets where an Exception gets thrown when 1 image in a set did not have a successful relative fit while the others did.  This showed up as the Exception:
`
KeyError: "fitmask"
`
In addition, problems with blank images not generating a source catalog was causing 'amutils.build_wcscat' to throw the following Exception:
`  
File "/home/mburger/anaconda3/envs/2019.5.clone/lib/python3.6/site-packages/drizzlepac/hlautils/astrometric_utils.py", line 559, in extract_point_sources
    if high_sn is not None and len(srcs) > high_sn:
TypeError: object of type 'NoneType' has no len()
`

Both of these issues were corrected in this PR based on testing of ibc305yvq, iaac240d0, ibg414010, and ibh707010.  