### PR TITLE
Update imports of interpret_big_flags to use astropy instead

### DIFF
--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -13,6 +13,7 @@ import copy
 import numpy as np
 
 from astropy import wcs as pywcs
+from astropy.nddata import interpret_bit_flags
 import stwcs
 from astropy.io import fits
 from spherical_geometry.polygon import SphericalPolygon
@@ -26,10 +27,7 @@ from stwcs.wcsutil import altwcs
 from stsci.tools import fileutil as fu
 from stsci.stimage import xyxymatch
 from stsci.tools import logutil, textutil
-try:
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
+
 
 from . import catalogs
 from . import linearfit

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -37,16 +37,12 @@ import sys
 import numpy as np
 import astropy
 from astropy.io import fits
+from astropy.nddata import interpret_bit_flags
 
 from stwcs import updatewcs as uw
 from stwcs.wcsutil import altwcs, wcscorr
 from stsci.tools import (cfgpars, parseinput, fileutil, asnutil, irafglob,
                          check_files, logutil, mputil, textutil)
-try:
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
-
 
 from . import wcs_functions
 from . import util

--- a/drizzlepac/resetbits.py
+++ b/drizzlepac/resetbits.py
@@ -64,13 +64,10 @@ EXAMPLES
 """
 import os
 import numpy as np
+from astropy.nddata import interpret_bit_flags
+
 from stsci.tools import stpyfits as fits
 from stsci.tools import parseinput, logutil
-
-try:
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
 
 from . import util
 

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -11,13 +11,11 @@ input image while recording the subtracted value in the image header.
 """
 import os, sys
 
-from .imageObject import imageObject
-from stsci.tools import fileutil, teal, logutil
-try:
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
+import numpy as np
+from astropy.nddata import interpret_bit_flags
 
+from stsci.tools import fileutil, teal, logutil
+import stsci.imagestats as imagestats
 
 from stsci.skypac.skymatch import skymatch
 from stsci.skypac.utils import MultiFileLog, ResourceRefCount, ext2str, \
@@ -25,8 +23,7 @@ from stsci.skypac.utils import MultiFileLog, ResourceRefCount, ext2str, \
 from stsci.skypac.parseat import FileExtMaskInfo, parse_at_file
 
 from . import processInput
-import stsci.imagestats as imagestats
-import numpy as np
+from .imageObject import imageObject
 
 from . import util
 from .version import *


### PR DESCRIPTION
The function 'interpret_dq_bits' originally developed as part of 'stsci.tools.bitmask' has been integrated (as-is?) into astropy.  These changes simply replace the imports to point to the astropy version now instead of stsci.tools.  

The astropy function has the exact same API for both inputs and output values while also retaining (word-for-word) the same docstring description making this a pure drop-in replacement for the stsci.tools version the code had been using.