### PR TITLE
Add taskname to quality_analysis

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -623,12 +623,14 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
             off = (0., 0.)
             rot = 0.
             scale = -1.
+            nmatches = 0
         else:
             off = info['shift']
             rot = info['<rot>']
             scale = info['<scale>']
+            nmatches = info['nmatches']
         msg = "Image {} --".format(i.meta['name'])
-        msg += "\n    SHIFT:({:9.4f},{:9.4f})  ".format(off[0], off[1])
+        msg += "\n    SHIFT:({:9.4f},{:9.4f})  NMATCHES: {} ".format(off[0], off[1], nmatches)
         msg += " ROT:{:9.4f}  SCALE:{:9.4f}".format(rot, scale)
         log.info(msg)
 
@@ -641,7 +643,9 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
         for image in imglist:
             image.meta["group_id"] = 1234567
         # 2: Perform absolute alignment
+
         matched_cat = tweakwcs.align_wcs(imglist, reference_catalog, match=match, fitgeom=fitgeom)
+        import pickle; pickle.dump(imglist, open('final_match_to_gaia.pickle', 'wb'))
     else:
         # Insure the expanded reference catalog has all the information needed
         # to complete processing.

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -73,6 +73,8 @@ MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
+                            
+__taskname__ = 'quality_analysis'
 
 def determine_alignment_residuals(input, files, max_srcs=2000, 
                                   json_timestamp=None,


### PR DESCRIPTION
This simple change resolves the problem in `quality_analysis` when it tries to report the name of the module and did not have that information defined yet as `__taskname__`. 

Additional information on the number of matches used in the relative fit now also gets reported to aid in debugging and quality analysis of each dataset as it gets processed. 