### PR TITLE
Reset initialization for pipeline QA test

### DIFF
--- a/drizzlepac/hlautils/quality_analysis.py
+++ b/drizzlepac/hlautils/quality_analysis.py
@@ -39,7 +39,7 @@ from . import astrometric_utils as amutils
 from .. import tweakutils
 
 
-def determine_alignment_residuals(input, files, max_srcs=2000, fit_dict=None):
+def determine_alignment_residuals(input, files, max_srcs=2000):
     """Determine the relative alignment between members of an association.
 
     Parameters
@@ -207,11 +207,11 @@ def get_tangent_positions(chip, indices, start_indx=0):
 
 # -------------------------------------------------------------------------------
 # Simple interface for running all the analysis functions defined for this package
-def run_all(input, files, fit_dict=None):
+def run_all(input, files):
 
-    json_file = determine_alignment_residuals(input, files, fit_dict=fit_dict)
-
-    return json_file
+    json_file = determine_alignment_residuals(input, files)
+    
+    print("Generated quality statistics as {}".format(json_file))
 
 
 # -------------------------------------------------------------------------------

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -669,9 +669,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     if qa_switch:
         # Generate quality statistics for astrometry if specified
         calfiles = _calfiles_flc if _calfiles_flc else _calfiles
-        json_file = qa.run_all(inFile, calfiles, fit_dict=align_dicts)
-
-        print("Generated quality statistics as {}".format(json_file))
+        qa.run_all(inFile, calfiles)
 
 
 def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignment=True,


### PR DESCRIPTION
The QA test for standard pipeline processing originally passed in the alignment dictionary generated during processing.  However, in cases where all astrometry updates get turned off, this dict is uninitialized.  Furthermore, it turned out the QA test did not use that input in the first place (planned for, but not used).  

This set of changes addresses both situations as documented in JIRA ticket [HLA-317](https://jira.stsci.edu/browse/HLA-317).