### PR TITLE
Update all alignment parameter files to force use of rscale only

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -208,8 +208,12 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
         Table which contains processing information and alignment results for every raw image evaluated
 
     """
-    log.info("*** HLAPIPELINE Processing Version {!s} ({!s}) started at: {!s} ***\n".format(__version__, __version_date__, util._ptime()[0]))
-
+    log.info("*** HAP PIPELINE Processing Version {!s} ({!s}) started at: {!s} ***\n".format(__version__, __version_date__, util._ptime()[0]))
+    if runfile is not None:
+        fh = logutil.logging.FileHandler(runfile)
+        fh.setLevel(logutil.logging.DEBUG)
+        log.addHandler(fh)
+        
     # 0: print git info
     if print_git_info:
         log.info("{} STEP 0: Display Git revision info  {}".format("-" * 20, "-" * 49))

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -36,6 +36,7 @@
     },
   "match_relative_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 100,
       "separation": 4.0,
       "tolerance": 2.0,
@@ -43,6 +44,7 @@
     },
   "match_default_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 250,
       "separation": 0.1,
       "tolerance": 100,
@@ -50,6 +52,7 @@
     },
   "match_2dhist_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 75,
       "separation": 0.1,
       "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -36,6 +36,7 @@
     },
   "match_relative_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 75,
       "separation": 4.0,
       "tolerance": 2.0,
@@ -43,6 +44,7 @@
     },
   "match_default_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 250,
       "separation": 0.1,
       "tolerance": 100,
@@ -50,6 +52,7 @@
     },
   "match_2dhist_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 75,
       "separation": 0.1,
       "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -36,6 +36,7 @@
       },
     "match_relative_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 100,
         "separation": 4.0,
         "tolerance": 2.0,
@@ -43,6 +44,7 @@
       },
     "match_default_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
         "tolerance": 100,
@@ -50,6 +52,7 @@
       },
     "match_2dhist_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 0.1,
         "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -36,6 +36,7 @@
       },
     "match_relative_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 4.0,
         "tolerance": 2.0,
@@ -43,6 +44,7 @@
       },
     "match_default_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
         "tolerance": 100,
@@ -50,6 +52,7 @@
       },
     "match_2dhist_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 0.1,
         "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -36,6 +36,7 @@
       },
     "match_relative_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 4.0,
         "tolerance": 2.0,
@@ -43,6 +44,7 @@
       },
     "match_default_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
         "tolerance": 100,
@@ -50,6 +52,7 @@
       },
     "match_2dhist_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 0.1,
         "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -36,6 +36,7 @@
     },
   "match_relative_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 100,
       "separation": 4.0,
       "tolerance": 2.0,
@@ -43,6 +44,7 @@
     },
   "match_default_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 250,
       "separation": 0.1,
       "tolerance": 100,
@@ -50,6 +52,7 @@
     },
   "match_2dhist_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 75,
       "separation": 0.1,
       "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -36,6 +36,7 @@
     },
   "match_relative_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 75,
       "separation": 4.0,
       "tolerance": 2.0,
@@ -43,6 +44,7 @@
     },
   "match_default_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 250,
       "separation": 0.1,
       "tolerance": 100,
@@ -50,6 +52,7 @@
     },
   "match_2dhist_fit":
     {
+      "fitgeom": "rscale",
       "searchrad": 75,
       "separation": 0.1,
       "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -36,6 +36,7 @@
       },
     "match_relative_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 100,
         "separation": 4.0,
         "tolerance": 2.0,
@@ -43,6 +44,7 @@
       },
     "match_default_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
         "tolerance": 100,
@@ -50,6 +52,7 @@
       },
     "match_2dhist_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 0.1,
         "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -36,6 +36,7 @@
       },
     "match_relative_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 4.0,
         "tolerance": 2.0,
@@ -43,6 +44,7 @@
       },
     "match_default_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
         "tolerance": 100,
@@ -50,6 +52,7 @@
       },
     "match_2dhist_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 0.1,
         "tolerance": 2,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -36,6 +36,7 @@
       },
     "match_relative_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 4.0,
         "tolerance": 2.0,
@@ -43,6 +44,7 @@
       },
     "match_default_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
         "tolerance": 100,
@@ -50,6 +52,7 @@
       },
     "match_2dhist_fit":
       {
+        "fitgeom": "rscale",
         "searchrad": 75,
         "separation": 0.1,
         "tolerance": 2,

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -901,10 +901,10 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                 _trlmsg += "   No correction to absolute astrometric frame applied!\n"
                 print(_trlmsg)
                 _updateTrlFile(trlfile, _trlmsg)
-                if 'aposteriori' not in err:
+                if 'aposteriori' not in repr(err):
                     traceback.print_exc()
                 else:
-                    print("WARNING: {}".format(err.args[0]))
+                    print("WARNING: {}".format(err))
                 return None
 
             _updateTrlFile(trlfile, trlmsg)

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -901,7 +901,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                 _trlmsg += "   No correction to absolute astrometric frame applied!\n"
                 print(_trlmsg)
                 _updateTrlFile(trlfile, _trlmsg)
-                if 'aposteriori' not in err.args[0]:
+                if 'aposteriori' not in err:
                     traceback.print_exc()
                 else:
                     print("WARNING: {}".format(err.args[0]))


### PR DESCRIPTION
Yet another way in which we can insure that only 'fitgeom=rscale' gets used.