### PR TITLE
Catch when HDRNAME is missing

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -959,7 +959,8 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
         hdulist[sci_extn].header['CRDER1'] = info['RMS_RA'].value if info['RMS_RA'] is not None else -1.0
         hdulist[sci_extn].header['CRDER2'] = info['RMS_DEC'].value if info['RMS_DEC'] is not None else -1.0
         hdulist[sci_extn].header['NMATCHES'] = len(info['ref_mag']) if info['ref_mag'] is not None else -1.0
-        del hdulist[sci_extn].header['HDRNAME']
+        if 'HDRNAME' in hdulist[sci_extn].header:
+            del hdulist[sci_extn].header['HDRNAME']
         hdulist[sci_extn].header['HDRNAME'] = hdr_name
         hdulist.flush()
         hdulist.close()


### PR DESCRIPTION
Added logic to avoid trying to delete the HDRNAME keyword when it was not present.  This affected the processing of some associations (like j9l929010).  