### PR TITLE
Add HAPLEVEL to ExposureProduct file headers

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -434,6 +434,9 @@ class ExposureProduct(HAPProduct):
 
         log.info("Copying {} to SVM input: \n    {}".format(filename, edp_filename))
         shutil.copy(filename, edp_filename)
+        
+        # Add HAPLEVEL keyword as required by pipeline processing
+        fits.setval(edp_filename, 'HAPLEVEL', value=0, comment='Classificaion level of this product')
 
         return edp_filename
         


### PR DESCRIPTION
Pipeline processing of HAP products requires the use of the HAPLEVEL keyword in order for the system to categorize all the products correctly and successfully archive the results.  This small fix adds this keyword to the HAP input files. 