### PR TITLE
Filter out various header keywords from json file harvesting

### DIFF
--- a/drizzlepac/haputils/diagnostic_json_harvester.py
+++ b/drizzlepac/haputils/diagnostic_json_harvester.py
@@ -282,7 +282,7 @@ def make_dataframe_line(json_filename_list, log_level=logutil.logging.INFO):
         json_data = du.read_json_file(json_filename)
         # add information from "header" section to ingest_dict just once
         if not header_ingested:
-            # filter out ALL header keywords not listed included in 'header_keywords_to_keep'
+            # filter out ALL header keywords not included in 'header_keywords_to_keep'
             header_keywords_to_keep = ['APERTURE',
                                        'CHINJECT',
                                        'DATE-OBS',

--- a/drizzlepac/haputils/diagnostic_json_harvester.py
+++ b/drizzlepac/haputils/diagnostic_json_harvester.py
@@ -9,6 +9,7 @@ import collections
 import glob
 import os
 import pdb
+import re
 import sys
 
 # Related third party imports
@@ -284,6 +285,31 @@ def make_dataframe_line(json_filename_list, log_level=logutil.logging.INFO):
         if not header_ingested:
             for header_item in json_data['header'].keys():
                 ingest_dict["data"]["header."+header_item] = json_data['header'][header_item]
+
+            # use regex to find additional drizzle header keywords to remove
+            header_patterns_to_remove = ["D\d+VER",
+                                         "D\d+GEOM",
+                                         "D\d+DATA",
+                                         "D\d+DEXP",
+                                         "D\d+OUDA",
+                                         "D\d+OUWE",
+                                         "D\d+OUCO",
+                                         "D\d+MASK",
+                                         "D\d+WTSC",
+                                         "D\d+KERN",
+                                         "D\d+PIXF",
+                                         "D\d+COEF",
+                                         "D\d+OUUN",
+                                         "D\d+FVAL",
+                                         "D\d+WKEY",
+                                         "D\d+SCAL",
+                                         "D\d+ISCL"]
+            header_items_to_remove = []
+            for pattern in header_patterns_to_remove:
+                r = re.compile(pattern)
+                header_items_to_remove += list(filter(r.match, json_data['header'].keys()))
+            for header_item_to_remove in header_items_to_remove:
+                del(ingest_dict["data"]["header."+header_item_to_remove])
             header_ingested = True
 
         # add information from "general information" section to ingest_dict just once

--- a/drizzlepac/haputils/diagnostic_json_harvester.py
+++ b/drizzlepac/haputils/diagnostic_json_harvester.py
@@ -9,7 +9,6 @@ import collections
 import glob
 import os
 import pdb
-import re
 import sys
 
 # Related third party imports
@@ -283,33 +282,24 @@ def make_dataframe_line(json_filename_list, log_level=logutil.logging.INFO):
         json_data = du.read_json_file(json_filename)
         # add information from "header" section to ingest_dict just once
         if not header_ingested:
+            # filter out ALL header keywords not listed included in 'header_keywords_to_keep'
+            header_keywords_to_keep = ['APERTURE',
+                                       'CHINJECT',
+                                       'DATE-OBS',
+                                       'DEC_TARG',
+                                       'EXPTIME',
+                                       'FGSLOCK',
+                                       'GYROMODE',
+                                       'MTFLAG',
+                                       'OBSKEY',
+                                       'OBSTYPE',
+                                       'RA_TARG',
+                                       'SCAN_TYP',
+                                       'SUBARRAY',
+                                       'TIME-OBS']
             for header_item in json_data['header'].keys():
-                ingest_dict["data"]["header."+header_item] = json_data['header'][header_item]
-
-            # use regex to find additional drizzle header keywords to remove
-            header_patterns_to_remove = ["D\d+VER",
-                                         "D\d+GEOM",
-                                         "D\d+DATA",
-                                         "D\d+DEXP",
-                                         "D\d+OUDA",
-                                         "D\d+OUWE",
-                                         "D\d+OUCO",
-                                         "D\d+MASK",
-                                         "D\d+WTSC",
-                                         "D\d+KERN",
-                                         "D\d+PIXF",
-                                         "D\d+COEF",
-                                         "D\d+OUUN",
-                                         "D\d+FVAL",
-                                         "D\d+WKEY",
-                                         "D\d+SCAL",
-                                         "D\d+ISCL"]
-            header_items_to_remove = []
-            for pattern in header_patterns_to_remove:
-                r = re.compile(pattern)
-                header_items_to_remove += list(filter(r.match, json_data['header'].keys()))
-            for header_item_to_remove in header_items_to_remove:
-                del(ingest_dict["data"]["header."+header_item_to_remove])
+                if header_item in header_keywords_to_keep:
+                    ingest_dict["data"]["header."+header_item] = json_data['header'][header_item]
             header_ingested = True
 
         # add information from "general information" section to ingest_dict just once


### PR DESCRIPTION
diagnostic_json_harvester.py: added logic to make_dataframe_line() to ONLY harvest values the following header keywords into a dataframe line:

- APERTURE
- CHINJECT
- DATE-OBS
- DEC_TARG
- EXPTIME
- FGSLOCK
- GYROMODE
- MTFLAG
- OBSKEY
- OBSTYPE
- RA_TARG
- SCAN_TYP
- SUBARRAY
- TIME-OBS