### PR TITLE
Updates to SVM Quality Test "report wcs".

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -485,7 +485,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
             svm_qa.run_quality_analysis(total_obj_list, log_level=log_level)
 
             # Compute WCS differences between the primary WCS and the alternates, except for OPUS WCS
-            svm_qa.report_wcs(total_obj_list)
+            #svm_qa.report_wcs(total_obj_list)
 
         # Write out manifest file listing all products generated during processing
         log.info("Creating manifest file {}.".format(manifest_name))

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -484,9 +484,6 @@ def run_hap_processing(input_filename, diagnostic_mode=False, use_defaults_confi
             log.info("SVM Quality Assurance statistics have been requested for this dataset, {}.".format(input_filename))
             svm_qa.run_quality_analysis(total_obj_list, log_level=log_level)
 
-            # Compute WCS differences between the primary WCS and the alternates, except for OPUS WCS
-            #svm_qa.report_wcs(total_obj_list)
-
         # Write out manifest file listing all products generated during processing
         log.info("Creating manifest file {}.".format(manifest_name))
         log.info("  The manifest contains the names of products generated during processing.")


### PR DESCRIPTION
- Fixed use of variable before its initialization.
- Removed call to report_wcs from hapsequencer.py as the routine is called within svm_quality_analysis.py.
- Found bug in reporting all of the alternate WCS solutions in a single exposure,
  as well as the Delta (Primary-Alternate) solution.
- Also found the statistics for all exposures in a particular total drizzled
  product were not reported due to non-unique labels for parts of the JSON
  hierarchy.