### PR TITLE
Update adrizzle teal interface

### DIFF
--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -121,7 +121,7 @@ def run(configObj,wcsmap=None):
         blot_wcs = wcs_functions.build_hstwcs(
             user_wcs_pars['raref'], user_wcs_pars['decref'],
             user_wcs_pars['xrefpix'], user_wcs_pars['yrefpix'],
-            user_wcs_pars['outnx'], user_wcs_pars['outny'],
+            int(user_wcs_pars['outnx']), int(user_wcs_pars['outny']),
             user_wcs_pars['outscale'], user_wcs_pars['orient'] )
         configObj['coeffs'] = None
 

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -141,7 +141,7 @@ def run(configObj, wcsmap=None):
                 output_wcs = wcs_functions.build_hstwcs(
                     user_wcs_pars['raref'], user_wcs_pars['decref'],
                     user_wcs_pars['xrefpix'], user_wcs_pars['yrefpix'],
-                    user_wcs_pars['outnx'], user_wcs_pars['outny'],
+                    int(user_wcs_pars['outnx']), int(user_wcs_pars['outny']),
                     user_wcs_pars['outscale'], user_wcs_pars['orient'] )
             else:
                 # Define default WCS based on input image


### PR DESCRIPTION
The undocumented TEAL interface for just the 'adrizzle' and 'ablot' stand-alone tasks did not enforce integer values for the user-defined custom output WCS generation.  These small changes simply insure that user-provided sizes are always cast as integers before being used to define the custom output WCS. 

This problem came to light as the result of a user help question.  