### PR TITLE
Insure src catalog always has same number of columns

### DIFF
--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -558,7 +558,8 @@ def extract_point_sources(img, dqmask=None, fwhm=3.0, kernel=None,
     x, y, flux, src_id, sharp, round1, round2 = ndfind(img, 
                                                      sigma*threshold, 
                                                      fwhm, bkg[1],
-                                                     nbright=nbright)
+                                                     nbright=nbright,
+                                                     use_sharp_round=True)
     srcs = Table([x,y,flux,src_id], names=['xcentroid', 'ycentroid', 'flux', 'id'])
     
     """   

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -871,7 +871,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                                                   clobber=False, output=debug,
                                                   debug=debug, sat_flags=sat_flags)
                 if align_table is None:
-                    raise Exception
+                    raise Exception("No successful aposteriori fit determined.")
 
                 num_sources = align_table['matchSources'][0]
                 fraction_matched = num_sources / align_table['catalogSources'][0]
@@ -889,14 +889,17 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                         print(trlmsg)
                         _updateTrlFile(trlfile, trlmsg)
                         return None
-            except Exception:
+            except Exception as err:
                 # Something went wrong with alignment to GAIA, so report this in
                 # trailer file
                 _trlmsg = "EXCEPTION encountered in align...\n"
                 _trlmsg += "   No correction to absolute astrometric frame applied!\n"
                 print(_trlmsg)
                 _updateTrlFile(trlfile, _trlmsg)
-                traceback.print_exc()
+                if 'aposteriori' not in err.args[0]:
+                    traceback.print_exc()
+                else:
+                    print("WARNING: {}".format(err.args[0]))
                 return None
 
             _updateTrlFile(trlfile, trlmsg)


### PR DESCRIPTION
For datasets with no detectable point-sources, the quality analysis code ended up getting only 4 empty columns returned by the source finding code 'tweakutils.ndfind'.  This resulted in the following Exception being thrown as detected through testing:
`
File "/home/mburger/anaconda3/envs/caldp/lib/python3.6/site-packages/drizzlepac/hlautils/astrometric_utils.py", line 561, in extract_point_sources
    nbright=nbright)
ValueError: not enough values to unpack (expected 7, got 4)
`

This simple fix insures that the returned values always have the same number of values to unpack (7).  This fix was verified using ibh705w8q (original error case) and iaac240d0 (case with detected sources).  
