### PR TITLE
Segmentation catalog bug in diagnostic mode

### DIFF
--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -957,7 +957,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                      contrast=self._contrast)
                 if self.diagnostic_mode:
                     outname = self.imgname.replace(".fits", "_segment_deblended.fits")
-                    fits.PrimaryHDU(data=self.segm_deblended_img.data).writeto(outname)
+                    fits.PrimaryHDU(data=segm_deblended_img.data).writeto(outname)
 
                 # The deblending was successful, so just copy the deblended sources back to the sources attribute.
                 self.segm_img = copy.deepcopy(segm_deblended_img)


### PR DESCRIPTION
Fixed a bug which only happened in diagnostic mode.  After source segments are detected, a deblending process is invoked.  In diagnostic mode the inadvertent use of a non-existent variable caused an exception.  While this bug was not fatal, it could significantly reduce the number of detected sources in the image.