### PR TITLE
Generate cross-filter point-source comparisons

### DIFF
--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -97,7 +97,9 @@ def read_cat_file(catfile):
     elif catfile.endswith("segment-cat.ecsv"):
         ecsvData = Table.read(catfile, format='ascii.ecsv') #now will read in and process HAP catalog data
         data = numpy.stack((ecsvData["X-Centroid"].data, ecsvData["Y-Centroid"].data), axis=-1)
-
+    elif catfile.endswith("point-cat-fxm.ecsv"):
+        ecsvData = Table.read(catfile, format='ascii.ecsv') #now will read in and process HAP catalog data
+        data = numpy.stack((ecsvData["xcentroid"].data, ecsvData["ycentroid"].data), axis=-1)
     else:
         try:
             daoData = Table.read(catfile, format='ascii.daophot') #now will read in and process daophot data

--- a/drizzlepac/devutils/comparison_tools/starmatch_hist.py
+++ b/drizzlepac/devutils/comparison_tools/starmatch_hist.py
@@ -99,7 +99,7 @@ def read_cat_file(catfile):
         data = numpy.stack((ecsvData["X-Centroid"].data, ecsvData["Y-Centroid"].data), axis=-1)
     elif catfile.endswith("point-cat-fxm.ecsv"):
         ecsvData = Table.read(catfile, format='ascii.ecsv') #now will read in and process HAP catalog data
-        data = numpy.stack((ecsvData["xcentroid"].data, ecsvData["ycentroid"].data), axis=-1)
+        data = numpy.stack((ecsvData["xcentroid_ref"].data, ecsvData["ycentroid_ref"].data), axis=-1)
     else:
         try:
             daoData = Table.read(catfile, format='ascii.daophot') #now will read in and process daophot data

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -1568,7 +1568,7 @@ def xymatch(cat1, cat2, sep, multiple=False, stack=True, verbose=True):
 # ======================================================================================================================
 
 
-def rdtoxy(rd_coord_array, image, image_ext):
+def rdtoxy(rd_coord_array, image, image_ext, origin=1):
     """converts RA and dec to x, y image coords.
 
     rd_coord_array : numpy.ndarray
@@ -1580,6 +1580,10 @@ def rdtoxy(rd_coord_array, image, image_ext):
     image_ext : string
         fits image extension to be used in the conversion.
 
+    origin : int, optional
+        the coordinate in the upper left corner of the image.  In FITS and Fortran standards, this is 1.  In
+        Numpy and C standards this is 0. Default value is 1.
+
     Returns
     xy_arr: array
         array of converted x, y coordinate value pairs
@@ -1588,15 +1592,15 @@ def rdtoxy(rd_coord_array, image, image_ext):
     scifile = image + image_ext
     wcs = wcsutil.HSTWCS(scifile)
     try:
-        xy_arr = wcs.wcs_sky2pix(rd_coord_array, 1)
+        xy_arr = wcs.wcs_sky2pix(rd_coord_array, origin)
     except AttributeError:
-        xy_arr = wcs.wcs_world2pix(rd_coord_array, 1)
+        xy_arr = wcs.wcs_world2pix(rd_coord_array, origin)
     return (xy_arr)
 
 # ======================================================================================================================
 
 
-def xytord(xy_coord_array, image, image_ext):
+def xytord(xy_coord_array, image, image_ext, origin=1):
     """converts x, y image coords to RA and dec.
 
     xy_coord_array : numpy.ndarray
@@ -1608,6 +1612,10 @@ def xytord(xy_coord_array, image, image_ext):
     image_ext : string
         fits image extension to be used in the conversion.
 
+    origin : int, optional
+        the coordinate in the upper left corner of the image.  In FITS and Fortran standards, this is 1.  In
+        Numpy and C standards this is 0. Default value is 1.
+
     Returns
     -------
     rd_arr : array
@@ -1617,9 +1625,9 @@ def xytord(xy_coord_array, image, image_ext):
     scifile = image + image_ext
     wcs = wcsutil.HSTWCS(scifile)
     try:
-        rd_arr = wcs.all_pix2sky(xy_coord_array, 1)
+        rd_arr = wcs.all_pix2sky(xy_coord_array, origin)
     except AttributeError:
-        rd_arr = wcs.all_pix2world(xy_coord_array, 1)
+        rd_arr = wcs.all_pix2world(xy_coord_array, origin)
     return (rd_arr)
 
 # ======================================================================================================================

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -630,19 +630,19 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
 
                 # Report number and percentage of the total number of detected ref and comp sources that were matched
                 log.info("Cross-matching results")
-                log.info("Reference sourcelist:  {} of {} total sources cross-matched ({}%)".format(len(matching_lines_ref),
-                                                                                                    sl_lengths[0],
-                                                                                                    100.0 *(float(len(matching_lines_ref))/ float(sl_lengths[0]))))
-                log.info("Comp sourcelist: {} of {} total sources cross-matched ({}%)".format(len(matching_lines_comp),
-                                                                                              sl_lengths[1],
-                                                                                              100.0 * (float(len(matching_lines_comp)) / float(sl_lengths[1]))))
+                log.info("Reference sourcelist:  {} of {} total reference sources ({}%) cross-matched.".format(len(matching_lines_ref),
+                                                                                                               sl_lengths[0],
+                                                                                                               100.0 *(float(len(matching_lines_ref))/ float(sl_lengths[0]))))
+                log.info("Comparison sourcelist: {} of {} total comparison sources ({}%) cross-matched.".format(len(matching_lines_comp),
+                                                                                                                sl_lengths[1],
+                                                                                                                100.0 * (float(len(matching_lines_comp)) / float(sl_lengths[1]))))
 
                 if matching_lines_ref.size > 0:
                     # instantiate diagnostic object to store test results for eventual .json file output
                     diag_obj = du.HapDiagnostic(log_level=log_level)
                     diag_obj.instantiate_from_hap_obj(filtobj_dict[xmatch_comp_imgname]['filt_obj'],
                                                       data_source="{}.compare_interfilter_crossmatches".format(__taskname__),
-                                                      description="cross-matched interfilter comparison and reference catalog X and Y values",
+                                                      description="Interfilter cross-matched comparison and reference catalog X and Y values",
                                                       timestamp=json_timestamp,
                                                       time_since_epoch=json_time_since_epoch)
                     json_results_dict = collections.OrderedDict()
@@ -700,7 +700,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
 
                     # write out ds9 region file if log level is 'debug'
                     if log_level == logutil.logging.DEBUG:
-                        reg_filename = "{}_{}_comp_matches.reg".format(filtername_comp,filtername_ref)
+                        reg_filename = "{}_{}_comp_matches.reg".format(filtername_comp, filtername_ref)
                         matched_comp_coords.write(reg_filename, format='ascii.csv')
 
                     # compute statistics
@@ -721,7 +721,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                         sep_stat_dict["{}x{} sigma-clipped standard deviation".format(maxiters, sigma)] = clipped_stats[2]
 
                         # Store statistics as new data section
-                        diag_obj.add_data_item(sep_stat_dict, "interfilter cross-matched {} separation statistics".format(colname),
+                        diag_obj.add_data_item(sep_stat_dict, "Interfilter cross-matched {} separation statistics".format(colname),
                                                descriptions={"Non-clipped min": "Non-clipped min difference",
                                                              "Non-clipped max": "Non-clipped max difference",
                                                              "Non-clipped mean": "Non-clipped mean difference",

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -562,9 +562,13 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
         ctr = 1
         for total_obj in total_obj_list:
             for filt_obj in total_obj.fdp_list:
-                log.info("{}: {} {} {}".format(ctr, filt_obj.instrument.upper(),
-                                               filt_obj.detector.upper(), filt_obj.filters.upper()))
+                log.info("{}: {} {} {}".format(ctr, filt_obj.drizzle_filename))
+
+
+                sources = find_hap_point_sources(filt_obj)
+
                 ctr += 1
+
 
 # ------------------------------------------------------------------------------------------------------------
 
@@ -626,6 +630,25 @@ def find_gaia_sources(hap_obj, json_timestamp=None, json_time_since_epoch=None,
 
 # ----------------------------------------------------------------------------------------------------------------------
 
+
+def find_hap_point_sources(filt_obj):
+    """Identifies point sources in HAP imagery products
+
+    Parameters
+    ----------
+    # TODO: fill this out
+
+    Returns
+    -------
+    # TODO: fill this out
+    """
+    filt_hdulist = fits.open(filt_obj.drizzle_filename)
+    img_data = filt_hdulist["SCI"].data
+
+    filt_hdulist.close()
+    return 0
+
+# ----------------------------------------------------------------------------------------------------------------------
 
 def generate_gaia_catalog(hap_obj, columns_to_remove=None):
     """Uses astrometric_utils.create_astrometric_catalog() to create a catalog of all GAIA sources in the

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -759,6 +759,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
     del filtobj_dict
 
 
+
 # ------------------------------------------------------------------------------------------------------------
 
 

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -592,7 +592,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
             log.info("Wrote source catalog {}".format(temp_cat_name))
 
             reg_table = filtobj_dict[imgname]["sources"].copy()
-            reg_table.keep_columns(['xcentroid_ref', 'ycentroid_ref'])
+            reg_table.keep_columns(['ra', 'dec'])
             reg_filename = imgname[:-8] + "fxm_all.reg"
             reg_table.write(reg_filename, format='ascii.csv')
             print("wrote region file {}".format(reg_filename))

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -589,13 +589,19 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
             temp_cat_file_list.append(temp_cat_name)
             filtobj_dict[imgname]["sources"].write(temp_cat_name, format="ascii.ecsv")
             print("Wrote source catalog {}".format(temp_cat_name))
-            log.info("Wrote source catalog {}".format(temp_cat_name))
+            print("Wrote source catalog {}".format(temp_cat_name))
 
-            reg_table = filtobj_dict[imgname]["sources"].copy()
-            reg_table.keep_columns(['ra', 'dec'])
-            reg_filename = imgname[:-8] + "fxm_all.reg"
-            reg_table.write(reg_filename, format='ascii.csv')
-            print("wrote region file {}".format(reg_filename))
+            # write out ds9 region files
+            out_reg_stuff = {"xyorig": ['xcentroid', 'ycentroid'],
+                             "rd": ['ra', 'dec'],
+                             "xyref": ['xcentroid_ref', 'ycentroid_ref']}
+            for reg_type in out_reg_stuff.keys():
+                reg_table = filtobj_dict[imgname]["sources"].copy()
+                reg_table.keep_columns(out_reg_stuff[reg_type])
+                reg_table.rename_column(out_reg_stuff[reg_type][0],"#"+out_reg_stuff[reg_type][0])
+                reg_filename = "{}fxm_{}_all.reg".format(imgname[:-8], reg_type)
+                reg_table.write(reg_filename, format='ascii.csv')
+                print("wrote region file {}".format(reg_filename))
 
         # Perform cross-match based on X, Y coords
         for imgname in filtobj_dict.keys():
@@ -622,7 +628,6 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                 print("Comp sourcelist: {} of {} total sources cross-matched ({}%)".format(len(matching_lines_comp),
                                                                                               sl_lengths[1],
                                                                                               100.0 * (float(len(matching_lines_comp)) / float(sl_lengths[1]))))
-
 
 
     # Housekeeping
@@ -668,7 +673,8 @@ def transform_coords(filtobj_subdict, xmatch_ref_imgname, log_level=logutil.logg
     origin = 0
     fits_exten = "[1]"
     imgname = filtobj_subdict['filt_obj'].drizzle_filename
-
+    print("TRANSFORM IMGNAME: "+imgname)
+    print("TRANSFORM REFIMG:  "+xmatch_ref_imgname)
     # 2a: perform xcentroid, ycentroid -> ra, dec transform
     ra_dec_values = hla_flag_filter.xytord(xy_centroid_values, imgname, fits_exten, origin=origin)
 

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -754,7 +754,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
     # filtobj_dict dictionary
     log.info("")
     for temp_cat_filename in temp_cat_file_list:
-        log.info("removing temp catalog file {}".format(temp_cat_filename))
+        log.info("removing temporary catalog file {}".format(temp_cat_filename))
         os.remove(temp_cat_filename)
     del filtobj_dict
 

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -557,7 +557,8 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                   "cross matched sources. No filter-level products were found. ")
         return
     else:
-        log.info("Found {} filter-level products for use in inter-filter cross match comparisons.".format(num_filter_prods))
+        log.info("Found {} filter-level products for use in analysis of inter-filter cross matched source"
+                 " positions.".format(num_filter_prods))
         ctr = 1
         for total_obj in total_obj_list:
             for filt_obj in total_obj.fdp_list:

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -42,20 +42,20 @@ from astropy.coordinates import SkyCoord
 from astropy.io import ascii, fits
 from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
-from itertools import chain
-import numpy as np
-from scipy.spatial import KDTree
-
 from bokeh.layouts import row, column
 from bokeh.plotting import figure, output_file, save
 from bokeh.models import ColumnDataSource, Label
 from bokeh.models.tools import HoverTool
-
+from itertools import chain
+import numpy as np
+from photutils import DAOStarFinder
+from scipy.spatial import KDTree
 
 
 # Local application imports
 from drizzlepac import util, wcs_functions
 from drizzlepac.haputils import hla_flag_filter
+from drizzlepac.haputils import align_utils
 from drizzlepac.haputils import astrometric_utils as au
 import drizzlepac.haputils.diagnostic_utils as du
 import drizzlepac.devutils.comparison_tools.compare_sourcelists as csl
@@ -562,9 +562,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
         ctr = 1
         for total_obj in total_obj_list:
             for filt_obj in total_obj.fdp_list:
-                log.info("{}: {} {} {}".format(ctr, filt_obj.drizzle_filename))
-
-
+                log.info("{}: {}".format(ctr, filt_obj.drizzle_filename))
                 sources = find_hap_point_sources(filt_obj)
 
                 ctr += 1
@@ -642,10 +640,14 @@ def find_hap_point_sources(filt_obj):
     -------
     # TODO: fill this out
     """
-    filt_hdulist = fits.open(filt_obj.drizzle_filename)
-    img_data = filt_hdulist["SCI"].data
+    pdb.set_trace()
+    img_obj = align_utils.HAPImage(filt_obj.drizzle_filename)
 
-    filt_hdulist.close()
+    log.info("DAOStarFinder(fwhm={}, threshold={}*{})".format(source_fwhm, self.param_dict['nsigma'], self.image.bkg_rms_median))
+    daofind = DAOStarFinder(fwhm=source_fwhm, threshold=self.param_dict['nsigma'] * self.image.bkg_rms_median)
+    sources = daofind(image, mask=exclusion_mask)
+
+
     return 0
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -642,7 +642,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                     diag_obj = du.HapDiagnostic(log_level=log_level)
                     diag_obj.instantiate_from_hap_obj(filtobj_dict[xmatch_comp_imgname]['filt_obj'],
                                                       data_source="{}.compare_interfilter_crossmatches".format(__taskname__),
-                                                      description="matched point and segment catalog RA and Dec values",
+                                                      description="cross-matched interfilter comparison and reference catalog X and Y values",
                                                       timestamp=json_timestamp,
                                                       time_since_epoch=json_time_since_epoch)
                     json_results_dict = collections.OrderedDict()

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -759,7 +759,6 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
     del filtobj_dict
 
 
-
 # ------------------------------------------------------------------------------------------------------------
 
 

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -602,7 +602,7 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                 for reg_type in out_reg_stuff.keys():
                     reg_table = filtobj_dict[imgname]["sources"].copy()
                     reg_table.keep_columns(out_reg_stuff[reg_type])
-                    reg_table.rename_column(out_reg_stuff[reg_type][0],"#"+out_reg_stuff[reg_type][0])
+                    reg_table.rename_column(out_reg_stuff[reg_type][0], "#"+out_reg_stuff[reg_type][0])
                     reg_filename = "{}fxm_{}_all.reg".format(imgname[:-8], reg_type)
                     reg_table.write(reg_filename, format='ascii.csv')
                     log.info("wrote region file {}".format(reg_filename))
@@ -622,17 +622,15 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                 sl_names = [xmatch_ref_catname, xmatch_comp_catname]
                 img_names = [xmatch_ref_imgname, xmatch_comp_imgname]
                 sl_lengths = [max_sources, len(filtobj_dict[xmatch_comp_imgname]["sources"])]
-
-
-
                 matching_lines_ref, matching_lines_comp = csl.getMatchedLists(sl_names, img_names, sl_lengths,
                                                                               log_level=log_level)
 
-                # Report number and percentage of the total number of detected ref and comp sources that were matched
+                # Report number and percentage of the total number of detected ref and comp sources that were
+                # matched
                 log.info("Cross-matching results")
                 log.info("Reference sourcelist:  {} of {} total reference sources ({}%) cross-matched.".format(len(matching_lines_ref),
                                                                                                                sl_lengths[0],
-                                                                                                               100.0 *(float(len(matching_lines_ref))/ float(sl_lengths[0]))))
+                                                                                                               100.0 * (float(len(matching_lines_ref)) / float(sl_lengths[0]))))
                 log.info("Comparison sourcelist: {} of {} total comparison sources ({}%) cross-matched.".format(len(matching_lines_comp),
                                                                                                                 sl_lengths[1],
                                                                                                                 100.0 * (float(len(matching_lines_comp)) / float(sl_lengths[1]))))
@@ -666,8 +664,8 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                                                   "comparison catalog length": "unitless",
                                                   "number of cross-matches": "unitless"})
 
-                    # Generate tables containing just "xcentroid_ref" and "ycentroid_ref" columns with only the
-                    # cross-matched reference sources
+                    # Generate tables containing just "xcentroid_ref" and "ycentroid_ref" columns with only
+                    # the cross-matched reference sources
                     matched_ref_coords = filtobj_dict[xmatch_ref_imgname]["sources"].copy()
                     matched_ref_coords.keep_columns(['xcentroid_ref', 'ycentroid_ref'])
 
@@ -681,12 +679,11 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
 
                     # write out ds9 region files if log level is 'debug'
                     if log_level == logutil.logging.DEBUG:
-                        reg_filename = "{}_{}_ref_matches.reg".format(filtername_comp,filtername_ref)
+                        reg_filename = "{}_{}_ref_matches.reg".format(filtername_comp, filtername_ref)
                         matched_ref_coords.write(reg_filename, format='ascii.csv')
 
-
-                    # Generate tables containing just "xcentroid_ref" and "ycentroid_ref" columns with only the
-                    # cross-matched comparision sources
+                    # Generate tables containing just "xcentroid_ref" and "ycentroid_ref" columns with only
+                    # the cross-matched comparision sources
                     matched_comp_coords = filtobj_dict[imgname]["sources"].copy()
                     matched_comp_coords.keep_columns(['xcentroid_ref', 'ycentroid_ref'])
                     matched_comp_coords = matched_comp_coords[matching_lines_comp]
@@ -745,7 +742,8 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                                     :-9] + "_svm_interfilter_crossmatch.json"
                     diag_obj.write_json_file(json_filename, clobber=True)
                 else:
-                    log.warning("{} - {} interfilter cross match test could not be performed.".format(filtername_comp, filtername_ref))
+                    filt_names = "{} - {}".format(filtername_comp, filtername_ref)
+                    log.warning("{} interfilter cross match test could not be performed.".format(filt_names))
 
     # Housekeeping. Delete the *_point-cat-fxm.ecsv files created for cross-matching, and the
     # filtobj_dict dictionary
@@ -753,7 +751,10 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
         log.info("removing temp catalog file {}".format(temp_cat_filename))
         os.remove(temp_cat_filename)
     del filtobj_dict
+
+
 # ------------------------------------------------------------------------------------------------------------
+
 
 def transform_coords(filtobj_subdict, xmatch_ref_imgname, log_level=logutil.logging.NOTSET):
     """Transform comparision image frame of reference x, y coords to RA and dec, then back to x, y coords in
@@ -784,7 +785,7 @@ def transform_coords(filtobj_subdict, xmatch_ref_imgname, log_level=logutil.logg
 
     # 1: stack up xcentroid and ycentorid columns from sources table
     xy_centroid_values = np.stack((filtobj_subdict['sources']['xcentroid'],
-                             filtobj_subdict['sources']['ycentroid']), axis=1)
+                                   filtobj_subdict['sources']['ycentroid']), axis=1)
 
     # 2: perform coordinate transforms.
     origin = 0
@@ -811,6 +812,7 @@ def transform_coords(filtobj_subdict, xmatch_ref_imgname, log_level=logutil.logg
         col_ctr += 1
 
     return filtobj_subdict
+
 
 def find_gaia_sources(hap_obj, json_timestamp=None, json_time_since_epoch=None,
                       log_level=logutil.logging.NOTSET):
@@ -932,7 +934,9 @@ def find_hap_point_sources(filt_obj, log_level=logutil.logging.NOTSET):
 
     return {"filt_obj": filt_obj, "sources": sources}
 
+
 # ----------------------------------------------------------------------------------------------------------------------
+
 
 def generate_gaia_catalog(hap_obj, columns_to_remove=None):
     """Uses astrometric_utils.create_astrometric_catalog() to create a catalog of all GAIA sources in the
@@ -1870,6 +1874,7 @@ HOVER_COLUMNS = ['gen_info.instrument',
 
 FIGURE_TOOLS = 'pan,wheel_zoom,box_zoom,zoom_in,zoom_out,xbox_select,reset,save'
 
+
 def build_svm_plots(data_source, output_basename=''):
     """Create all the plots for the results generated by these comparisons
     
@@ -1887,21 +1892,20 @@ def build_svm_plots(data_source, output_basename=''):
         
     # Start with gaia_comparison
     gaia_col_names = HOVER_COLUMNS + ['distribution_characterization_statistics.Number_of_GAIA_sources',
-                                    'distribution_characterization_statistics.X_centroid',
-                                    'distribution_characterization_statistics.X_offset',
-                                    'distribution_characterization_statistics.X_standard_deviation',
-                                    'distribution_characterization_statistics.Y_centroid',
-                                    'distribution_characterization_statistics.Y_offset',
-                                    'distribution_characterization_statistics.Y_standard_deviation',
-                                    'distribution_characterization_statistics.maximum_neighbor_distance',
-                                    'distribution_characterization_statistics.mean_neighbor_distance',
-                                    'distribution_characterization_statistics.minimum_neighbor_distance',
-                                    'distribution_characterization_statistics.standard_deviation_of_neighbor_distances']
+                                      'distribution_characterization_statistics.X_centroid',
+                                      'distribution_characterization_statistics.X_offset',
+                                      'distribution_characterization_statistics.X_standard_deviation',
+                                      'distribution_characterization_statistics.Y_centroid',
+                                      'distribution_characterization_statistics.Y_offset',
+                                      'distribution_characterization_statistics.Y_standard_deviation',
+                                      'distribution_characterization_statistics.maximum_neighbor_distance',
+                                      'distribution_characterization_statistics.mean_neighbor_distance',
+                                      'distribution_characterization_statistics.minimum_neighbor_distance',
+                                      'distribution_characterization_statistics.standard_deviation_of_neighbor_distances']
 
     gaia_cols = get_pandas_data(data_source, gaia_col_names)
 
-    gaia_plots_name = build_gaia_plots(gaia_cols, gaia_col_names, 
-                                  output_basename=output_basename)
+    gaia_plots_name = build_gaia_plots(gaia_cols, gaia_col_names, output_basename=output_basename)
     
     # Generate plots for point-segment catalog cross-match comparisons
     xmatch_col_names = HOVER_COLUMNS + ['Cross-match_details.number_of_cross-matches',
@@ -1926,8 +1930,7 @@ def build_svm_plots(data_source, output_basename=''):
 
     xmatch_cols = get_pandas_data(data_source, xmatch_col_names)
 
-    xmatch_plots_name = build_crossmatch_plots(xmatch_cols, xmatch_col_names, 
-                                  output_basename=output_basename)
+    xmatch_plots_name = build_crossmatch_plots(xmatch_cols, xmatch_col_names, output_basename=output_basename)
     
 
 # -----------------------------------------------------------------------------
@@ -1969,63 +1972,64 @@ def build_gaia_plots(gaiaCDS, data_cols, output_basename='svm_qa'):
     
     colormap = [qa.DETECTOR_LEGEND[x] for x in gaiaCDS.data[data_cols[1]]]
     gaiaCDS.data['colormap'] = colormap
-    inst_det = ["{}/{}".format(i,d) for (i,d) in zip(gaiaCDS.data[data_cols[0]], 
-                                         gaiaCDS.data[data_cols[1]])]
+    inst_det = ["{}/{}".format(i, d) for (i, d) in zip(gaiaCDS.data[data_cols[0]],
+                                                       gaiaCDS.data[data_cols[1]])]
     gaiaCDS.data[qa.INSTRUMENT_COLUMN] = inst_det
     
     plot_list = []
 
     hist4, edges4 = np.histogram(gaiaCDS.data[data_cols[num_hover_cols]], bins=50)
     title4 = 'Number of GAIA sources in Field'
-    p4 = [plot_histogram(title4, hist4, edges4, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='Number of GAIA sources', ylabel='Number of products')]
+    p4 = [plot_histogram(title4, hist4, edges4, y_start=0,
+                         fill_color='navy', background_fill_color='#fafafa',
+                         xlabel='Number of GAIA sources', ylabel='Number of products')]
     plot_list += p4
 
-    p0 = [qa.build_circle_plot(x=data_cols[num_hover_cols + 1], 
-                            y=data_cols[num_hover_cols + 4],
-                           source=gaiaCDS,  
-                           title='Centroid of GAIA Sources in Field',
-                           x_label="X Centroid (pixels)",
-                           y_label='Y Centroid (pixels)',
-                           tips=[3, 0, 1, 2, 8],
-                           colormap=True, legend_group=qa.INSTRUMENT_COLUMN)]
+    p0 = [qa.build_circle_plot(x=data_cols[num_hover_cols + 1],
+                               y=data_cols[num_hover_cols + 4],
+                               source=gaiaCDS,
+                               title='Centroid of GAIA Sources in Field',
+                               x_label="X Centroid (pixels)",
+                               y_label='Y Centroid (pixels)',
+                               tips=[3, 0, 1, 2, 8],
+                               colormap=True,
+                               legend_group=qa.INSTRUMENT_COLUMN)]
     plot_list += p0
 
-    p1 = [qa.build_circle_plot(x=data_cols[num_hover_cols + 2], 
-                            y=data_cols[num_hover_cols + 5],
-                           source=gaiaCDS,  
-                           title='Offset of Centroid of GAIA Sources in Field',
-                           x_label="X Offset (pixels)",
-                           y_label='Y Offset (pixels)',
-                           tips=[3, 0, 1, 2, 8],
-                           colormap=True, legend_group=qa.INSTRUMENT_COLUMN)]
+    p1 = [qa.build_circle_plot(x=data_cols[num_hover_cols + 2],
+                               y=data_cols[num_hover_cols + 5],
+                               source=gaiaCDS,
+                               title='Offset of Centroid of GAIA Sources in Field',
+                               x_label="X Offset (pixels)",
+                               y_label='Y Offset (pixels)',
+                               tips=[3, 0, 1, 2, 8],
+                               colormap=True, legend_group=qa.INSTRUMENT_COLUMN)]
     plot_list += p1
 
-    p2 = [qa.build_circle_plot(x=data_cols[num_hover_cols + 3], 
-                            y=data_cols[num_hover_cols + 6],
-                           source=gaiaCDS,  
-                           title='Standard Deviation of GAIA Source Positions in Field',
-                           x_label="STD(X) (pixels)",
-                           y_label='STD(Y) (pixels)',
-                           tips=[3, 0, 1, 2, 8],
-                           colormap=True, legend_group=qa.INSTRUMENT_COLUMN)]
+    p2 = [qa.build_circle_plot(x=data_cols[num_hover_cols + 3],
+                               y=data_cols[num_hover_cols + 6],
+                               source=gaiaCDS,
+                               title='Standard Deviation of GAIA Source Positions in Field',
+                               x_label="STD(X) (pixels)",
+                               y_label='STD(Y) (pixels)',
+                               tips=[3, 0, 1, 2, 8],
+                               colormap=True, legend_group=qa.INSTRUMENT_COLUMN)]
     plot_list += p2
 
     # Generate histogram for mean neighbor distance
     hist3, edges3 = np.histogram(gaiaCDS.data[data_cols[-3]], bins=50)
     title3 = 'Mean distance between GAIA sources in Field'
-    p3 = [plot_histogram(title3, hist3, edges3, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='separation (pixels)', ylabel='Number of products')]
+    p3 = [plot_histogram(title3, hist3, edges3, y_start=0,
+                         fill_color='navy', background_fill_color='#fafafa',
+                         xlabel='separation (pixels)', ylabel='Number of products')]
     plot_list += p3
 
-    
     # Display!
     save(column(plot_list))
     
     # Return the name of the plot file just created
     return output
+
 
 def build_crossmatch_plots(xmatchCDS, data_cols, output_basename='svm_qa'):
     """
@@ -2062,38 +2066,41 @@ def build_crossmatch_plots(xmatchCDS, data_cols, output_basename='svm_qa'):
     
     colormap = [qa.DETECTOR_LEGEND[x] for x in xmatchCDS.data[data_cols[1]]]
     xmatchCDS.data['colormap'] = colormap
-    inst_det = ["{}/{}".format(i,d) for (i,d) in zip(xmatchCDS.data[data_cols[0]], 
-                                         xmatchCDS.data[data_cols[1]])]
+    inst_det = ["{}/{}".format(i, d) for (i, d) in zip(xmatchCDS.data[data_cols[0]],
+                                                       xmatchCDS.data[data_cols[1]])]
     xmatchCDS.data[qa.INSTRUMENT_COLUMN] = inst_det
     
     plot_list = []
 
     hist0, edges0 = np.histogram(xmatchCDS.data[data_cols[num_hover_cols]], bins=50)
     title0 = 'Number of Point-to-Segment Cross-matched sources'
-    p0 = [plot_histogram(title0, hist0, edges0, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='Number of Cross-matched sources', ylabel='Number of products')]
+    p0 = [plot_histogram(title0, hist0, edges0, y_start=0, fill_color='navy',
+                         background_fill_color='#fafafa', xlabel='Number of Cross-matched sources',
+                         ylabel='Number of products')]
     plot_list += p0
 
     hist1, edges1 = np.histogram(xmatchCDS.data[data_cols[num_hover_cols + 11]], bins=50)
     title1 = 'Mean Separation (Sigma-clipped) of Point-to-Segment Cross-matched sources'
-    p1 = [plot_histogram(title1, hist1, edges1, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='Mean Separation of Cross-matched sources (arcseconds)', ylabel='Number of products')]
+    p1 = [plot_histogram(title1, hist1, edges1, y_start=0,
+                         fill_color='navy', background_fill_color='#fafafa',
+                         xlabel='Mean Separation of Cross-matched sources (arcseconds)',
+                         ylabel='Number of products')]
     plot_list += p1
     
     hist2, edges2 = np.histogram(xmatchCDS.data[data_cols[num_hover_cols + 12]], bins=50)
     title2 = 'Median Separation (Sigma-clipped) of Point-to-Segment Cross-matched sources'
-    p2 = [plot_histogram(title2, hist2, edges2, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='Median Separation of Cross-matched sources (arcseconds)', ylabel='Number of products')]
+    p2 = [plot_histogram(title2, hist2, edges2, y_start=0,
+                         fill_color='navy', background_fill_color='#fafafa',
+                         xlabel='Median Separation of Cross-matched sources (arcseconds)',
+                         ylabel='Number of products')]
     plot_list += p2
     
     hist3, edges3 = np.histogram(xmatchCDS.data[data_cols[num_hover_cols + 13]], bins=50)
     title3 = 'Standard-deviation (sigma-clipped) of Separation of Point-to-Segment Cross-matched sources'
-    p3 = [plot_histogram(title3, hist3, edges3, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='STD(Separation) of Cross-matched sources (arcseconds)', ylabel='Number of products')]
+    p3 = [plot_histogram(title3, hist3, edges3, y_start=0,
+                         fill_color='navy', background_fill_color='#fafafa',
+                         xlabel='STD(Separation) of Cross-matched sources (arcseconds)',
+                         ylabel='Number of products')]
     plot_list += p3
     
     # Save the plot to an HTML file
@@ -2104,7 +2111,8 @@ def build_crossmatch_plots(xmatchCDS, data_cols, output_basename='svm_qa'):
 # -----------------------------------------------------------------------------
 # Utility functions for plotting
 #    
-   
+
+
 def get_pandas_data(data_source, data_columns):
     """Load the harvested data, stored in a CSV file, into local arrays.
 
@@ -2141,7 +2149,6 @@ def get_pandas_data(data_source, data_columns):
     else:
         data_cols = df_handle.get_columns_CSV(data_columns)
 
-
     # Setup the source of the data to be plotted so the axis variables can be
     # referenced by column name in the Pandas dataframe
     dataDF = ColumnDataSource(data_cols)
@@ -2151,18 +2158,15 @@ def get_pandas_data(data_source, data_columns):
     return dataDF
     
     
-def plot_histogram(title, hist, edges, y_start=0, 
-                    fill_color='navy', background_fill_color='#fafafa', 
-                    xlabel='', ylabel=''):
-    p = figure(title=title, tools=FIGURE_TOOLS, 
-              background_fill_color=background_fill_color)
-    p.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:],
-           fill_color=fill_color, line_color="white", alpha=0.5)
+def plot_histogram(title, hist, edges, y_start=0, fill_color='navy',
+                   background_fill_color='#fafafa', xlabel='', ylabel=''):
+    p = figure(title=title, tools=FIGURE_TOOLS, background_fill_color=background_fill_color)
+    p.quad(top=hist, bottom=0, left=edges[:-1], right=edges[1:], fill_color=fill_color,
+           line_color="white", alpha=0.5)
 
     p.y_range.start = y_start
     p.legend.location = "center_right"
     p.xaxis.axis_label = xlabel
     p.yaxis.axis_label = ylabel
-    p.grid.grid_line_color="white"
+    p.grid.grid_line_color = "white"
     return p
-

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -580,8 +580,6 @@ def compare_interfilter_crossmatches(total_obj_list, json_timestamp=None, json_t
                     xmatch_ref_imgname = filt_obj.drizzle_filename
         log.info("")
         log.info("Crossmatch reference image {} contains {} sources.".format(xmatch_ref_imgname, max_sources))
-        print("\a\a\a")
-        pdb.set_trace()
 
 
 # ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Linked issues/tickets**
- Git issue #702 
- JIRA ticket [HLA-381](https://jira.stsci.edu/browse/HLA-381)

**High-level summary**
-Added new test to svm_quality_analysis.py that quantifies the quality of alignment of filter products in multi-filter datasets. 
- This is accomplished for a given multi-filter dataset by:

1. independently identifying point sources in each filter product
2. convert X and Y coords of all identified sources to the common reference frame of the image that yielded the most sources.
3. Cross-match using the catalog with the most sources as the reference for all crossmatches
4. Compare the X, Y positions of the cross-matched sources in the various catalogs vs. the reference catalog and compute statistics on the differences.
5. For each interfilter comparison, write details of the cross-match, computed stats and the cross-matched catalogs to a .json file.
 
**Summary of changes to code**
- starmatch_hist.py:
     - added support for temporary *fxm.ecsv catalog files generated for the crossmatch by svm_quality_analysis.compare_interfilter_crossmatches().
-  hla_flag_filter.py:
     - added optional input parameter "origin" to subroutines xytord() and rdtoxy() so that the x, y coordinate origin can be specified.
- svm_quality_analysis.py:
     -  Assorted pep8 fixes throughout code
     - Added subroutines compare_interfilter_crossmatches(), find_hap_point_sources() and transform_coords() for the new test
     - added new optional command line input switch '-fxm' to run new interfilter crossmatch test