### PR TITLE
Initial fix for manifest file

### DIFF
--- a/drizzlepac/hapcatalog.py
+++ b/drizzlepac/hapcatalog.py
@@ -9,7 +9,6 @@ from stsci.tools import logutil
 
 from drizzlepac import util
 from drizzlepac.devutils.confirm_execution import confirm_execution
-from drizzlepac.hlautils.catalog_utils import HAPCatalogs
 from drizzlepac import hapsequencer
 from drizzlepac.hlautils import config_utils
 from drizzlepac.hlautils import poller_utils

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -299,7 +299,7 @@ def create_drizzle_products(total_obj_list):
                 exposure_obj.wcs_drizzle_product(meta_wcs)
                 product_list.append(exposure_obj.drizzle_filename)
                 product_list.append(exposure_obj.full_filename)
-                product_list.append(exposure_obj.headerlet_filename)
+                # product_list.append(exposure_obj.headerlet_filename)
                 product_list.append(exposure_obj.trl_filename)
 
         # Create drizzle-combined total detection image after the drizzle-combined filter image and
@@ -450,7 +450,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
 
         reference_catalog = run_align_to_gaia(total_obj_list, log_level=log_level, diagnostic_mode=diagnostic_mode)
         if reference_catalog:
-            product_list += [reference_catalog]
+            product_list += reference_catalog
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))
@@ -560,7 +560,10 @@ def run_align_to_gaia(total_obj_list, log_level=logutil.logging.INFO, diagnostic
         if align_table is None:
             gaia_obj.refname = None
 
-        return gaia_obj.refname
+        # Get names of all headerlet files written out to file
+        headerlet_filenames = [f for f in align_table.filtered_table['headerletFile'] if f != "None"]
+        
+        return [gaia_obj.refname]+headerlet_filenames
 
         #
         # Composite WCS fitting should be done at this point so that all exposures have been fit to GAIA at

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -37,13 +37,11 @@ import fnmatch
 import glob
 import logging
 import os
-import pdb
 import pickle
 import sys
 import traceback
 
 from astropy.table import Table
-import numpy as np
 import drizzlepac
 
 

--- a/drizzlepac/hlautils/cell_utils.py
+++ b/drizzlepac/hlautils/cell_utils.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 
 from matplotlib import pyplot as plt
 from scipy import ndimage
@@ -648,8 +647,6 @@ def compute_band_height(wcs):
 # CKmeans implementation from github/llimllib/ckmeans
 #
 #
-import numpy as np
-
 def ssq(j, i, sum_x, sum_x_sq):
     if (j > 0):
         muji = (sum_x[i] - sum_x[j-1]) / (i - j + 1)
@@ -780,7 +777,6 @@ def partition_n(iterable, n):
     s = sliceable(iterable)
     l = len(s)
     b, mid, e = [0], list(range(1, l)), [l]
-    getslice = s.__getitem__
     splits = (d for i in range(l) for d in combinations(mid, n-1))
     return [[s[sl] for sl in map(slice, chain(b, d), chain(d, e))]
             for d in splits]
@@ -828,7 +824,7 @@ def ckmeans_test():
         args, expected = test
         try:
             result = ckmeans(*args)
-        except:
+        except Exception:
             print("✗ {}, {}".format(args[0], args[1], result))
             raise
         errormsg = "✗ ckmeans({}) = {} != {}\n{} > {}".format(

--- a/drizzlepac/make_cfgobj_files.py
+++ b/drizzlepac/make_cfgobj_files.py
@@ -1,7 +1,7 @@
 from configobj import ConfigObj
 from validate import Validator
 import os
-import pdb
+
 param_dict = {
     "ACS HRC": {
         "astrodrizzle": {

--- a/drizzlepac/run_config_utils.py
+++ b/drizzlepac/run_config_utils.py
@@ -3,8 +3,6 @@ import pdb
 import sys
 
 
-import drizzlepac
-from drizzlepac import hapsequencer
 from drizzlepac.hlautils import config_utils
 from drizzlepac.hlautils import poller_utils
 


### PR DESCRIPTION
This simple update replaces the expected list of headerlet filenames that currently gets added to the manifest file with the list of actually generated headerlet filenames.   Initial testing indicates it does not interfere with generating the manifest file when all expected headerlets are written out (verified using iboa31).  