### PR TITLE
Address error case in AlignmentTable

### DIFF
--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -354,8 +354,9 @@ class HAPImage:
         return wht_image
 
     def close(self):
-        self.imghdu.close()
-        self.imghdu = None
+        if self.imghdu is not None:
+            self.imghdu.close()
+            self.imghdu = None
         self.dqmask = None
         self.wht_image = None
         self._wht_image = None


### PR DESCRIPTION
Some datasets trigger an Exception when trying to close an already closed fits.HDUList object for the input image.  The change here adds logic to look for this case and handle it correctly.  

This error case was identified when processing jc4b03010, which this change resolved.