### PR TITLE
Add CPDIS and DP to the list of distortion keywords

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,18 +18,23 @@ of the list).
 ==================
 
 In addition to a few dozen bug fixes, the following updates to the algorithms
-were also implemented.  
+were also implemented.
 
-- Added ``rules_file`` parameter to AstroDrizzle to enable use of custom 
+- Added polynomial look-up table distortion keywords to the list of distortion
+  keywords used by ``outputimage.deleteDistortionKeywords`` so that
+  distortions can be removed from ACS images that use ``NPOLFILE``.
+  This now allows removal of alternate WCS from blotted image headers. [#709]
+
+- Added ``rules_file`` parameter to AstroDrizzle to enable use of custom
   files in pipeline processing. [#674]
 
 - Only apply solutions from the astrometry database which were non-aposteriori
   WCS solutions as the PRIMARY WCS.  This allows the pipeline to compare the
-  true apriori WCS solutions (e.g., GSC or HSC WCSs) to aposteriori solutions 
-  computed using the latest distortion-models and alignment algorithms being 
+  true apriori WCS solutions (e.g., GSC or HSC WCSs) to aposteriori solutions
+  computed using the latest distortion-models and alignment algorithms being
   used at the time of processing. [#669]
 
-- Verification using a similarity index gets reported in the trailer file and 
+- Verification using a similarity index gets reported in the trailer file and
   does not get used as a Pass/Fail criteria for alignment.  [#619]
 
 - If verification fails for either pipeline-default or apriori solution, reset
@@ -44,7 +49,7 @@ were also implemented.
 - Fix a bug in ``tweakreg`` due to which the number of matched sources needed to be
   *strictly* greater than ``minobj``. Now the minimum number of matched sources
   maust be *at least* equal or greater than ``minobj``. [#604]
-  
+
 - Fix a crash in ``tweakreg`` when ``2dhist`` is enabled and ``numpy``
   version is ``1.18.1`` and later. [#583, #587]
 
@@ -67,10 +72,10 @@ were also implemented.
 - Updated to be compatible with tweakwcs v0.6.0 to correct chip-to-chip alignment issues
   in aposteriori WCS solutions. [#596]
 
-- Correctly define output drizzle product filename during pipeline processing 
+- Correctly define output drizzle product filename during pipeline processing
   for exposures with 'drz' in the rootname. [#523]
 
-- Implement multiple levels of verification for the drizzle products generated 
+- Implement multiple levels of verification for the drizzle products generated
   during pipeline processing (using runastrodriz); including overlapp difference
   computations [#520], and magnitude correlation [#512].
 
@@ -78,11 +83,11 @@ were also implemented.
 
 - Fix problem with NaNs when looking for sources to use for aligning images [#512]
 
-- Fixed code that selected the brightest sources to use for alignment allowing 
+- Fixed code that selected the brightest sources to use for alignment allowing
   alignment to work (more often) for images with saturated sources. [#512]
 
 - Use logic for defining the PSF extracted from the images to shrink it in each
-  axis by one-half for images of crowded fields to allow for more sources to be 
+  axis by one-half for images of crowded fields to allow for more sources to be
   extracted by daofind-like algorithm. This enables source finding and alignment
   to work more reliably on crowded field images. [#512]
 

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -693,7 +693,7 @@ def getTemplates(fnames, blend=True, rules_file=None):
         newtab = None
     else:
         # apply rules to create final version of headers, plus table
-        # TODO:  NEED to add pointer to dataset-specific rules file as 
+        # TODO:  NEED to add pointer to dataset-specific rules file as
         #        'rules_file' parameter.
         newhdrs, newtab = blendheaders.get_blended_headers(inputs=fnames,
                                                             rules_file=rules_file)
@@ -737,19 +737,19 @@ def addWCSKeywords(wcs,hdr,blot=False,single=False,after=None):
     if not blot:
         blendheaders.remove_distortion_keywords(hdr)
 
+
 def deleteDistortionKeywords(hdr):
     """ Delete distortion related keywords from output drizzle science header
         since the drizzled image should have no remaining distortion.
     """
-    dist_kws = ['D2IMERR1','D2IMERR2','D2IMDIS1','D2IMDIS2','D2IM1.*','D2IM2.*','D2IMEXT']
+    dist_kws = ['D2IMERR1','D2IMERR2','D2IMDIS1','D2IMDIS2','D2IM1.*','D2IM2.*',
+                'D2IMEXT', 'DP1', 'DP2', 'CPDIS?', 'CPERR?']
     for kw in dist_kws:
-        try:
+        if kw in hdr:
             del hdr[kw]
-        except KeyError as e:
-            pass
 
 
-def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True, 
+def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
                     rules_file=None):
     """ Write out a simple FITS file given a numpy array and the name of another
     FITS file to use as a template for the output image header.
@@ -779,7 +779,7 @@ def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
         # Get default headers from multi-extension FITS file
         # If input data is not in MEF FITS format, it will return 'None'
         # NOTE: These are HEADER objects, not HDUs
-        (prihdr,scihdr,errhdr,dqhdr),newtab = getTemplates(template,EXTLIST, 
+        (prihdr,scihdr,errhdr,dqhdr),newtab = getTemplates(template,EXTLIST,
                                                            rules_file=rules_file)
 
         if scihdr is None:


### PR DESCRIPTION
Recent changes to `stwcs`, see, e.g, https://github.com/spacetelescope/stwcs/pull/141 introduced warnings in drizzlepac, in particular during the `blot` step. These warnings are similar to:
```
-Generating simple FITS output: j8c107d5q_sci1_blt.fits
WARNING: wcs_from_key: Could not read WCS with key A [stwcs.wcsutil.altwcs]
WARNING:               Skipping in-memory file '[<astropy.io.fits.hdu.image.PrimaryHDU object at 0x134ec9650>][0]' [stwcs.wcsutil.altwcs]
WARNING: wcs_from_key: Could not read WCS with key B [stwcs.wcsutil.altwcs]
WARNING:               Skipping in-memory file '[<astropy.io.fits.hdu.image.PrimaryHDU object at 0x134ec9650>][0]' [stwcs.wcsutil.altwcs]
```
As a result, alternate WCSes in blotted are not removed.

I tracked these warnings to the following two factors:

1. The `wcs_from_key` (new alternative to `readAltWCS`) does not have `verbose` parameter and _always_ reports the warnings seen above. The old `readAltWCS` was failing quietly. For this reason, pre-https://github.com/spacetelescope/stwcs/pull/141, `drizzlepac` was not producing these warnings.

2. The actual reason reading alternate WCS in blotted images fails is because `astropy.wcs.WCS()` detects `CPDIS*` and `DP*` distortion keywords and hence it was looking for `WCSDVARR` extension which was missing. These distortion keywords were not "cleaned" from image headers by `drizzlepac.outputimage. deleteDistortionKeywords()`

This PR updates the list of distortion keywords used in `drizzlepac.outputimage. deleteDistortionKeywords()` and solves the issue of not deleted alternate WCS left in blotted image headers and observed warnings.

CC: @stsci-hack 