### PR TITLE
Update docs to describe astrometry processing more fully

### DIFF
--- a/doc/source/astrometry.rst
+++ b/doc/source/astrometry.rst
@@ -119,7 +119,7 @@ a posteriori solutions
 ^^^^^^^^^^^^^^^^^^^^^^^
 The *a posteriori* solutions, on the other hand, get determined from measuring sources in each image, finding overlapping sources from an astrometric catalog, identifying and cross-matching image sources with sources from the astrometric catalog and performing a fit to correct the WCS.  These type of solutions can not be determined for all datasets due to a number of reasons, such as lack of sources in the image and/or lack of overlapping sources from an astrometric catalog.  When these solutions can be determined for an observation, they are given a value for the `WCSNAME` keyword which follows the convention:
 
-  **<Starting WCS>-FIT_<REL|IMG>_<Astrometric Catalog>**
+  **<Starting WCS>-FIT_<REL|IMG|EVM|SVM>_<Astrometric Catalog>**
 
 For example,
 
@@ -134,12 +134,15 @@ The terms are defined as:
 
   * **`FIT`**
 
-    - This term refers to the fact that sources from the image were identified, cross-matched and fit to sources from an astrometric catalog.
+    - This term refers to the fact that sources from the image were identified, cross-matched and fit to sources from an astrometric catalog to create an *a posteriori* WCS solution.  
+        
+  * **`<REL|IMG|EVM|SVM>`**
 
-  * **`<REL|IMG>`**
+    - `REL` : This term denotes the fact that all images were aligned relative (REL) to each other and then aligned to an astrometric catalog.  This attempts to maintain the original relative alignment between the images in a given visit.
+    - `IMG` : This term denotes the fact the the images were fit individually to the astrometric catalog.  These solutions are applied only when relative alignment does not yield a viable fit to the astrometric catalog.
+    - `EVM` : The cross-match and fit to an astrometric catalog was performed on a single exposure by itself as part of processing the exposures of an entire visit. This will typically only apply to those rare visits which do not have enough valid exposures in the visit for alignment.
+    - `SVM` : This term refers to alignment of all the exposures in a single-visit to an astrometric catalog.  The exposures of a visit are aligned to each other (relative alignment), then, as a group, all the exposures are cross-matched and fit to the astrometric catalog specified in the next term in the WCSNAME.
 
-    - The term `REL` denotes the fact that all images were aligned relative (REL) to each other and then aligned to an astrometric catalog.  This attempts to maintain the original relative alignment between the images in a given visit.
-    - The term `IMG` denotes the fact the the images were fit individually to the astrometric catalog.  These solutions are applied only when relative alignment does not yield a viable fit to the astrometric catalog.
 
   * **<Astrometric Catalog>**
 

--- a/doc/source/astrometry.rst
+++ b/doc/source/astrometry.rst
@@ -161,6 +161,36 @@ These separate terms provide as succinct a description of the solution determine
 
     A successfully determined *a posteriori* solution will **always** be used to replace the active WCS (after insuring the previous WCS has been saved as a headerlet extension already) regardless of the original solution.
 
+Pipeline Processing
+-------------------
+All HST observations get processed in an automated environment using standard
+parameters for the calibration code, including the alignment and combination of 
+individual exposures into undistorted products.  The standard pipeline processing
+to create the undistorted drizzled images (drc.fits or drz.fits) gets performed 
+using the 'runastrodriz' task in this package.  This same processing can be 
+run at any time using:
+
+.. code-block:: bash
+
+    runastrodriz j8cw03010_asn.fits
+    
+    runastrodriz j8cw03f6q_raw.fits
+    
+The files which need to be present are:
+
+    * RAW files (*raw.fits)
+    * FLT files (*flt.fits)
+    * FLC files (*flc.fits, if any were created by the pipeline)
+    * ASN file  (*asn.fits, if applicable)
+    
+This processing includes a lot of logic intended to not only apply pre-defined (apriori) 
+WCS solutions, but also to try and determine a new aposteriori solution then 
+verify which solution (default pipeline, apriori or aposteriori) actually provides
+the WCS which comes closest to the GAIA astrometric frame.  
+The :ref:`runastrodriz-description` of the runastrodriz task provides 
+the full discussion of the logic used to define the
+defined 'active' WCS that gets used to create the products which get archived.
+ 
 
 Choosing a WCS
 ---------------

--- a/doc/source/hla.rst
+++ b/doc/source/hla.rst
@@ -1,8 +1,13 @@
 .. hla:
-
+*******************************
 Enhanced Pipeline Products API
-------------------------------
+*******************************
+These modules provide the basic functionality used to automatically process
+data using this package to apply the distortion models to the WCS of HST 
+observations and to verify the alignment of the observations. 
 
+haputils.astrometric_utils
+--------------------------
 
 .. automodule:: drizzlepac.haputils.astrometric_utils
 .. autofunction:: drizzlepac.haputils.astrometric_utils.create_astrometric_catalog
@@ -16,6 +21,25 @@ Enhanced Pipeline Products API
 .. autofunction:: drizzlepac.haputils.astrometric_utils.filter_catalog
 .. autofunction:: drizzlepac.haputils.astrometric_utils.build_self_reference
 .. autofunction:: drizzlepac.haputils.astrometric_utils.within_footprint
-.. autofunction:: drizzlepac.haputils.astrometric_utils.create_image_footprint
 .. autofunction:: drizzlepac.haputils.astrometric_utils.find_hist2d_offset
 .. autofunction:: drizzlepac.haputils.astrometric_utils.build_wcscat
+.. autofunction:: drizzlepac.haputils.astrometric_utils.compute_similarity
+.. autofunction:: drizzlepac.haputils.astrometric_utils.determine_focus_index
+.. autofunction:: drizzlepac.haputils.astrometric_utils.max_overlap_diff
+.. autofunction:: drizzlepac.haputils.astrometric_utils.detect_point_sources
+
+
+haputils.analyze
+-----------------
+.. automodule:: drizzlepac.haputils.analyze
+.. autofunction:: drizzlepac.haputils.analyze.analyze_data
+
+haputils.align_utils
+---------------------
+.. automodule:: drizzlepac.haputils.align_utils
+.. autoclass:: drizzlepac.haputils.align_utils.AlignmentTable
+.. autofunction:: drizzlepac.haputils.align_utils.match_relative_fit
+.. autofunction:: drizzlepac.haputils.align_utils.match_default_fit
+.. autofunction:: drizzlepac.haputils.align_utils.match_2dhist_fit
+
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -116,6 +116,7 @@ The task 'runastrodriz' can be used to reproduce the same Drizzle processing tha
    :maxdepth: 2
 
    Running Astrodriz <runastrodriz.rst>
+   hla
 
 
 Astrometry and Advanced Pipeline Products

--- a/doc/source/runastrodriz.rst
+++ b/doc/source/runastrodriz.rst
@@ -106,7 +106,6 @@ sections providing additional detail on each step.
         b) verify relative alignment with focus index after masking out CRs
         c) copy all drizzle products to parent directory
         d) if alignment fails, update trailer file with failure information
-        e) if alignment verified, copy updated input exposures to parent directory
 
     #. If alignment is verified,
 
@@ -198,8 +197,29 @@ Data to be Processed
 Once the code has performed all the initialization, it prepares the processing by defining what files need to be combined together from the input files it can find.  This includes looking for CTE-corrected versions of the calibrated exposures (FLC files) as well as all the non-CTE-corrected files (FLT files) and creating a separate list of each type.  Many types of data do not get CTE-corrected by the instruments calibration software, such as calacs.e or calwf3.e, and so no list of FLC files will be made.  This will tell the code that it only needs to process the FLT files by themselves.  If FLC files are found, all updates to the astrometry and WCS will be performed on those files and the results then get copied into the FLT file headers upon completion of the processing.  
 
 
+Updating the WCS
+----------------
+The first operation on the calibrated input files focuses on applying the calibrations
+for the distortion model to the WCS.  This operation gets performed using the 
+`updatewcs` task using the syntax:
 
+.. code:: python
 
+    from stwcs.updatewcs import updatewcs
+    updatewcs(calfiles_flc, use_db=False)
+    
+where `calfiles_flc' is the list of CTE-corrected FLC files or in the case there are
+no CTE-corrected files, the list of calibrated FLT files.  Crucially, the use
+of `use_db=False` forces `updatewcs` to only apply the distortion model to the
+default WCS to create what is referred to as the **pipeline-default WCS**.  This
+WCS has a `WCSNAME` associated with it that has the format ``IDC_<rootname>`` where
+``<rootname>`` is the rootname of the `IDCTAB` reference files applied to the WCS. 
+
+This default WCS serves as the basis for all subsequent processing as the code
+tries to determine the WCS which is aligned most closely to the GAIA astrometric
+coordinate system.  
+
+ 
 
 
 

--- a/doc/source/runastrodriz.rst
+++ b/doc/source/runastrodriz.rst
@@ -61,3 +61,81 @@ for each input image.
 The '-n' option allows the user to specify the number of cores to be used in
 running AstroDrizzle.
 
+
+.. _runastrodriz-description:
+
+Description
+===========
+A lot of effort goes into trying to determine the WCS solution which provides
+closest agreement with the GAIA astrometry frame.  Combining the 
+images successfully requires the most accurate alignment possible between all 
+the input exposures taking into account the best available distortion model
+for the input exposures.  Being able to compare the combined image to other exposures
+taken of the same field at other times, or even with other telescopes, requires
+that the WCS be defined to come as close to the GAIA frame as possible.  The 
+processing done by `runastrodriz` attempts to not only apply the most current 
+distortion model, but also the best available pre-computed GAIA-based WCS 
+solutions while proceeding to determine it's own solution to the available GAIA
+reference stars for the field-of-view.  It then performs numerous checks to see 
+which of these solutions results in the most accurately aligned images to each 
+other, then to GAIA and selects that WCS solution.  This selected WCS solution 
+serves as the basis for creating the final, distorted-corrected, combined 
+drizzle products for the set of exposures being processed. 
+
+Overview
+--------
+The overall logic implemented by `runastrodriz` to generate the final set of 
+drizzle products involves creating multiple sets of drizzle products and ultimately
+selecting one as the 'best'.  The basic steps are outlined here, with following 
+sections providing additional detail on each step.
+
+    #. Initialization
+    
+      a) Get any defined environment variables to control processing
+      b) Interpret input file
+      c) Make sure all input files are in a local directory
+      d) Check for DRIZCORR calibration switch in input files
+      e) Create name for output log files
+      f) Define lists of individual input files to be processed
+      
+    #. Run updatewcs without astrometry database update on all input exposures (FLCs? and FLTs)
+    
+    #. Generate initial default products and perform verification
+
+        a) perform cosmic-ray identification and generate drizzle products using astrodrizzle for all sets of inputs
+        b) verify relative alignment with focus index after masking out CRs
+        c) copy all drizzle products to parent directory
+        d) if alignment fails, update trailer file with failure information
+        e) if alignment verified, copy updated input exposures to parent directory
+
+    #. If alignment is verified,
+
+        a) copy inputs to separate sub-directory for processing
+        b) run updatewcs to get a priori updates
+        
+          * apply 'best' apriori (not aposteriori) solution
+
+        c) generate drizzle products for all sets of inputs (FLC and/or FLT) without CR identification
+        d) verify alignment using focus index on FLC or, if no FLC, FLT products
+        e) if alignment fails, update trailer file with info on failure
+        f) if product alignment verified:
+        
+            * copy all drizzle products to parent directory
+            * copy updated input exposures to parent directory
+
+    #. If a posteriori correction enabled,
+
+        a) copy all inputs to separate sub-directory for processing
+        b) run align to align the images
+        c) generate drizzle products for all sets of inputs (FLC and/or FLT) without CR identification
+        d) verify alignment using focus index on FLC or, if no FLC, FLT products
+        e) determine similarity index relative to pipeline default product
+        f) if either focus or similarity indicates a problem, update trailer file with info on failure
+        g) if product alignment verified:
+        
+           * copy all drizzle products to parent directory
+           * copy updated input exposures to parent directory
+
+    #. Remove all processing sub-directories
+
+

--- a/doc/source/runastrodriz.rst
+++ b/doc/source/runastrodriz.rst
@@ -588,10 +588,48 @@ The result of this lengthy process is a set of WCS objects which have been
 updated with a fit to a GAIA catalog representing an ``a posteriori`` solution. 
 
 
+Generate the Aligned Drizzle Products
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Successful alignment of the WCSs to a GAIA catalog means that these ``a posteriori``
+updated exposures can be combined to create a drizzled product using ``AstroDrizzle``.
 
 
+Verify A Posteriori Alignment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+These newly updated drizzle products still need to be evaluated to insure that the
+fit performed to GAIA maintained relative alignment between the images as well. 
+Mis-alignment of the images to each other can result from too few sources being
+used for the fit imprinting the errors in those source positions on the relative
+alignment.  The verification used is the same focus and similarity checks that were 
+performed on the ``a priori`` updated drizzle products and even the pipeline 
+default drizzle products.  
 
+A Posteriori Failure
+^^^^^^^^^^^^^^^^^^^^
+At any number of points throughout this computation and verification, it could 
+end up quitting and flagging this attempt as a failure. If this happens, no 
+updated WCS solutions get created or saved and processing returns to the parent 
+directory while deleting the entire ``<dataset>_aposteriori`` directory along 
+with all the mis-aligned or un-alignable files.  This allows the processing to 
+revert to using the previously verified WCS solutions as the ``best`` WCS solution 
+available for these observations. 
 
+A Posteriori Success
+^^^^^^^^^^^^^^^^^^^^
+Successfully fitting to GAIA can only be declared after the verification process
+returned values indicating good alignment in the drizzle product.  The processing
+would then copy these ``a posteriori``-updated input exposures from the sub-directory
+these computations were being performed in based up to the parent directory to 
+replace the previously updated versions of the input files.  This entire sub-directory
+then gets deleted, unless the processing was being run in debug mode.  
 
-
-
+Creation of Final Aligned Products
+----------------------------------
+The starting directory now contains updated input FLC/FLT files based on WCSs which
+have been verified to have maintained relative alignment and with alignment as close
+to the GAIA astrometric coordinate system as possible.  These exposures get 
+processed by ``AstroDrizzle`` to create the final, combined drizzle products for 
+the user and for archiving at STScI in the Mikulski Archive for Space Telescopes (MAST).
+These products include the calibrated drizzle(DRZ) products as well as any 
+CTE-corrected drizzle(DRC) products depending on what input exposures are
+available.   

--- a/doc/source/runastrodriz.rst
+++ b/doc/source/runastrodriz.rst
@@ -97,9 +97,9 @@ sections providing additional detail on each step.
       d) Check for DRIZCORR calibration switch in input files
       e) Create name for output log files
       f) Define lists of individual input files to be processed
-      
+
     #. Run updatewcs without astrometry database update on all input exposures (FLCs? and FLTs)
-    
+
     #. Generate initial default products and perform verification
 
         a) perform cosmic-ray identification and generate drizzle products using astrodrizzle for all sets of inputs
@@ -137,5 +137,79 @@ sections providing additional detail on each step.
            * copy updated input exposures to parent directory
 
     #. Remove all processing sub-directories
+
+
+Initialization
+--------------
+
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^^
+The pipeline processing code starts out by looking to see whether the user has defined any processing behavior through the use of these environment variables:
+
+  * **'ASTROMETRY_COMPUTE_APOSTERIORI'**: This environment variable specifies whether or not to attempt an *a posteriori* alignment where the code looks for sources in each of the images and uses those positions to perform relative alignment between the images and then fit those images to the GAIA frame.  
+  * **'ASTROMETRY_APPLY_APRIORI'**: This environment variable turns on/off application of any pre-defined(*a priori*) WCS solution found in the astrometry database.  
+  * **'ASTROMETRY_STEP_CONTROL' [DEPRECATED, do not use]**: Old variable replaced by 'ASTROMETRY_APPLY_APRIORI'.   
+
+Values that can be provided for setting these variables are:
+
+  * 'on', 'yes', 'true': Any of these values will turn **on** the processing controlled by the variable
+  * 'off', 'no', 'false': Any of these values will turn **off** the processing controleed by the variable
+
+By default, all the processing steps are turned **on** during pipeline processing in order to maximize the chances of aligning the data as closely as possible to the absolute astrometry standard coordinate system defined through the use of the GAIA catalogs.  However, these controls are provided to support those observations which would not be suitable for such alignment, including observations of single sources.
+
+Input Data
+^^^^^^^^^^^
+The processing code needs to be told what data to process, and for `runastrodriz`, a single input filename is all that **can** be provided.  This single input will be either:
+
+  * the name of an association table for a whole set of input exposures with a filename that looks like **'<rootname>_asn.fits'**, where <rootname> is the designation for the association, such as *'ie6d07030_asn.fits'*.  
+  * the name of a single (uncalibrated) exposure with a filename that looks like **'<rootname>_raw.fits'**.
+
+This one input filename, though, will simply provide the code with the information it needs to find all the calibrated input exposures which need to have their distortion-models updated and applied.  The whole set of input files required for processing includes:
+
+  * ASN (``*_asn.fits``) files: These small FITS tables provide the relationship between the input exposures and the output products with the output filenames defined in the table.  There will NOT be an ASN table for exposures which were taken by themselves (called 'singletons').  
+  * RAW (``*_raw.fits``) files: Not processed directly, but required in order to get the intended value of the `DRIZCORR` calibration switch.  The ASN files also only give the rootname, and with the possibility of multiple suffixes (_flt, _flc,...) for calibrated products, the code starts with the _raw files to insure that what is specified in the ASN table is actually present and has been calibrated before processing.
+  * FLT/FLC (``*_flt.fits`` or ``*_flc.fits``) files: These are the non-CTE-corrected (_flt) and CTE-corrected (_flc) calibrated exposures to be processed.
+  
+The FLT/FLC files will be the ones that actually get processed and updated with the new distortion models and WCSs, while the others allow the code to know what FLT/FLC files should be included in the processing.  This allows for multiple associations of data to live in the same directory and not interfere with each other as they are re-processed.  That can be useful when interested in combining data from multiple visits, for example.  
+
+.. warning::  Should any of these files not be available (found in the local directory), the code will raise an Exception when trying to run 'drizzlepac.astrodrizzle.AstroDrizzle' on the data.  The message will indicate what file was missing with something like: **"Exception: File ie6d07ujq_flt not found."**
+
+Calibration Switches
+^^^^^^^^^^^^^^^^^^^^
+This processing serves as an official calibration step defined for HST data through the use of the **DRIZCORR** header keyword.  This keyword can be found along with all the other calibration switches in the PRIMARY header (extension 0) of the exposures FITS file. A quick way to view this (or any keyword) value would be with:
+
+.. code:: python
+
+    from astropy.io import fits
+    val = fits.getval('ie6d07ujq_flt.fits', 'drizcorr')
+    
+
+This switch must be set to 'PERFORM' in order to allow the processing to be done. Processing will be completely skipped should the value of this switch in the '_raw.fits' file be set to 'OMIT'.
+
+Log Files
+^^^^^^^^^^
+A number of log files, or 'trailer' files, get generated during processing, and their filenames get defined as early as possible in the processing.  The primary file will be a file with a '.tra' extension and should have the same '<rootname>' as the input file used to start the code.  For example, if you were to reprocess 'ie6d07030_asn.fits', you would end up with a trailer file with the name 'ie6d07030.tra'.  
+
+This log file contains the messages generated from performing all the updates to the distortion model, updates from the astrometry database (if any), and all the image combinations performed by 'AstroDrizzle()' to create the final set of calibrated, drizzled exposures.  Should any problems arise when during the processing, the log can provide the error messages and tracebacks to determine what went wrong.
+
+
+Data to be Processed
+^^^^^^^^^^^^^^^^^^^^^
+Once the code has performed all the initialization, it prepares the processing by defining what files need to be combined together from the input files it can find.  This includes looking for CTE-corrected versions of the calibrated exposures (FLC files) as well as all the non-CTE-corrected files (FLT files) and creating a separate list of each type.  Many types of data do not get CTE-corrected by the instruments calibration software, such as calacs.e or calwf3.e, and so no list of FLC files will be made.  This will tell the code that it only needs to process the FLT files by themselves.  If FLC files are found, all updates to the astrometry and WCS will be performed on those files and the results then get copied into the FLT file headers upon completion of the processing.  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 


### PR DESCRIPTION
The documentation in this package needs to be updated to more fully explain the expanded astrometry processing now implemented for pipeline calibration of HST imaging data.  Updates to the documentation are intended to provide end-users with a better understanding of the logic and algorithms used to do what is possible to get their HST data aligned to GAIA as well as possible while retaining the relative alignment between all their exposures.  