### PR TITLE
Simplify logic for archiving WCS in tweakreg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ of the list).
 In addition to a few dozen bug fixes, the following updates to the algorithms
 were also implemented.
 
+- Simplified the logic in ``tweakreg`` for deciding how to archive primary WCS
+  resulting in a reduction of duplicate WCSes in image headers. [#715]
+
 - Added polynomial look-up table distortion keywords to the list of distortion
   keywords used by ``outputimage.deleteDistortionKeywords`` so that
   distortions can be removed from ACS images that use ``NPOLFILE``.

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -20,8 +20,8 @@ from stwcs.wcsutil import headerlet
 __taskname__ = 'buildwcs'
 
 # This is specifically NOT intended to match the package-wide version information.
-__version__ = '0.1.0'
-__version_date__ = '22-June-2011'
+__version__ = '0.1.1'
+__version_date__ = '13-July-2020'
 
 # These default parameter values have the same keys as the parameters from
 # the configObj interface
@@ -371,8 +371,7 @@ def generate_headerlet(outwcs,template,wcsname,outname=None):
         extname = ('sipwcs',extnum[1])
         hdrlet = headerlet.createHeaderlet(fname,wcsname)
         # update hdrlet with header values from outwcs
-        for kw in outwcs_hdr.items():
-            hdrlet[extname].header[kw[0]] = kw[1]
+        hdrlet[extname].header.update(outwcs_hdr)
         hdrlet[extname].header['WCSNAME'] = wcsname
     else:
         print('Creating headerlet from scratch...')

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -804,9 +804,7 @@ def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
     if outextver == 0: outextver = 1
     scihdr['EXTNAME'] = outextname.upper()
     scihdr['EXTVER'] = outextver
-
-    for card in wcshdr.cards:
-        scihdr[card.keyword] = (card.value, card.comment)
+    scihdr.update(wcshdr)
 
     # Create PyFITS HDUList for all extensions
     outhdu = fits.HDUList()

--- a/drizzlepac/tweakback.py
+++ b/drizzlepac/tweakback.py
@@ -31,8 +31,8 @@ from . import util
 __taskname__ = 'tweakback' # unless someone comes up with anything better
 
 # This is specifically NOT intended to match the package-wide version information.
-__version__ = '0.4.0'
-__version_date__ = '14-Oct-2014'
+__version__ = '0.4.1'
+__version_date__ = '13-July-2020'
 
 
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
@@ -218,10 +218,6 @@ def tweakback(drzfile, input=None,  origwcs = None,
         extlist = get_ext_list(imhdulist, extname='SCI')
         if not extlist:
             extlist = [0]
-
-        # insure that input PRIMARY WCS has been archived before overwriting
-        # with new solution
-        wcsutil.altwcs.archiveWCS(imhdulist, extlist, reusekey=True)
 
         # Process MEF images...
         for ext in extlist:

--- a/drizzlepac/tweakreg.help
+++ b/drizzlepac/tweakreg.help
@@ -188,10 +188,10 @@ updatehdr : bool (Default = No)
     the shiftfile as well.
 
 wcsname : str (Default = 'TWEAK')
-    Name of updated WCS.
+    Name of updated primary WCS.
 
 reusename : bool (Default = False)
-    Allows overwriting of an existing WCS with the same name as
+    Allows overwriting of an existing primary WCS with the same name as
     specified by ``wcsname`` parameter.
 
 *HEADERLET CREATION*

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -160,15 +160,18 @@ def run(configobj):
     if configobj['UPDATE HEADER']['updatehdr']:
         wname = configobj['UPDATE HEADER']['wcsname']
         # verify that a unique WCSNAME has been specified by the user
-        if not configobj['UPDATE HEADER']['reusename']:
-            for fname in filenames:
-                uniq = util.verifyUniqueWcsname(fname,wname)
-                if not uniq:
-                    errstr = 'WCSNAME "%s" already present in "%s".  '%(wname,fname)+\
-                    'A unique value for the "wcsname" parameter needs to be ' + \
-                    'specified. \n\nQuitting!'
-                    print(textutil.textbox(errstr,width=60))
-                    raise IOError
+        for fname in filenames:
+            unique_wcsname = util.verifyUniqueWcsname(
+                fname,
+                wname,
+                include_primary = not configobj['UPDATE HEADER']['reusename']
+            )
+            if not unique_wcsname:
+                errstr = (f"WCSNAME '{wname}' already present in '{fname}'. "
+                          "A unique value for the 'wcsname' parameter needs "
+                          "to be specified.")
+                print(textutil.textbox(errstr + "\n\nQuitting!", width=80))
+                raise ValueError(errstr)
 
     if configobj['updatewcs']:
         print('\nRestoring WCS solutions to original state using updatewcs...\n')

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -467,18 +467,15 @@ def count_sci_extensions(filename):
 
     return num_sci,extname
 
-def verifyUniqueWcsname(fname,wcsname):
+
+def verifyUniqueWcsname(fname, wcsname, include_primary=True):
     """
     Report whether or not the specified WCSNAME already exists in the file
     """
-    uniq = True
-    numsci,extname = count_sci_extensions(fname)
-    wnames = altwcs.wcsnames(fname,ext=(extname,1))
+    numsci, extname = count_sci_extensions(fname)
+    wnames = altwcs.wcsnames(fname, ext=(extname, 1), include_primary=include_primary)
+    return wcsname.upper() not in [v.upper() for v in wnames.values()]
 
-    if wcsname in wnames.values():
-        uniq = False
-
-    return uniq
 
 def verifyUpdatewcs(fname):
     """


### PR DESCRIPTION
This PR greatly simplifies the logic for archiving primary WCS. Now, if `'reusename'=True` then primary WCS is archived if provided `'wcsname'`is different from the `'WCSNAME'` of the primary WCS in image headers.

If primary WCS' name is the same (case-insensitive) as the name provided by `'wcsname'` parameter and `'reusename'=True`, then primary WCS will be updated by `tweakreg` in-place without archiving primary WCS. If `'reusename'=False` then an exception will be raised.

This PR reduces the number of duplicate alternate WCS created by `tweakreg` and it also solves the issue of non-unique WCS names in image headers: the algorithm is designed not to create WCSes with the same name.

Fixes #697 

This PR **requires functionality from** https://github.com/spacetelescope/stwcs/pull/149 and https://github.com/spacetelescope/stwcs/pull/153

CC: @nden
