### PR TITLE
Expand search for JSON files in harvester

### DIFF
--- a/drizzlepac/haputils/diagnostic_json_harvester.py
+++ b/drizzlepac/haputils/diagnostic_json_harvester.py
@@ -82,6 +82,11 @@ def get_json_files(search_path=os.getcwd(), log_level=logutil.logging.INFO):
     for search_pattern in search_patterns:
         search_string = os.path.join(search_path, search_pattern)
         search_results = glob.glob(search_string)
+        if len(search_results) == 0:
+            # Try another directory lower
+            search_string = os.path.join(search_path, '*', search_pattern)
+            search_results = glob.glob(search_string)
+            
         log.info("{} files found: {}".format(search_pattern, len(search_results)))
         if len(search_results) > 0:
             json_list += glob.glob(search_string)

--- a/drizzlepac/haputils/diagnostic_json_harvester.py
+++ b/drizzlepac/haputils/diagnostic_json_harvester.py
@@ -58,11 +58,20 @@ def flatten_dict(dd, separator='.', prefix=''):
 
 def get_json_files(search_path=os.getcwd(), log_level=logutil.logging.INFO):
     """use glob to create a list of json files to harvest
+    
+    This function looks for all the json files containing qa test results generated
+    by `runastrodriz` and `runsinglehap`.  The search starts in the directory 
+    specified in the `search_path` parameter, but will look in immediate
+    sub-directories as well if no json files are located in the directory 
+    specified by `search_path`.
 
     Parameters
     ----------
     search_path : str, optional
         directory path to search for .json files. Default value is the current working directory.
+        This serves as the starting directory for finding the .json files, with the
+        search expanding to immediate sub-directories if no .json files are found
+        in this directory.
 
     log_level : int, optional
         The desired level of verboseness in the log statements displayed on the screen and written to the

--- a/drizzlepac/haputils/diagnostic_json_harvester.py
+++ b/drizzlepac/haputils/diagnostic_json_harvester.py
@@ -89,7 +89,7 @@ def get_json_files(search_path=os.getcwd(), log_level=logutil.logging.INFO):
             
         log.info("{} files found: {}".format(search_pattern, len(search_results)))
         if len(search_results) > 0:
-            json_list += glob.glob(search_string)
+            json_list += search_results
 
     # store json filenames in a dictionary keyed by Pandas DataFrame index value
     if json_list:


### PR DESCRIPTION
The current version of the JSON harvester will only search for JSON files in the currently specified directory.  This works perfectly well when all the data is in a single directory, perhaps as will be the case for pipeline processing.  Unfortunately, testing on large numbers of datasets, each in their own directory, makes this code impossible to collate all the JSON files since it would need to be called separately for each dataset/directory.  

This small revision simply adds logic to look in the underlying directories for the desired JSON files.  The result is that a single call pointing to the parent directory for all the datasets directories can now find all the desired JSON files in one step resulting in a collated Pandas DataFrame file with all the results.  