### PR TITLE
Fix a crash when finding sources in very large images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,10 @@ of the list).
 3.1.7 (unreleased)
 ==================
 
-- Fix a bug in tweakreg due to which the number of matched sources needed to be
+- Fix a crash in ``tweakreg`` when finding sources in very large images
+  due to a bug in ``scipy.signal.convolve2d``. [#670]
+
+- Fix a bug in ``tweakreg`` due to which the number of matched sources needed to be
   *strictly* greater than ``minobj``. Now the minimum number of matched sources
   maust be *at least* equal or greater than ``minobj``. [#604]
 

--- a/drizzlepac/findobj.py
+++ b/drizzlepac/findobj.py
@@ -10,7 +10,7 @@ import sys
 import math
 
 import numpy as np
-from scipy import signal, ndimage
+from scipy import ndimage
 
 import stsci.imagestats as imagestats
 
@@ -180,7 +180,7 @@ def findstars(jdata, fwhm, threshold, skymode,
     ysigsq = (ratio**2) * xsigsq
 
     # convolve image with gaussian kernel
-    convdata = signal.convolve2d(jdata, nkern, boundary='symm', mode='same').astype(np.float32)
+    convdata = ndimage.convolve(jdata, nkern, mode='reflect').astype(np.float32)
 
     # clip image to create regions around each source for segmentation
     if mask is None:


### PR DESCRIPTION
Source finding in very large images fails due to convolution image containing `NaN`s. This is due to a bug in `scipy.signal.convolve2d` - see https://github.com/scipy/scipy/issues/10761 

Both `scipy.signal.fftconvolve` and `scipy.ndimage.convolve` work correctly.

This PR replaces the call to `scipy.signal.convolve2d` with `scipy.ndimage.convolve`.