### PR TITLE
Implement cross-correlation as default fitting option for SVM processing

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -421,6 +421,8 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                             table_fit = alignment_table.fit_dict[(catalog_name, algorithm_name)]
                             table_fit[imglist_ctr].meta['fit method'] = algorithm_name
                             table_fit[imglist_ctr].meta['fit quality'] = fit_quality
+                        log.debug("FIT determined was: {}".format(
+                                    alignment_table.fit_dict[(catalog_name, algorithm_name)][0].meta))
 
                         # populate fit_info_dict
                         fit_info_dict["{} {}".format(catalog_name, algorithm_name)] = \
@@ -475,7 +477,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
             if fit_quality == 1 or (best_fit_qual in [2, 3, 4] and
                 "relative" in algorithm_name):
                 break
-        log.info("best_fit found to be: {}".format(best_fit_label))
+        log.info("\nBEST FIT found to be: \n    {}\n".format(best_fit_label))
         log.info("FIT_DICT: {}".format(alignment_table.fit_dict.keys()))
         # Reset imglist to point to best solution...
         alignment_table.select_fit(best_fit_label[0], best_fit_label[1])
@@ -562,8 +564,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                 result.add_column(filtered_table[col], name=col)
         if filtered_table is not None:
             filtered_table.pprint(max_width=-1)
-    return filtered_table
-
+    return filtered_table, alignment_table
 
 
 # ----------------------------------------------------------------------------------------------------------

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -553,13 +553,13 @@ def run_align_to_gaia(tot_obj, log_level=logutil.logging.INFO, diagnostic_mode=F
     log.info("\n{}: Finished aligning gaia_obj to GAIA".format(str(datetime.datetime.now())))
     log.info("ALIGNED WCS: \n{}".format(tot_obj.meta_wcs))
 
-        # Return the name of the alignment catalog
-        return gaia_obj.refname
+    # Return the name of the alignment catalog
+    return gaia_obj.refname
 
-        #
-        # Composite WCS fitting should be done at this point so that all exposures have been fit to GAIA at
-        # the same time (on the same frame)
-        #
+    #
+    # Composite WCS fitting should be done at this point so that all exposures have been fit to GAIA at
+    # the same time (on the same frame)
+    #
 
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -553,14 +553,86 @@ def run_align_to_gaia(tot_obj, log_level=logutil.logging.INFO, diagnostic_mode=F
     log.info("\n{}: Finished aligning gaia_obj to GAIA".format(str(datetime.datetime.now())))
     log.info("ALIGNED WCS: \n{}".format(tot_obj.meta_wcs))
 
-    # Return the name of the alignment catalog
-    if align_table is None:
-        gaia_obj.refname = None
-    else:
-        # Get names of all headerlet files written out to file
-        headerlet_filenames = [f for f in align_table.filtered_table['headerletFile'] if f != "None"]
-        
-    return [gaia_obj.refname]+headerlet_filenames
+        # Return the name of the alignment catalog
+        return gaia_obj.refname
+
+        #
+        # Composite WCS fitting should be done at this point so that all exposures have been fit to GAIA at
+        # the same time (on the same frame)
+        #
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+def run_sourcelist_comparision(total_list, diagnostic_mode = False, log_level=logutil.logging.INFO):
+    """ This subroutine automates execution of drizzlepac/devutils/comparison_tools/compare_sourcelist_flagging.py to
+    compare HAP-generated filter catalogs with their HLA classic counterparts.
+
+    NOTE: In order for this subroutine to run, the following environment variables need to be set:
+    - HLA_CLASSIC_BASEPATH
+    - HLA_BUILD_VER
+
+    Alternatively, if the HLA classic path is unavailable, The comparison can be run using
+    locally stored HLA classic files. The relevant HLA classic imagery and sourcelist files
+    must be placed in a subdirectory of the current working directory called 'hla_classic'.
+
+    Parameters
+    ----------
+    total_obj_list: list
+        List of TotalProduct objects, one object per instrument/detector combination is
+        a visit.  The TotalProduct objects are comprised of FilterProduct and ExposureProduct
+        objects.
+
+    diagnostic_mode : Boolean, optional.
+        create intermediate diagnostic files? Default value is False.
+
+    log_level : int, optional
+        The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+        Default value is 20, or 'info'.
+
+    RETURNS
+    -------
+    Nothing.
+    """
+    # get HLA classic path details from envroment variables
+    hla_classic_basepath = os.getenv('HLA_CLASSIC_BASEPATH')
+    hla_build_ver = os.getenv("HLA_BUILD_VER")
+    for tot_obj in total_list:
+        combo_comp_pdf_list = []
+        if hla_classic_basepath and hla_build_ver and os.path.exists(hla_classic_basepath):
+            hla_cassic_basepath = os.path.join(hla_classic_basepath, tot_obj.instrument, hla_build_ver)
+            hla_classic_path = os.path.join(hla_cassic_basepath, tot_obj.prop_id, tot_obj.prop_id + "_" + tot_obj.obset_id)  # Generate path to HLA classic products
+        elif os.path.exists(os.path.join(os.getcwd(), "hla_classic")):  # For local testing
+            hla_classic_basepath = os.path.join(os.getcwd(), "hla_classic")
+            hla_classic_path = hla_classic_basepath
+        else:
+            return  # bail out if HLA classic path can't be found.
+        for filt_obj in tot_obj.fdp_list:
+            hap_imgname = filt_obj.drizzle_filename
+            hla_imgname = glob.glob("{}/{}{}_dr*.fits".format(hla_classic_path, filt_obj.basename, filt_obj.filters))[0]
+            if not os.path.exists(hap_imgname) or not os.path.exists(hla_imgname):  # Skip filter if one or both of the images can't be found
+                continue
+            for hap_sourcelist_name in [filt_obj.point_cat_filename, filt_obj.segment_cat_filename]:
+                if hap_sourcelist_name.endswith("point-cat.ecsv"):
+                    hla_classic_cat_type = "dao"
+                    plotfile_prefix = filt_obj.product_basename + "_point"
+                else:
+                    hla_classic_cat_type = "sex"
+                    plotfile_prefix = filt_obj.product_basename + "_segment"
+                if hla_classic_basepath and hla_build_ver and os.path.exists(hla_classic_basepath):
+                    hla_sourcelist_name = "{}/logs/{}{}_{}phot.txt".format(hla_classic_path, filt_obj.basename,
+                                                                           filt_obj.filters, hla_classic_cat_type)
+                else:
+                    hla_sourcelist_name = "{}/{}{}_{}phot.txt".format(hla_classic_path, filt_obj.basename,
+                                                                      filt_obj.filters, hla_classic_cat_type)
+                if not os.path.exists(hap_sourcelist_name) or not os.path.exists(hla_sourcelist_name):  # Skip catalog type if one or both of the catalogs can't be found
+                    continue
+
+                # convert HLA Classic RA and Dec values to HAP reference frame so the RA and Dec comparisons are correct
+                updated_hla_sourcelist_name = correct_hla_classic_ra_dec(hla_sourcelist_name, hla_classic_cat_type, log_level)
+                log.info("HAP image:                   {}".format(os.path.basename(hap_imgname)))
+                log.info("HLA Classic image:           {}".format(os.path.basename(hla_imgname)))
+                log.info("HAP catalog:                 {}".format(os.path.basename(hap_sourcelist_name)))
+                log.info("HLA Classic catalog:         {}".format(os.path.basename(updated_hla_sourcelist_name)))
 
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/drizzlepac/hlautils/align_utils.py
+++ b/drizzlepac/hlautils/align_utils.py
@@ -3,7 +3,7 @@ import datetime
 import copy
 import sys
 import traceback
-import warnings
+import pickle
 
 from collections import OrderedDict
 
@@ -602,6 +602,9 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     # and use those shifts to get the images roughly aligned prior to fitting with
     # tweakwcs.  This should allow MUCH tighter parameters to be used which would
     # be less susceptible to source confusion (bad matches/fits) and errors.
+    with open('imglist.pickle', mode='w') as imgpickle:
+        pickle.dump(imglist, imgpickle)
+
     amutils.determine_initial_shifts(imglist)
 #    fit_pars['searchrad'] = fit_pars['searchrad'] if fit_pars['searchrad'] < 25.0 else 25.0
 #    fit_pars['separation'] = fit_pars['separation'] if fit_pars['separation'] > 2.0 else 2.0
@@ -1043,17 +1046,17 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
         # Update headerlet
         update_headerlet_phdu(item, out_headerlet)
 
-        # Write headerlet
-        if headerlet_filenames:
-            headerlet_filename = headerlet_filenames[image_name]  # Use HAP-compatible filename defined in runhlaprocessing.py
-        else:
-            if image_name.endswith("flc.fits"):
-                headerlet_filename = image_name.replace("flc", "flt_hlet")
-            if image_name.endswith("flt.fits"):
-                headerlet_filename = image_name.replace("flt", "flt_hlet")
-        out_headerlet.writeto(headerlet_filename, overwrite=True)
-        log.info("Wrote headerlet file {}.\n\n".format(headerlet_filename))
-        out_headerlet_dict[image_name] = headerlet_filename
+            # Write headerlet
+            if headerlet_filenames:
+                headerlet_filename = headerlet_filenames[image_name]  # Use HAP-compatible filename defined in runhlaprocessing.py
+            else:
+                if image_name.endswith("flc.fits"):
+                    headerlet_filename = image_name.replace("flc", "flt_hlet")
+                if image_name.endswith("flt.fits"):
+                    headerlet_filename = image_name.replace("flt", "flt_hlet")
+            out_headerlet.writeto(headerlet_filename, overwrite=True)
+            log.info("Wrote headerlet file {}.\n\n".format(headerlet_filename))
+            out_headerlet_dict[image_name] = headerlet_filename
 
         # Attach headerlet as HDRLET extension
         if headerlet.verify_hdrname_is_unique(hdulist, hdr_name):

--- a/drizzlepac/hlautils/astrometric_utils.py
+++ b/drizzlepac/hlautils/astrometric_utils.py
@@ -14,7 +14,6 @@ reference catalog. ::
 
 """
 import os
-import pdb
 from io import BytesIO
 import csv
 import requests

--- a/drizzlepac/hlautils/product.py
+++ b/drizzlepac/hlautils/product.py
@@ -236,7 +236,8 @@ class FilterProduct(HAPProduct):
         alignment_pars = self.configobj_pars.get_pars('alignment')
 
         # Only perform the relative alignment
-        method_name = 'relative'
+        # method_name = 'relative'
+        method_name = 'xcorr'
 
         exposure_filenames = []
         headerlet_filenames = {}

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -38,7 +38,7 @@
       {
         "searchrad": 75,
         "separation": 4.0,
-        "tolerance": 2.0,
+        "tolerance": 1.0,
         "use2dhist": true
       },
     "match_default_fit":

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -528,6 +528,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 find_crs = not align_dicts[0]['alignment_verified']
             else:
                 find_crs = False
+            trlmsg += "Setting find_crs to {} for a posteriori alignment".format(find_crs)
             tmpname = "_".join([_trlroot, 'aposteriori'])
             sub_dirs.append(tmpname)
             align_aposteriori = verify_alignment(_inlist,

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -511,6 +511,7 @@ def interpret_wcsname_type(wcsname):
     wcstype = ''
     fit_terms = {'REL': 'relatively aligned to {}',
                  'IMG': 'aligned image-by-image to {}',
+                 'XCR': 'relatively aligned to {}',
                  'EVM': 'aligned by visit-exposures to {}',
                  'SVM': 'aligned by visit to {}'}
     post_fit = 'a posteriori solution '


### PR DESCRIPTION
Many observations are difficult to align due any number of factors, including lack of point sources or crowding or too many saturated sources or all of the above.  Registration based on cross-correlation can be used when there are problems with point-source based alignment.  

The changes here implement a new fitting function based on scikit-image's feature module to use cross-correlation to determine the relative alignment to within a 1pixel.  This initial correction then gets passed to 'tweakwcs' for final alignment with suitable input parameters (searchrad=1.0).  This new function has also been made the default fitting routine for single-visit mosaic (SVM) processing. 

Classification of sources in the alignment catalog also uses scikit-image's hough line transforms to look for linear sources and flags them as non-PSFs so they will be ignored when being selected for use in alignment.  

This algorithm still needs to be extensively tested, but does work well on ib3m53. 
