### PR TITLE
Improve catalog memory

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -42,6 +42,8 @@ import pickle
 import sys
 import traceback
 
+from memory_profiler import profile
+
 from astropy.table import Table
 import numpy as np
 import drizzlepac
@@ -75,7 +77,7 @@ envvar_qa_svm = "SVM_QUALITY_TESTING"
 
 # --------------------------------------------------------------------------------------------------------------
 
-
+@profile
 def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, phot_mode='both'):
     """This subroutine utilizes hlautils/catalog_utils module to produce photometric sourcelists for the specified
     total drizzle product and it's associated child filter products.
@@ -249,7 +251,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
 
 
 # ----------------------------------------------------------------------------------------------------------------------
-
+@profile
 def create_drizzle_products(total_obj_list):
     """
     Run astrodrizzle to produce products specified in the total_obj_list.
@@ -340,7 +342,7 @@ def create_drizzle_products(total_obj_list):
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-
+@profile
 def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_configs=True,
                        input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
                        log_level=logutil.logging.INFO):
@@ -528,7 +530,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
 
 # ------------------------------------------------------------------------------------------------------------
-
+@profile
 def run_align_to_gaia(total_obj_list, log_level=logutil.logging.INFO, diagnostic_mode=False):
     # Run align.py on all input images sorted by overlap with GAIA bandpass
     log.info("\n{}: Align the all filters to GAIA with the same fit".format(str(datetime.datetime.now())))
@@ -574,7 +576,7 @@ def run_align_to_gaia(total_obj_list, log_level=logutil.logging.INFO, diagnostic
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-
+@profile
 def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_level, diagnostic_mode=False):
     """
     Super-basic and profoundly inelegant interface to hla_flag_filter.py.

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -493,9 +493,6 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
             # Compute WCS differences between the primary WCS and the alternates, except for OPUS WCS
             svm_qa.report_wcs(total_obj_list)
 
-        # 9: Compare results to HLA classic counterparts (if possible)
-        if diagnostic_mode:
-            run_sourcelist_comparision(total_obj_list, diagnostic_mode=diagnostic_mode, log_level=log_level)
         # Write out manifest file listing all products generated during processing
         log.info("Creating manifest file {}.".format(manifest_name))
         log.info("  The manifest contains the names of products generated during processing.")

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -42,8 +42,6 @@ import pickle
 import sys
 import traceback
 
-from memory_profiler import profile
-
 from astropy.table import Table
 import numpy as np
 import drizzlepac
@@ -77,7 +75,6 @@ envvar_qa_svm = "SVM_QUALITY_TESTING"
 
 # --------------------------------------------------------------------------------------------------------------
 
-@profile
 def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, phot_mode='both'):
     """This subroutine utilizes hlautils/catalog_utils module to produce photometric sourcelists for the specified
     total drizzle product and it's associated child filter products.
@@ -251,7 +248,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
 
 
 # ----------------------------------------------------------------------------------------------------------------------
-@profile
+
 def create_drizzle_products(total_obj_list):
     """
     Run astrodrizzle to produce products specified in the total_obj_list.
@@ -342,7 +339,6 @@ def create_drizzle_products(total_obj_list):
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-@profile
 def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_configs=True,
                        input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
                        log_level=logutil.logging.INFO):
@@ -527,7 +523,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
 
 # ------------------------------------------------------------------------------------------------------------
-@profile
+
 def run_align_to_gaia(total_obj_list, log_level=logutil.logging.INFO, diagnostic_mode=False):
     # Run align.py on all input images sorted by overlap with GAIA bandpass
     log.info("\n{}: Align the all filters to GAIA with the same fit".format(str(datetime.datetime.now())))
@@ -573,7 +569,6 @@ def run_align_to_gaia(total_obj_list, log_level=logutil.logging.INFO, diagnostic
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-@profile
 def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_level, diagnostic_mode=False):
     """
     Super-basic and profoundly inelegant interface to hla_flag_filter.py.

--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -196,7 +196,7 @@ class CatalogImage:
         self.bkg_rms_ra = bkg_rms_ra.copy()
         self.bkg_rms_median = bkg_rms_median.copy()
         
-        del bkg, bkg_backgroun_ra, bkg_rms_ra, bkg_rms_median, bkg_median
+        del bkg, bkg_background_ra, bkg_rms_ra, bkg_rms_median, bkg_median
 
     def _get_header_data(self):
         """Read FITS keywords from the primary or extension header and store the
@@ -225,7 +225,7 @@ class CatalogImage:
         if keyword_dict["detector"] != "SBC":
             keyword_dict["ccd_gain"] = self.imghdu[0].header["CCDGAIN"]
         keyword_dict["aperture_pa"] = self.imghdu[0].header["PA_V3"]
-        keyword_dict["gain_keys"] = [imghdu[0].header[k[:8]] for k in imghdu[0].header["ATODGN*"]]
+        keyword_dict["gain_keys"] = [self.imghdu[0].header[k[:8]] for k in self.imghdu[0].header["ATODGN*"]]
 
         # The total detection product has the FILTER keyword in
         # the primary header - read it for any instrument.

--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -67,11 +67,9 @@ class CatalogImage:
         self.keyword_dict = self._get_header_data()
 
         # Populated by self.compute_background()
-        self.bkg = None
         self.bkg_background_ra = None
         self.bkg_rms_ra = None
         self.bkg_rms_median = None
-        self.bkg_median = None
 
         # Populated by self.build_kernel()
         self.kernel = None
@@ -80,6 +78,10 @@ class CatalogImage:
 
     def close(self):
         self.imghdu.close()
+        self.bkg_background_ra = None
+        self.bkg_rms_ra = None
+        self.bkg_rms_median = None
+        
 
     # def build_kernel(self, box_size, win_size, fwhmpsf):
     def build_kernel(self, box_size, win_size, fwhmpsf):
@@ -91,6 +93,11 @@ class CatalogImage:
                                                                   threshold=self.bkg_rms_ra,
                                                                   fwhm=fwhmpsf / self.imgwcs.pscale)
         (self.kernel, self.kernel_psf) = k
+
+        # Finished with wht_image, clean up memory immediately...
+        del self.wht_image
+        self.wht_image = None
+        
 
     def compute_background(self, box_size, win_size,
                            bkg_estimator=SExtractorBackground, rms_estimator=StdBackgroundRMS):
@@ -185,12 +192,11 @@ class CatalogImage:
         log.info("    Median RMS background: {}".format(bkg_rms_median))
         log.info("")
 
-        self.bkg = bkg
         self.bkg_background_ra = bkg_background_ra.copy()
         self.bkg_rms_ra = bkg_rms_ra.copy()
         self.bkg_rms_median = bkg_rms_median.copy()
-        self.bkg_median = bkg_median.copy()
         
+        del bkg, bkg_backgroun_ra, bkg_rms_ra, bkg_rms_median, bkg_median
 
     def _get_header_data(self):
         """Read FITS keywords from the primary or extension header and store the
@@ -215,9 +221,11 @@ class CatalogImage:
         keyword_dict["target_dec"] = self.imghdu[0].header["DEC_TARG"]
         keyword_dict["expo_start"] = self.imghdu[0].header["EXPSTART"]
         keyword_dict["texpo_time"] = self.imghdu[0].header["TEXPTIME"]
+        keyword_dict["exptime"] = self.imghdu[0].header["EXPTIME"]
         if keyword_dict["detector"] != "SBC":
             keyword_dict["ccd_gain"] = self.imghdu[0].header["CCDGAIN"]
         keyword_dict["aperture_pa"] = self.imghdu[0].header["PA_V3"]
+        keyword_dict["gain_keys"] = [imghdu[0].header[k[:8]] for k in imghdu[0].header["ATODGN*"]]
 
         # The total detection product has the FILTER keyword in
         # the primary header - read it for any instrument.
@@ -242,6 +250,8 @@ class CatalogImage:
         keyword_dict["orientation"] = self.imghdu[1].header["ORIENTAT"]
         keyword_dict["aperture_ra"] = self.imghdu[1].header["RA_APER"]
         keyword_dict["aperture_dec"] = self.imghdu[1].header["DEC_APER"]
+        keyword_dict["photflam"] = self.imghdu[1].header["PHOTFLAM"]
+        keyword_dict["photplam"] = self.imghdu[1].header["PHOTPLAM"]
 
         return keyword_dict
 
@@ -326,6 +336,7 @@ class HAPCatalogs:
 
         for catalog in self.catalogs.values():
             catalog.measure_sources(filter_name, **pars)
+            catalog.close()
 
     def write(self, **pars):
         """Write catalogs for this image to output files.
@@ -375,9 +386,9 @@ class HAPCatalogBase:
         self.sourcelist_filename = self.imgname.replace(self.imgname[-9:], self.catalog_suffix)
 
         # Compute average gain - there will always be at least one gain value in the primary header
-        gain_keys = self.image.imghdu[0].header['atodgn*']
+        gain_keys = self.image.keyword_dict['gain_keys']
         gain_values = [gain_keys[g] for g in gain_keys if gain_keys[g] > 0.0]
-        self.gain = self.image.imghdu[0].header['exptime'] * np.mean(gain_values)
+        self.gain = self.image.keyword_dict['exptime'] * np.mean(gain_values)
 
         # Convert photometric aperture radii from arcsec to pixels
         self.aper_radius_arcsec = [self.param_dict['aperture_1'], self.param_dict['aperture_2']]
@@ -634,8 +645,8 @@ class HAPPointCatalog(HAPCatalogBase):
         photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers,
                                                                 bg_apers,
                                                                 data=image,
-                                                                photflam=self.image.imghdu[1].header['photflam'],
-                                                                photplam=self.image.imghdu[1].header['photplam'],
+                                                                photflam=self.image.keyword_dict['photflam'],
+                                                                photplam=self.image.keyword_dict['photplam'],
                                                                 error_array=self.image.bkg_rms_ra,
                                                                 bg_method=self.param_dict['salgorithm'],
                                                                 epadu=self.gain)
@@ -1130,8 +1141,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
         # Compute the MagIso
         filter_measurements_table["MagIso"] = photometry_tools.convert_flux_to_abmag(filter_measurements_table["source_sum"],
-                                                                                     self.image.imghdu[1].header['photflam'],
-                                                                                     self.image.imghdu[1].header['photplam'])
+                                                                                     self.image.keyword_dict['photflam'],
+                                                                                     self.image.keyword_dict['photplam'])
 
         # Determine the "good rows" as defined by the X and Y coordinates not being nans as
         # the pos_xy array cannot contain any nan values.  Note: It is possible for a filter
@@ -1167,9 +1178,9 @@ class HAPSegmentCatalog(HAPCatalogBase):
             photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers,
                                                                     bg_apers,
                                                                     data=input_image,
-                                                                    photflam=self.image.imghdu[1].header['photflam'],
-                                                                    photplam=self.image.imghdu[1].header['photplam'],
-                                                                    error_array=self.bkg.background_rms,
+                                                                    photflam=self.image.keyword_dict['photflam'],
+                                                                    photplam=self.image.keyword_dict['photplam'],
+                                                                    error_array=self.image.bkg_rms_ra,
                                                                     bg_method=self.param_dict['salgorithm'],
                                                                     epadu=self.gain)
 

--- a/drizzlepac/hlautils/catalog_utils.py
+++ b/drizzlepac/hlautils/catalog_utils.py
@@ -85,7 +85,7 @@ class CatalogImage:
 
     # def build_kernel(self, box_size, win_size, fwhmpsf):
     def build_kernel(self, box_size, win_size, fwhmpsf):
-        if self.bkg is None:
+        if self.bkg_background_ra is None:
             self.compute_background(box_size, win_size)
 
         k, self.kernel_fwhm = astrometric_utils.build_auto_kernel(self.data,
@@ -195,6 +195,7 @@ class CatalogImage:
         self.bkg_background_ra = bkg_background_ra.copy()
         self.bkg_rms_ra = bkg_rms_ra.copy()
         self.bkg_rms_median = bkg_rms_median.copy()
+        self.bkg_median = bkg_median.copy()
         
         del bkg, bkg_background_ra, bkg_rms_ra, bkg_rms_median, bkg_median
 
@@ -336,7 +337,9 @@ class HAPCatalogs:
 
         for catalog in self.catalogs.values():
             catalog.measure_sources(filter_name, **pars)
-            catalog.close()
+
+        for catalog in self.catalogs.values():
+            catalog.image.close()
 
     def write(self, **pars):
         """Write catalogs for this image to output files.
@@ -378,7 +381,6 @@ class HAPCatalogBase:
     def __init__(self, image, param_dict, param_dict_qc, diagnostic_mode, tp_sources):
         self.image = image
         self.imgname = image.imgname
-        self.bkg = image.bkg
         self.param_dict = param_dict
         self.param_dict_qc = param_dict_qc
         self.diagnostic_mode = diagnostic_mode
@@ -387,7 +389,7 @@ class HAPCatalogBase:
 
         # Compute average gain - there will always be at least one gain value in the primary header
         gain_keys = self.image.keyword_dict['gain_keys']
-        gain_values = [gain_keys[g] for g in gain_keys if gain_keys[g] > 0.0]
+        gain_values = [g for g in gain_keys if g > 0.0]
         self.gain = self.image.keyword_dict['exptime'] * np.mean(gain_values)
 
         # Convert photometric aperture radii from arcsec to pixels


### PR DESCRIPTION
Changes based on what was learned in #643 for the alignment steps were now applied as appropriate to the catalog generation processing as run in single-visit processing.  These appear to improve the memory use (cutting it by 1/3 or more in processing iboa31) without affecting the final results.