### PR TITLE
Fix debug problem in AlignmentTable for 3.1.8x

### DIFF
--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -481,7 +481,7 @@ class HAPImage:
 
             # Report other useful quantities
             log.debug("{} CHIP: {}".format(self.rootname, chip))
-            log.debug("Mean background: {}".format(bkg_mean))
+            log.debug("Mean background: {}".format(bkg_rms_mean))
             log.debug("Mean threshold: {}".format(np.mean(threshold)))
             log.debug("Mean RMS      : {}".format(bkg_rms_mean))
             log.debug("")


### PR DESCRIPTION
An oversight in redefining the terms reported in debug mode within AlignmentTable caused the code to throw an Exception when log_level = DEBUG. This change corrects that mistake by reporting a value that actually gets computed.

Essentially cherry-picking PR #652 for the release branch.