### PR TITLE
Resolve HSTDP2020.2 WCS exceptions

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -780,7 +780,11 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, print_fit
         log.info("FIT SOLUTION REJECTED")
         filtered_table['status'][:] = 1
         for ctr in range(0, len(filtered_table)):
-            filtered_table[ctr]['processMsg'] = fit_status_dict[filtered_table[ctr]['imageName'] + ",1"]["reason"]
+            imgname = filtered_table[ctr]['imageName'] + ",1"
+            if imgname in fit_status_dict:
+                filtered_table[ctr]['processMsg'] = fit_status_dict[imgname]["reason"]
+            else:
+                filtered_table[ctr]['processMsg'] = "Not a valid exposure"
     else:
         for ctr in range(0, len(filtered_table)):
             filtered_table[ctr]['processMsg'] = ""

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -864,21 +864,23 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
 
         # update header with new WCS info
         sci_extn = sci_ext_dict["{}".format(item.meta['chip'])]
+        hdr_name = "{}_{}".format(image_name.rstrip(".fits"), wcs_name)
         updatehdr.update_wcs(hdulist, sci_extn, item.wcs, wcsname=wcs_name, reusename=True)
         hdulist[sci_extn].header['RMS_RA'] = item.meta['fit_info']['RMS_RA'].value
         hdulist[sci_extn].header['RMS_DEC'] = item.meta['fit_info']['RMS_DEC'].value
         hdulist[sci_extn].header['CRDER1'] = item.meta['fit_info']['RMS_RA'].value
         hdulist[sci_extn].header['CRDER2'] = item.meta['fit_info']['RMS_DEC'].value
         hdulist[sci_extn].header['NMATCHES'] = len(item.meta['fit_info']['ref_mag'])
-        hdulist[sci_extn].header['HDRNAME'] = "{}_{}".format(image_name.rstrip(".fits"), wcs_name)
-
+        hdulist[sci_extn].header['HDRNAME'] = hdr_name
+        
+        
         if chipctr == num_sci_ext:
             # Close updated flc.fits or flt.fits file
             hdulist.flush()
             hdulist.close()
 
             # Create headerlet
-            out_headerlet = headerlet.create_headerlet(image_name, hdrname=wcs_name, wcsname=wcs_name,
+            out_headerlet = headerlet.create_headerlet(image_name, hdrname=hdr_name, wcsname=wcs_name,
                                                        logging=False)
 
             # Update headerlet
@@ -897,7 +899,8 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
             out_headerlet_dict[image_name] = headerlet_filename
 
             # Attach headerlet as HDRLET extension
-            headerlet.attach_headerlet(image_name, headerlet_filename, logging=False)
+            if headerlet.verify_hdrname_is_unique(hdulist, hdr_name):
+                headerlet.attach_headerlet(image_name, headerlet_filename, logging=False)
 
         chipctr += 1
     return (out_headerlet_dict)

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -287,9 +287,10 @@ class AlignmentTable:
                                                fit_label=fit_label)
 
         for table_index in range(0, len(self.filtered_table)):
-            self.filtered_table[table_index]['headerletFile'] = headerlet_dict[
-                self.filtered_table[table_index]['imageName']]
-
+            fname = self.filtered_table[table_index]['imageName']
+            row = self.filtered_table[table_index]
+            row['headerletFile'] = headerlet_dict[fname] if fname in headerlet_dict else "None"
+                
 
 class HAPImage:
     """Core class defining interface for each input exposure/product
@@ -864,7 +865,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
 
         # update header with new WCS info
         sci_extn = sci_ext_dict["{}".format(item.meta['chip'])]
-        hdr_name = "{}_{}".format(image_name.rstrip(".fits"), wcs_name)
+        hdr_name = "{}_{}-hlet.fits".format(image_name.rstrip(".fits"), wcs_name)
         updatehdr.update_wcs(hdulist, sci_extn, item.wcs, wcsname=wcs_name, reusename=True)
         hdulist[sci_extn].header['RMS_RA'] = item.meta['fit_info']['RMS_RA'].value
         hdulist[sci_extn].header['RMS_DEC'] = item.meta['fit_info']['RMS_DEC'].value

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1070,7 +1070,7 @@ def restore_pipeline_default(files):
             num_sci = fileutil.countExtn(fhdu)
             for sciext in range(num_sci):
                 if 'hdrname' in fhdu[('sci', sciext + 1)].header:
-                del fhdu[('sci', sciext + 1)].header['hdrname']
+                    del fhdu[('sci', sciext + 1)].header['hdrname']
 
 # Function written from (essentially) first principles
 def old_restore_pipeline_default(files):

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -603,7 +603,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 try:
                     wcsname = fits.getval(fname, 'wcsname', ext=1)
                     wcstype = updatehdr.interpret_wcsname_type(wcsname)
-                    hdrname = "{}_{}".format(fname.replace('.fits', ''), wcsname)
+                    hdrname = "{}_{}-hlet.fits".format(fname.replace('.fits', ''), wcsname)
                     headerlet.write_headerlet(fname, hdrname, output='flt',
                                               wcskey='PRIMARY',
                                               author="OPUS",

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1063,7 +1063,14 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
 def restore_pipeline_default(files):
     """Restore pipeline-default IDC_* WCS as PRIMARY WCS in all input files"""
     updatewcs.updatewcs(files, use_db=False)
-
+    # Remove HDRNAME, if added by some other code.  
+    #  This keyword only needs to be included in the headerlet file itself.
+    for f in files:
+        with fits.open(f, mode='update') as fhdu:
+            num_sci = fileutil.countExtn(fhdu)
+            for sciext in range(num_sci):
+                if 'hdrname' in fhdu[('sci', sciext + 1)].header:
+                del fhdu[('sci', sciext + 1)].header['hdrname']
 
 # Function written from (essentially) first principles
 def old_restore_pipeline_default(files):


### PR DESCRIPTION
HSTDP 2020.2 testing encountered exceptions being generated, and worked around, when pipeline processing j9l929010 and 9 other datasets.  It turns out that these datasets still have incomplete IDC_* solutions in the astrometry database, and trying to restore one of them as the active PRIMARY WCS caused subsequent processing to throw an Exception (missing wcs.idcscale).  

These changes address this issue as well as tries to make the names for the new aposteriori headerlets consistent with what is stored in the database.    