### PR TITLE
Comment out Windows builds for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,10 @@ jobs:
     name: MacOS
     os: macos
 
-- template: azure-templates.yml
-  parameters:
-    name: Windows
-    os: windows
+#- template: azure-templates.yml
+#  parameters:
+#    name: Windows
+#    os: windows
 
 - job: 'PEP8'
   pool:


### PR DESCRIPTION
The Windows builds are not properly supported yet.  Therefore, they should be commented out and re-instated once we start supporting that platform again.