### PR TITLE
Fix critical bugs in svm026

### DIFF
--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -210,7 +210,7 @@ class AlignmentTable:
     def perform_fit(self, method_name, catalog_name, reference_catalog, 
                     fitgeom='general'):
         """Perform fit using specified method, then determine fit quality"""
-        # Updated fits_pars with value for fitgeom
+        # Updated fits_pars with value for fitgeom        
         self.fit_pars[method_name]['fitgeom'] = fitgeom
         log.info("Setting 'fitgeom' parameter to {} for {} fit".format(fitgeom, method_name))
         
@@ -608,12 +608,27 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     match = tweakwcs.TPMatch(**fit_pars)
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
     #                          tolerance=100, use2dhist=False)
-
     # Align images and correct WCS
     # NOTE: this invocation does not use an astrometric catalog. This call allows all the input images to be aligned in
     # a relative way using the first input image as the reference.
     # 1: Perform relative alignment
     match_relcat = tweakwcs.align_wcs(imglist, None, match=match, expand_refcat=True, fitgeom=fitgeom)
+
+    log.info("Relative alignment found: ")
+    for i in imglist:
+        info = i.meta['fit_info']
+        if 'shift' not in info:
+            off = (0., 0.)
+            rot = 0.
+            scale = -1.
+        else:
+            off = info['shift']
+            rot = info['<rot>']
+            scale = info['<scale>']
+        msg = "Image {} --".format(i.meta['name'])
+        msg += "\n    SHIFT:({:9.4f},{:9.4f})  ".format(off[0], off[1])
+        msg += " ROT:{:9.4f}  SCALE:{:9.4f}".format(rot, scale)
+        log.info(msg)
 
     # This logic enables performing only relative fitting and skipping fitting to GAIA
     if reference_catalog is not None:

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -520,11 +520,14 @@ def sort_poller_table(obset_table):
         row['flam'] = photflam
 
     # Determine the rank order the data with a primary key of photflam and a secondary key
-    # of exposure time (in seconds).  The primary key is sorted in decending
-    # order, and the secondary key is sorted in ascending order.  Use the rank to sort
+    # of exposure time (in seconds).  The primary and secondary keys both need 
+    # to be sorted in descending order.  Use the rank to sort
     # the original input table for output.
-    rank = np.lexsort((-expanded_obset_table['flam'], expanded_obset_table['exptime']))
-    # rank = np.lexsort((expanded_obset_table['exptime'], -expanded_obset_table['flam']))
+    # Unfortunately, there are cases where the default works better; namely, 
+    # fields with few point sources which are bright that are saturated in the
+    # longer exposure time images (like j8cw03 and j8cw53).  
+    # rank = np.lexsort((-expanded_obset_table['flam'], -expanded_obset_table['exptime']))
+    rank = np.lexsort((expanded_obset_table['exptime'], -expanded_obset_table['flam']))
     updated_obset_table = obset_table[rank]
 
     return updated_obset_table

--- a/drizzlepac/hlautils/poller_utils.py
+++ b/drizzlepac/hlautils/poller_utils.py
@@ -527,7 +527,9 @@ def sort_poller_table(obset_table):
     # fields with few point sources which are bright that are saturated in the
     # longer exposure time images (like j8cw03 and j8cw53).  
     # rank = np.lexsort((-expanded_obset_table['flam'], -expanded_obset_table['exptime']))
-    rank = np.lexsort((expanded_obset_table['exptime'], -expanded_obset_table['flam']))
+    # Original implementation:
+    # rank = np.lexsort((expanded_obset_table['exptime'], -expanded_obset_table['flam']))
+    rank = np.lexsort((-expanded_obset_table['flam'], expanded_obset_table['exptime']))
     updated_obset_table = obset_table[rank]
 
     return updated_obset_table

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -110,8 +110,8 @@ from drizzlepac.hlautils import quality_analysis as qa
 __taskname__ = "runastrodriz"
 
 # Local variables
-__version__ = "2.2.0"
-__version_date__ = "(22-May-2020)"
+__version__ = "2.3.0"
+__version_date__ = "(29-May-2020)"
 
 # Define parameters which need to be set specifically for
 #    pipeline use of astrodrizzle
@@ -1063,9 +1063,9 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
     gsc240 = catalog_date.split('-')
     gdate = datetime.date(int(gsc240[0]), int(gsc240[1]), int(gsc240[2]))
     msg = ''
-    wcsnames = None
-    print(filenames)
+
     for f in filenames:
+        wcsnames = None
         with fits.open(f, mode='update') as fhdu:
             # Check to see whether a RAW/uncalibrated file has been provided
             # If so, skip it since updatewcs has not been run on it yet.
@@ -1119,7 +1119,7 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
                             # Look for apriori_type (HSC, GSC,...)
                             if apriori_type in w:
                                 # restore this WCS
-                                msg += 'Restoring {} as primary WCS'.format(w)
+                                msg += 'Restoring apriori WCS {} as primary WCS in {}\n'.format(w, f)
                                 headerlet.restore_from_headerlet(fhdu,
                                                                  force=True,
                                                                  hdrname=h,


### PR DESCRIPTION
The astrometry pipeline processing in svm0.2.6 was found to have bugs which prevented it from successfully completing.  Specifically, the selection of the correct apriori WCS from the astrometry database did not reset for each file, so it tried to update the second (and subsequent files) with a headerlet that had the name defined in the first image.  In addition, the sorting implemented in poller_utils was updated to document how the sorting needs to take into account saturation in the images, something that will need to be implemented in a later revision. 

This fix resolves that problem and allows the data to process correctly.