### PR TITLE
Enable control over fitgeom in alignment

### DIFF
--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -566,6 +566,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     log.info("{} (match_relative_fit) Cross matching and fitting {}".format("-" * 20, "-" * 27))
     # 0: Specify matching algorithm to use
     match = tweakwcs.TPMatch(**fit_pars)
+    import pdb; pdb.set_trace()
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
     #                          tolerance=100, use2dhist=False)
 
@@ -573,7 +574,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     # NOTE: this invocation does not use an astrometric catalog. This call allows all the input images to be aligned in
     # a relative way using the first input image as the reference.
     # 1: Perform relative alignment
-    tweakwcs.align_wcs(imglist, None, match=match, expand_refcat=True)
+    tweakwcs.align_wcs(imglist, None, match=match, expand_refcat=True, fitgeom='rscale')
 
     # Set all the group_id values to be the same so the various images/chips will be aligned to the astrometric
     # reference catalog as an ensemble.
@@ -582,7 +583,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     for image in imglist:
         image.meta["group_id"] = 1234567
     # 2: Perform absolute alignment
-    tweakwcs.align_wcs(imglist, reference_catalog, match=match)
+    tweakwcs.align_wcs(imglist, reference_catalog, match=match, fitgeom='rscale')
 
     # 3: Interpret RMS values from tweakwcs
     interpret_fit_rms(imglist, reference_catalog)

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -201,6 +201,8 @@ class AlignmentTable:
         """Perform fit using specified method, then determine fit quality"""
         # Updated fits_pars with value for fitgeom
         self.fit_pars[method_name]['fitgeom'] = fitgeom
+        log.info("Setting 'fitgeom' parameter to {}".format(fitgeom))
+        
         imglist = self.fit_methods[method_name](self.imglist, reference_catalog,
                                                 **self.fit_pars[method_name])
 

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -262,10 +262,11 @@ class FilterProduct(HAPProduct):
                 log.debug("Abbreviated reference catalog displayed below\n{}".format(ref_catalog))
                 align_table.reference_catalogs[self.refname] = ref_catalog
                 if len(ref_catalog) > align_utils.MIN_CATALOG_THRESHOLD:
-                    align_table.perform_fit(method_name, catalog_name, ref_catalog)
+                    align_table.perform_fit(method_name, catalog_name, ref_catalog,
+                                           fitgeom=fitgeom)
                     align_table.select_fit(catalog_name, method_name)
                     align_table.apply_fit(headerlet_filenames=headerlet_filenames,
-                                         fit_label=fit_label, fitgeom=fitgeom)
+                                         fit_label=fit_label)
                 else:
                     log.warning("Not enough reference sources for absolute alignment...")
                     raise ValueError

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -227,7 +227,7 @@ class FilterProduct(HAPProduct):
         self.edp_list.append(edp)
 
     def align_to_gaia(self, catalog_name='GAIADR2', headerlet_filenames=None, output=True,
-                        fit_label='EVM', align_table=None):
+                        fit_label='EVM', align_table=None, fitgeom='rscale'):
         """Extract the flt/flc filenames from the exposure product list, as
            well as the corresponding headerlet filenames to use legacy alignment
            routine.
@@ -265,7 +265,7 @@ class FilterProduct(HAPProduct):
                     align_table.perform_fit(method_name, catalog_name, ref_catalog)
                     align_table.select_fit(catalog_name, method_name)
                     align_table.apply_fit(headerlet_filenames=headerlet_filenames,
-                                         fit_label=fit_label)
+                                         fit_label=fit_label, fitgeom=fitgeom)
                 else:
                     log.warning("Not enough reference sources for absolute alignment...")
                     raise ValueError

--- a/drizzlepac/hlautils/quality_analysis.py
+++ b/drizzlepac/hlautils/quality_analysis.py
@@ -28,10 +28,12 @@ https://programminghistorian.org/en/lessons/visualizing-with-bokeh
 import json
 import os
 
+from astropy.table import Table
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 import numpy as np
 
+from stwcs.wcsutil import HSTWCS
 from stsci.tools.fileutil import countExtn
 import tweakwcs
 
@@ -203,6 +205,72 @@ def get_tangent_positions(chip, indices, start_indx=0):
     img_y.extend(chip_y)
 
     return img_x, img_y, max_indx, chip_indx
+
+
+# -------------------------------------------------------------------------------
+# Compare source list with GAIA ref catalog
+def match_to_gaia(imcat, refcat, product, output, searchrad=5.0):
+    """Create a catalog with sources matched to GAIA sources
+    
+    Parameters
+    ----------
+    imcat : str or obj
+        Filename or astropy.Table of source catalog written out as ECSV file
+        
+    refcat : str
+        Filename of GAIA catalog files written out as ECSV file
+        
+    product : str
+        Filename of drizzled product used to derive the source catalog
+        
+    output : str
+        Rootname for matched catalog file to be written as an ECSV file 
+    
+    """
+    if isinstance(imcat, str):
+        imtab = Table.read(imcat, format='ascii.ecsv')
+        imtab.rename_column('X-Center', 'x')
+        imtab.rename_column('Y-Center', 'y')
+    else:
+        imtab = imcat
+        if 'X-Center' in imtab.colnames:
+            imtab.rename_column('X-Center', 'x')
+            imtab.rename_column('Y-Center', 'y')
+            
+    
+    reftab = Table.read(refcat, format='ascii.ecsv')
+    
+    # define WCS for matching
+    tpwcs = tweakwcs.FITSWCS(HSTWCS(product, ext=1))
+    
+    # define matching parameters
+    tpmatch = tweakwcs.TPMatch(searchrad=searchrad)
+    
+    # perform match
+    ref_indx, im_indx = tpmatch(reftab, imtab, tpwcs)
+    print('Found {} matches'.format(len(ref_indx)))
+    
+    # Obtain tangent plane positions for both image sources and refeence sources
+    im_x, im_y = tpwcs.det_to_tanp(imtab['x'][im_indx], imtab['y'][im_indx])
+    ref_x, ref_y = tpwcs.world_to_tanp(reftab['RA'][ref_indx], reftab['DEC'][ref_indx])
+    if 'RA' not in imtab.colnames:
+        im_ra, im_dec = tpwcs.det_to_world(imtab['x'][im_indx], imtab['y'][im_indx])
+    else:
+        im_ra = imtab['RA'][im_indx]
+        im_dec = imtab['DEC'][im_indx]
+        
+
+    # Compile match table
+    match_tab = Table(data=[im_x, im_y, im_ra, im_dec, 
+                            ref_x, ref_y, 
+                            reftab['RA'][ref_indx], reftab['DEC'][ref_indx]],
+                      names=['img_x','img_y', 'img_RA', 'img_DEC', 
+                             'ref_x', 'ref_y', 'ref_RA', 'ref_DEC'])
+    if not output.endswith('.ecsv'):
+        output = '{}.ecsv'.format(output)                             
+    match_tab.write(output, format='ascii.ecsv')
+    
+                       
 
 
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
Not all datasets have enough (good quality) sources to perform a full 'general' fit, which is the default for tweakwcs.  These changes expose control over the 'fitgeom' parameter in `tweakwcs.align_wcs()` to enable the code to set the value instead of relying solely on the default value.  Additional PRs/tickets will be needed to describe work to define the value of 'fitgeom' for each instrument if that turns out to be necessary.

The SVM processing was updated to set the value of 'fitgeom' to 'rscale' for all SVM processing under the assumption that higher order fitting done in standard pipeline processing has accounted for any skew in the observations being combined in SVM processing.   

This addresses [JIRA Ticket HLA-316](https://jira.stsci.edu/browse/HLA-316).