### PR TITLE
Insure rscale as primary/default fit mode for all alignment

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -208,7 +208,7 @@ class AlignmentTable:
         return list(self.fit_methods.keys())
 
     def perform_fit(self, method_name, catalog_name, reference_catalog, 
-                    fitgeom='general'):
+                    fitgeom='rscale'):
         """Perform fit using specified method, then determine fit quality"""
         # Updated fits_pars with value for fitgeom        
         self.fit_pars[method_name]['fitgeom'] = fitgeom
@@ -602,7 +602,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
         fitgeom=fit_pars['fitgeom']
         del fit_pars['fitgeom']
     else:
-        fitgeom='general'
+        fitgeom='rscale'
 
     # 0: Specify matching algorithm to use
     match = tweakwcs.TPMatch(**fit_pars)
@@ -680,7 +680,7 @@ def match_default_fit(imglist, reference_catalog, **fit_pars):
         fitgeom=fit_pars['fitgeom']
         del fit_pars['fitgeom']
     else:
-        fitgeom='general'
+        fitgeom='rscale'
 
     log.info("{} (match_default_fit) Cross matching and fitting "
              "{}".format("-" * 20, "-" * 27))
@@ -723,7 +723,7 @@ def match_2dhist_fit(imglist, reference_catalog, **fit_pars):
         fitgeom=fit_pars['fitgeom']
         del fit_pars['fitgeom']
     else:
-        fitgeom='general'
+        fitgeom='rscale'
 
 
     log.info("{} (match_2dhist_fit) Cross matching and fitting "


### PR DESCRIPTION
This insures that all places where the default value for the fitting mode is defined as 'rscale' and not 'general'.  The standard pipeline processing relies almost exclusively on these default values insuring that (as requested by INS and the HSTMO) there can be no chance that pipeline processing will use 'general' fitting mode for aligning data either in a relative sense (exposure to exposure) or in an absolute sense (to GAIA).