### PR TITLE
Add generation of absolute astrometry residuals to pipeline Q&A tests

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -566,7 +566,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                 result.add_column(filtered_table[col], name=col)
         if filtered_table is not None:
             filtered_table.pprint(max_width=-1)
-    return filtered_table
+    return alignment_table
 
 
 

--- a/drizzlepac/haputils/pipeline_graphics.py
+++ b/drizzlepac/haputils/pipeline_graphics.py
@@ -345,6 +345,7 @@ def build_astrometry_plots(pandas_file,
     gaiafitCDS = ColumnDataSource(gaia_fit_data)
     gaiaresidsCDS = ColumnDataSource(gaia_resids_data)
     
+    gaia_output = 'gaiafit_{}'.format(output)
 
     if output_dir is not None:
         summary_filename = os.path.join(output_dir, output)

--- a/drizzlepac/haputils/pipeline_graphics.py
+++ b/drizzlepac/haputils/pipeline_graphics.py
@@ -133,7 +133,9 @@ def build_vector_plot(sourceCDS, **plot_dict):
     return p1
 
 
-def generate_summary_plots(fitCDS, output='cal_qa_results.html'):
+def generate_summary_plots(fitCDS, results_columns, 
+                           base_title='Relative Alignment',
+                           output='cal_qa_results.html'):
     """Generate the graphics associated with this particular type of data.
 
     Parameters
@@ -167,64 +169,64 @@ def generate_summary_plots(fitCDS, output='cal_qa_results.html'):
     pipeline_tips = build_tooltips(tooltips_list, hover_columns, list(range(0, len(hover_columns))))
         
     # Data point figures
-    p1 = HAPFigure(title='RMS Values',
+    p1 = HAPFigure(title='{}: RMS Values'.format(base_title),
                    x_label="RMS_X (pixels)",
                    y_label="RMS_Y (pixels)",
                    hover_tips=pipeline_tips)
 
     p1.build_glyph('circle', 
-                   x=RESULTS_COLUMNS[0], 
-                   y=RESULTS_COLUMNS[1],
+                   x=results_columns[0], 
+                   y=results_columns[1],
                    sourceCDS=fitCDS,  
                    glyph_color='colormap',
                    legend_group='inst_det')
 
 
     # Data point figures
-    p2 = HAPFigure(title='Offsets',
+    p2 = HAPFigure(title='{}: Offsets'.format(base_title),
                    x_label="Shift X (pixels)",
                    y_label="Shift Y (pixels)",
                    hover_tips=pipeline_tips)
 
     p2.build_glyph('circle', 
-                   x=RESULTS_COLUMNS[2], 
-                   y=RESULTS_COLUMNS[3],
+                   x=results_columns[2], 
+                   y=results_columns[3],
                    sourceCDS=fitCDS,  
                    glyph_color='colormap',
                    legend_group='inst_det')
 
-    p3 = HAPFigure(title='Rotation',
+    p3 = HAPFigure(title='{}: Rotation'.format(base_title),
                    x_label="Number of matched sources",
                    y_label="Rotation (degrees)",
                    hover_tips=pipeline_tips)
 
     p3.build_glyph('circle', 
-                   x=RESULTS_COLUMNS[8], 
-                   y=RESULTS_COLUMNS[4],
+                   x=results_columns[8], 
+                   y=results_columns[4],
                    sourceCDS=fitCDS,  
                    glyph_color='colormap',
                    legend_group='inst_det')
 
-    p4 = HAPFigure(title='Scale',
+    p4 = HAPFigure(title='{}: Scale'.format(base_title),
                    x_label="Number of matched sources",
                    y_label="Scale",
                    hover_tips=pipeline_tips)
 
     p4.build_glyph('circle', 
-                   x=RESULTS_COLUMNS[8], 
-                   y=RESULTS_COLUMNS[5],
+                   x=results_columns[8], 
+                   y=results_columns[5],
                    sourceCDS=fitCDS,  
                    glyph_color='colormap',
                    legend_group='inst_det')
 
-    p5 = HAPFigure(title='Skew',
+    p5 = HAPFigure(title='{}: Skew'.format(base_title),
                    x_label="Number of matched sources",
                    y_label="Skew (degrees)",
                    hover_tips=pipeline_tips)
 
     p5.build_glyph('circle', 
-                   x=RESULTS_COLUMNS[8], 
-                   y=RESULTS_COLUMNS[9],
+                   x=results_columns[8], 
+                   y=results_columns[9],
                    sourceCDS=fitCDS,  
                    glyph_color='colormap',
                    legend_group='inst_det')
@@ -233,9 +235,11 @@ def generate_summary_plots(fitCDS, output='cal_qa_results.html'):
     save(column(p1.fig, p2.fig, p3.fig, p4.fig, p5.fig))
                      
     return output
-    
+
+
 def generate_relative_residual_plots(residsCDS, filename, rms=(0.,0.),
-                            display_plot=False, output_dir=None, output=''):
+                            display_plot=False, output_dir=None, output='',
+                            title_prefix='Residuals'):
     rootname = '_'.join(filename.split("_")[:-1])
     output = '{}_vectors_{}'.format(rootname, output)
     if output_dir is not None:
@@ -262,7 +266,7 @@ def generate_relative_residual_plots(residsCDS, filename, rms=(0.,0.),
     plot_range = Range1d(-max_range, max_range)
 
     rms_x,rms_y = rms
-    title_start = 'Residuals for {} '.format(filename)
+    title_start = '{} for {} '.format(title_prefix, filename)
     title_rms = 'RMS(X)={:.3f}, RMS(Y)={:.3f}'.format(rms_x, rms_y)
     title_base = '{}[{} sources, {}]'.format(title_start, npoints, title_rms)
 
@@ -337,8 +341,38 @@ def build_astrometry_plots(pandas_file,
                       'residuals.ref_x',
                       'residuals.ref_y']
 
-    fit_data = get_pandas_data(pandas_file, RESULTS_COLUMNS)
+    results_columns = ['fit_results.rms_x',
+                       'fit_results.rms_y',
+                       'fit_results.xsh',
+                       'fit_results.ysh',
+                       'fit_results.rot',
+                       'fit_results.scale',
+                       'fit_results.rot_fit',
+                       'fit_results.scale_fit',
+                       'fit_results.nmatches',
+                       'fit_results.skew']
+
+    gaia_fit_columns = ['gaia_fit_results.rms_x',
+                       'gaia_fit_results.rms_y',
+                       'gaia_fit_results.xsh',
+                       'gaia_fit_results.ysh',
+                       'gaia_fit_results.rot',
+                       'gaia_fit_results.scale',
+                       'gaia_fit_results.rot_fit',
+                       'gaia_fit_results.scale_fit',
+                       'gaia_fit_results.nmatches',
+                       'gaia_fit_results.skew',
+                       'gaia_fit_results.aligned_to']
+
+    gaia_resids_columns = ['gaia_fit_residuals.img_x',
+                           'gaia_fit_residuals.img_y',
+                           'gaia_fit_residuals.ref_x',
+                           'gaia_fit_residuals.ref_y']
+
+    fit_data = get_pandas_data(pandas_file, results_columns)
     resids_data = get_pandas_data(pandas_file, resids_columns)
+    gaia_fit_data = get_pandas_data(pandas_file, gaia_fit_columns)
+    gaia_resids_data = get_pandas_data(pandas_file, gaia_resids_columns)
     
     fitCDS = ColumnDataSource(fit_data)
     residsCDS = ColumnDataSource(resids_data)
@@ -353,7 +387,8 @@ def build_astrometry_plots(pandas_file,
         summary_filename = output
         
     # Generate the astrometric plots
-    astrometry_plot_name = generate_summary_plots(fitCDS, output=summary_filename)
+    relative_plot_name = generate_summary_plots(fitCDS, results_columns,
+                                                output=summary_filename)
     
     resids_plot_names = [relative_plot_name]
 
@@ -398,7 +433,8 @@ def build_astrometry_plots(pandas_file,
         resids_plot_name = generate_relative_residual_plots(gaia_cds, filename, 
                                                    rms=(gaia_rms_x,gaia_rms_y),
                                                    output_dir=output_dir,
-                                                   output=gaia_output)
+                                                   output=gaia_output,
+                                                   title_prefix='Residuals from {}'.format(catalog_name))
         resids_plot_names.append(resids_plot_name)
         
 

--- a/drizzlepac/haputils/pipeline_graphics.py
+++ b/drizzlepac/haputils/pipeline_graphics.py
@@ -342,6 +342,8 @@ def build_astrometry_plots(pandas_file,
     
     fitCDS = ColumnDataSource(fit_data)
     residsCDS = ColumnDataSource(resids_data)
+    gaiafitCDS = ColumnDataSource(gaia_fit_data)
+    gaiaresidsCDS = ColumnDataSource(gaia_resids_data)
     
 
     if output_dir is not None:
@@ -352,9 +354,17 @@ def build_astrometry_plots(pandas_file,
     # Generate the astrometric plots
     astrometry_plot_name = generate_summary_plots(fitCDS, output=summary_filename)
     
-    resids_plot_names = [astrometry_plot_name]
+    resids_plot_names = [relative_plot_name]
 
-    for filename,rootname in zip(fitCDS.data['header.FILENAME'], fitCDS.data['index']):
+    # Generate plots for absolute alignment
+    catalog_name = gaiafitCDS.data[gaia_fit_columns[-1]][0].upper()
+    gaia_title = 'Alignment to {}'.format(catalog_name)
+    absolute_plot_name = generate_summary_plots(gaiafitCDS, gaia_fit_columns,
+                                                base_title=gaia_title,
+                                                  output=summary_filename)
+
+    # Generate residual plots for relative alignment
+    for filename,rootname in zip(fitCDS.data['gen_info.imgname'], fitCDS.data['index']):
         i = residsCDS.data['index'].tolist().index(rootname)
         resids_dict = {'x': residsCDS.data[resids_columns[0]][i],
                        'y': residsCDS.data[resids_columns[1]][i],
@@ -370,6 +380,26 @@ def build_astrometry_plots(pandas_file,
                                                    output_dir=output_dir,
                                                    output=output)
         resids_plot_names.append(resids_plot_name)
+
+    # Generate residual plots for alignment to GAIA
+    for filename,rootname in zip(gaiafitCDS.data['gen_info.imgname'], gaiafitCDS.data['index']):        
+        # Now add plots for fits to GAIA
+        j = gaiaresidsCDS.data['index'].tolist().index(rootname)
+        gaia_resids_dict = {'x': gaiaresidsCDS.data[gaia_resids_columns[0]][i],
+                            'y': gaiaresidsCDS.data[gaia_resids_columns[1]][i],
+                            'xr': gaiaresidsCDS.data[gaia_resids_columns[2]][i],
+                            'yr': gaiaresidsCDS.data[gaia_resids_columns[3]][i]}
+        gaia_cds = ColumnDataSource(gaia_resids_dict)
+
+        gaia_rms_x = float(gaiafitCDS.data[gaia_fit_columns[0]][i])
+        gaia_rms_y = float(gaiafitCDS.data[gaia_fit_columns[1]][i])
+        
+        resids_plot_name = generate_relative_residual_plots(gaia_cds, filename, 
+                                                   rms=(gaia_rms_x,gaia_rms_y),
+                                                   output_dir=output_dir,
+                                                   output=gaia_output)
+        resids_plot_names.append(resids_plot_name)
+        
 
     resids_plot_names = list(filter(lambda a: a != None, resids_plot_names))
     

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -181,7 +181,7 @@ def determine_alignment_residuals(input, files,
     # Check to see whether there were any successful fits...
     align_success = False
     for img in imglist:
-        wcsname = fits.getval(img.meta['filename'], 'wcsname', ext=("sci",1))
+        wcsname = fits.getval(img.meta['filename'], 'wcsname', ext=("sci", 1))
         img.meta['wcsname'] = wcsname
         img.meta['fit_info']['aligned_to'] = imglist[0].meta['filename']
         img.meta['reference_catalog'] = None
@@ -197,10 +197,10 @@ def determine_alignment_residuals(input, files,
         resids = extract_residuals(imglist)
 
         if resids is not None:
-            resids_files = generate_output_files(resids, 
-                                 json_timestamp=json_timestamp, 
-                                 json_time_since_epoch=json_time_since_epoch, 
-                                 exclude_fields=['group_id'])
+            resids_files = generate_output_files(resids,
+                                                 json_timestamp=json_timestamp,
+                                                 json_time_since_epoch=json_time_since_epoch,
+                                                 exclude_fields=['group_id'])
 
     return resids_files
 
@@ -220,15 +220,15 @@ def generate_output_files(resids_dict,
             del resids_dict[image]['fit_results'][field]
         # Define name for output JSON file...
         rootname = image.split("_")[0]
-        json_filename = "{}_cal_qa_astrometry_resids.json".format(rootname)
+        json_filename = "{}_cal_qa_{}.json".format(rootname, json_rootname)
         resids_files.append(json_filename)
-        
+
         # Define output diagnostic object
         diagnostic_obj = du.HapDiagnostic()
-        src_str = "{}.{}".format(__taskname__, calling_name) 
+        src_str = "{}.{}".format(__taskname__, calling_name)
         diagnostic_obj.instantiate_from_fitsfile(image,
-                                               data_source=src_str,
-                                               description="X and Y residuals from \
+                                                 data_source=src_str,
+                                                 description="X and Y residuals from \
                                                             relative alignment ",
                                                timestamp=json_timestamp,
                                                time_since_epoch=json_time_since_epoch)
@@ -261,20 +261,21 @@ def generate_output_files(resids_dict,
                                      )
         diagnostic_obj.add_data_item(resids_dict[image]['sources'], 'residuals',
                                      item_description="Matched source positions from input exposures",
-                                     descriptions={"x":"X position from source image on tangent plane",
-                                                   "y":"Y position from source image on tangent plane",
-                                                   "ref_x":"X position from ref image on tangent plane",
-                                                   "ref_y":"Y position from ref image on tangent plane"},
-                                     units={'x':'pixels',
-                                            'y':'pixels',
-                                            'ref_x':'pixels',
-                                            'ref_y':'pixels'}
+                                     descriptions={"x": "X position from source image on tangent plane",
+                                                   "y": "Y position from source image on tangent plane",
+                                                   "ref_x": "X position from ref image on tangent plane",
+                                                   "ref_y": "Y position from ref image on tangent plane"},
+                                     units={'x': 'pixels',
+                                            'y': 'pixels',
+                                            'ref_x': 'pixels',
+                                            'ref_y': 'pixels'}
                                      )
 
         diagnostic_obj.write_json_file(json_filename)
         log.info("Generated relative astrometric residuals for {} as:\n    {}.".format(image, json_filename))
 
     return resids_files
+
 
 def extract_residuals(imglist):
     """Convert fit results and catalogs from tweakwcs into list of residuals"""
@@ -304,8 +305,8 @@ def extract_residuals(imglist):
         if group_id not in group_dict:
             group_dict[group_name] = {}
             group_dict[group_name]['fit_results'] = {'group_id': group_id,
-                         'rms_x': None, 'rms_y': None, 'wcsname': wcsname}
-            group_dict[group_name]['sources'] = Table(names=['x', 'y', 
+                                                     'rms_x': None, 'rms_y': None, 'wcsname': wcsname}
+            group_dict[group_name]['sources'] = Table(names=['x', 'y',
                                                              'ref_x', 'ref_y'])
             cum_indx = 0
 
@@ -318,33 +319,33 @@ def extract_residuals(imglist):
             img_indx = fitinfo['matched_input_idx'][img_mask]
             # Extract X, Y for sources image being updated
             img_x, img_y, max_indx, chip_mask = get_tangent_positions(chip, img_indx,
-                                                           start_indx=cum_indx)
+                                                                      start_indx=cum_indx)
             cum_indx += max_indx
             
             # Extract X, Y for sources from reference image
             ref_x, ref_y = chip.world_to_tanp(ref_ra[ref_indx][chip_mask], ref_dec[ref_indx][chip_mask])
             group_dict[group_name]['fit_results'].update(
                  {'xsh': fitinfo['shift'][0], 'ysh': fitinfo['shift'][1],
-                 'rot': fitinfo['<rot>'], 'scale': fitinfo['<scale>'],
-                 'rot_fit': fitinfo['rot'], 'scale_fit': fitinfo['scale'],
-                 'nmatches': fitinfo['nmatches'], 'skew': fitinfo['skew'],
-                 'rms_x': sigma_clipped_stats((img_x - ref_x))[-1],
-                 'rms_y': sigma_clipped_stats((img_y - ref_y))[-1]})
+                  'rot': fitinfo['<rot>'], 'scale': fitinfo['<scale>'],
+                  'rot_fit': fitinfo['rot'], 'scale_fit': fitinfo['scale'],
+                  'nmatches': fitinfo['nmatches'], 'skew': fitinfo['skew'],
+                  'rms_x': sigma_clipped_stats((img_x - ref_x))[-1],
+                  'rms_y': sigma_clipped_stats((img_y - ref_y))[-1]})
 
-            new_vals = Table(data=[img_x, img_y, ref_x, ref_y], 
-                                    names=['x', 'y', 'ref_x', 'ref_y'])
+            new_vals = Table(data=[img_x, img_y, ref_x, ref_y],
+                             names=['x', 'y', 'ref_x', 'ref_y'])
             group_dict[group_name]['sources'] = vstack([group_dict[group_name]['sources'], new_vals])
-            
-        else: 
+
+        else:
             group_dict[group_name]['fit_results'].update(
                      {'xsh': None, 'ysh': None,
-                     'rot': None, 'scale': None,
-                     'rot_fit': None, 'scale_fit': None,
-                     'nmatches': -1, 'skew': None,
-                     'rms_x': -1, 'rms_y': -1})
-
+                      'rot': None, 'scale': None,
+                      'rot_fit': None, 'scale_fit': None,
+                      'nmatches': -1, 'skew': None,
+                      'rms_x': -1, 'rms_y': -1})
 
     return group_dict
+
 
 def get_tangent_positions(chip, indices, start_indx=0):
     img_x = []
@@ -369,21 +370,21 @@ def get_tangent_positions(chip, indices, start_indx=0):
 # Compare source list with GAIA ref catalog
 def match_to_gaia(imcat, refcat, product, output, searchrad=5.0):
     """Create a catalog with sources matched to GAIA sources
-    
+
     Parameters
     ----------
     imcat : str or obj
         Filename or astropy.Table of source catalog written out as ECSV file
-        
+
     refcat : str
         Filename of GAIA catalog files written out as ECSV file
-        
+
     product : str
         Filename of drizzled product used to derive the source catalog
-        
+
     output : str
-        Rootname for matched catalog file to be written as an ECSV file 
-    
+        Rootname for matched catalog file to be written as an ECSV file
+
     """
     if isinstance(imcat, str):
         imtab = Table.read(imcat, format='ascii.ecsv')
@@ -394,20 +395,19 @@ def match_to_gaia(imcat, refcat, product, output, searchrad=5.0):
         if 'X-Center' in imtab.colnames:
             imtab.rename_column('X-Center', 'x')
             imtab.rename_column('Y-Center', 'y')
-            
-    
+
     reftab = Table.read(refcat, format='ascii.ecsv')
-    
+
     # define WCS for matching
     tpwcs = tweakwcs.FITSWCS(HSTWCS(product, ext=1))
-    
+
     # define matching parameters
     tpmatch = tweakwcs.TPMatch(searchrad=searchrad)
-    
+
     # perform match
     ref_indx, im_indx = tpmatch(reftab, imtab, tpwcs)
     print('Found {} matches'.format(len(ref_indx)))
-    
+
     # Obtain tangent plane positions for both image sources and reference sources
     im_x, im_y = tpwcs.det_to_tanp(imtab['x'][im_indx], imtab['y'][im_indx])
     ref_x, ref_y = tpwcs.world_to_tanp(reftab['RA'][ref_indx], reftab['DEC'][ref_indx])
@@ -416,24 +416,83 @@ def match_to_gaia(imcat, refcat, product, output, searchrad=5.0):
     else:
         im_ra = imtab['RA'][im_indx]
         im_dec = imtab['DEC'][im_indx]
-        
 
     # Compile match table
-    match_tab = Table(data=[im_x, im_y, im_ra, im_dec, 
-                            ref_x, ref_y, 
+    match_tab = Table(data=[im_x, im_y, im_ra, im_dec,
+                            ref_x, ref_y,
                             reftab['RA'][ref_indx], reftab['DEC'][ref_indx]],
-                      names=['img_x','img_y', 'img_RA', 'img_DEC', 
+                      names=['img_x', 'img_y', 'img_RA', 'img_DEC',
                              'ref_x', 'ref_y', 'ref_RA', 'ref_DEC'])
     if not output.endswith('.ecsv'):
-        output = '{}.ecsv'.format(output)                             
+        output = '{}.ecsv'.format(output)
     match_tab.write(output, format='ascii.ecsv')
+
+
+def determine_gaia_residuals(fit_catalogs,
+                             json_timestamp=None, 
+                             json_time_since_epoch=None,
+                             log_level=logutil.logging.NOTSET):
+    # Report on the results of the actual alignment fit used for defining the
+    # final WCS
+    catname = fit_catalogs.selected_fit[0].meta['fit_info']['catalog']
+    gaia_cat = fit_catalogs.reference_catalogs[catname]
+
+    selected_fit = fit_catalogs.selected_fit
+    resids = {}
     
-                       
+    for img in selected_fit:
+        # The same fits is reported for each chip in a multi-chip image
+        if img in resids:
+            continue
+        # Get the resids
+        fitinfo = img.meta['fit_info']
+        ref_indx = fitinfo['matched_ref_idx']
+        imgname = img.meta['filename']
+        resids[imgname] = {}
+                # store results in dict
+        resids[imgname]['fit_results'] = {'aligned_to': catname,
+                                         'wcsname': "",
+                                         'group_id': img.meta['group_id']}
+
+        # Obtain tangent plane positions for both image sources and reference sources
+        img_x, img_y = img.world_to_tanp(fitinfo['fit_RA'], fitinfo['fit_DEC'])
+        ref_x, ref_y = img.world_to_tanp(gaia_cat['RA'][ref_indx], 
+                                             gaia_cat['DEC'][ref_indx])
+
+        # Compile match table
+        match_tab = Table(data=[img_x, img_y,
+                                fitinfo['fit_RA'], fitinfo['fit_DEC'],
+                                ref_x, ref_y,
+                                gaia_cat['RA'][ref_indx], gaia_cat['DEC'][ref_indx]],
+                          names=['img_x', 'img_y', 'img_RA', 'img_DEC',
+                                 'ref_x', 'ref_y', 'ref_RA', 'ref_DEC'])
+
+        resids[imgname]['fit_results'].update(
+             {'xsh': fitinfo['shift'][0], 'ysh': fitinfo['shift'][1],
+              'rot': fitinfo['<rot>'], 'scale': fitinfo['<scale>'],
+              'rot_fit': fitinfo['rot'], 'scale_fit': fitinfo['scale'],
+              'nmatches': fitinfo['nmatches'], 'skew': fitinfo['skew'],
+              'rms_x': sigma_clipped_stats((img_x - ref_x))[-1],
+              'rms_y': sigma_clipped_stats((img_y - ref_y))[-1]})
+
+        resids[imgname]['sources'] = match_tab
+
+    if resids:
+        descrip = 'Fit results for absolute alignment of input exposures to {}'.format(catname)
+        resids_files = generate_output_files(resids,
+                                           json_timestamp=json_timestamp,
+                                           json_time_since_epoch=json_time_since_epoch,
+                                           exclude_fields=['group_id'],
+                                           calling_name='determine_gaia_residuals',
+                                           json_rootname='gaia_fit_resids',
+                                           section_name='gaia_fit_results',
+                                           section_description=descrip)
+    return resids_files
 
 
 # -------------------------------------------------------------------------------
 # Simple interface for running all the analysis functions defined for this package
-def run_all(input, files, log_level=logutil.logging.NOTSET):
+def run_all(input, files, catalogs=None, log_level=logutil.logging.NOTSET):
 
     # generate a timestamp values that will be used to make creation time, creation date and epoch values
     # common to each json file
@@ -450,12 +509,7 @@ def run_all(input, files, log_level=logutil.logging.NOTSET):
                                               json_time_since_epoch=json_time_since_epoch,
                                               log_level=log_level)
     if catalogs is not None:
-        if 'GAIADR2' in catalogs.reference_catalogs:
-            gaia_cat = catalogs.reference_catalogs['GAIADR2']
-        else:            
-            gaia_cat = catalogs.reference_catalogs['GAIADR1']
-            
-        gaia_files = determine_gaia_residuals(input, files, gaia_cat,
+        gaia_files = determine_gaia_residuals(catalogs,
                                              json_timestamp=json_timestamp,
                                              json_time_since_epoch=json_time_since_epoch,
                                              log_level=log_level)

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -211,7 +211,8 @@ def generate_output_files(resids_dict,
                          calling_name='determine_alignment_residuals',
                          json_rootname='astrometry_resids',
                          section_name='fit_results',
-                         section_description='Fit results for relative alignment of input exposures'):
+                         section_description='Fit results for relative alignment of input exposures',
+                         resids_name='residuals'):
     """Write out results to JSON files, one per image"""
     resids_files = []
     for image in resids_dict:
@@ -259,7 +260,7 @@ def generate_output_files(resids_dict,
                                             'skew':'unitless',
                                             'wcsname':"unitless"}
                                      )
-        diagnostic_obj.add_data_item(resids_dict[image]['sources'], 'residuals',
+        diagnostic_obj.add_data_item(resids_dict[image]['sources'], resids_name,
                                      item_description="Matched source positions from input exposures",
                                      descriptions={"x": "X position from source image on tangent plane",
                                                    "y": "Y position from source image on tangent plane",
@@ -486,7 +487,8 @@ def determine_gaia_residuals(fit_catalogs,
                                            calling_name='determine_gaia_residuals',
                                            json_rootname='gaia_fit_resids',
                                            section_name='gaia_fit_results',
-                                           section_description=descrip)
+                                           section_description=descrip,
+                                           resids_name='gaia_fit_residuals')
     return resids_files
 
 

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -41,7 +41,6 @@ function myFunction() {
 
 
 """
-import json
 import sys
 from datetime import datetime
 import time

--- a/drizzlepac/haputils/testutils.py
+++ b/drizzlepac/haputils/testutils.py
@@ -65,7 +65,8 @@ def compare_wcs_alignment(dataset, force=False):
     try:
         # Step 1:
         #   Determine alignment for pipeline-defined WCS
-        results = align.perform_align([dataset], clobber=force, debug=True)
+        align_table = align.perform_align([dataset], clobber=force, debug=True)
+        results = align_table.filtered_table
         if not results:
             msg = "No valid exposures found for {}.".format(dataset)
             msg += "\n            Please check that input was either a valid ASN"
@@ -114,7 +115,8 @@ def compare_wcs_alignment(dataset, force=False):
                                                      archive=False, force=True)
         
             print("[testutils] Aligning: {} for WCSNAME: {}".format(dataset, wcs))
-            results = align.perform_align([dataset], clobber=False, debug=True)
+            align_table = align.perform_align([dataset], clobber=False, debug=True)
+            results = align_table.filtered_table
             alignment[wcs] = extract_results(results)
 
     finally:

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -450,10 +450,11 @@ class OutputImage:
             # Add primary header to output file...
             fo.append(hdu)
 
-            # remove all alternate WCS solutions from headers of this product
-            logutil.logging.disable(logutil.logging.INFO)
-            wcs_functions.removeAllAltWCS(fo,wcs_ext)
-            logutil.logging.disable(logutil.logging.NOTSET)
+            if not self.blot:
+                # remove all alternate WCS solutions from headers of this product
+                logutil.logging.disable(logutil.logging.INFO)
+                wcs_functions.removeAllAltWCS(fo,wcs_ext)
+                logutil.logging.disable(logutil.logging.NOTSET)
 
             # add table of combined header keyword values to FITS file
             if newtab is not None:

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -430,7 +430,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
 
         if align_with_apriori or force_alignment or align_to_gaia:
             # Generate initial default products and perform verification
-            align_dicts = verify_alignment(_inlist,
+            align_dicts, align_table = verify_alignment(_inlist,
                                              _calfiles, _calfiles_flc,
                                              _trlfile,
                                              tmpdir=None, debug=debug,
@@ -475,7 +475,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 tmpname = "_".join([_trlroot, 'apriori'])
                 sub_dirs.append(tmpname)
                 # Generate initial default products and perform verification
-                align_apriori = verify_alignment(_inlist,
+                align_apriori, apriori_table = verify_alignment(_inlist,
                                                  _calfiles, _calfiles_flc,
                                                  _trlfile,
                                                  tmpdir=tmpname, debug=debug,
@@ -530,7 +530,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 find_crs = False
             tmpname = "_".join([_trlroot, 'aposteriori'])
             sub_dirs.append(tmpname)
-            align_aposteriori = verify_alignment(_inlist,
+            align_aposteriori, aposteriori_table = verify_alignment(_inlist,
                                              _calfiles, _calfiles_flc,
                                              _trlfile,
                                              tmpdir=tmpname, debug=debug,
@@ -677,13 +677,10 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     qa_switch = _get_envvar_switch(envvar_qa_stats_name)
 
     if qa_switch:
-        alignment_table = None
-        if align_to_gaia and align_aposteriori:
-            # Get the copy of the source catalogs used for alignment
-            alignment_table = align_aposteriori['alignment_table'].copy()
+
         # Generate quality statistics for astrometry if specified
         calfiles = _calfiles_flc if _calfiles_flc else _calfiles
-        qa.run_all(inFile, calfiles, catalogs=alignment_table)
+        qa.run_all(inFile, calfiles, catalogs=aposteriori_table)
 
 
 def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignment=True,
@@ -828,6 +825,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
         print("Invalid alignment mode {} requested.".format(tmpdir))
         raise ValueError
 
+    full_table = None
     fraction_matched = 1.0
     num_sources = -1
     try:
@@ -997,7 +995,6 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
             prodname = align_focus['prodname']
         else:
             fd = amutils.FOCUS_DICT.copy()
-            fd['alignment_table'] = full_table
             fd['expnames'] = calfiles
             fd['prodname'] = drz_products[0]
             alignment_verified = True
@@ -1049,7 +1046,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
             # Return to main processing dir
             os.chdir(parent_dir)
 
-    return focus_dicts
+    return focus_dicts, full_table
 
 def apply_headerlet(filename, headerlet_file, flcfile=None):
     

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -812,7 +812,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
         del ivmlist
         # If there are no products to be generated, there is nothing to align...
         if asndict is None:
-            return None
+            return None, None
 
     # if tmpdir is turned off (== None), tmpname set to 'default-pipeline'
     tmpname = tmpdir if tmpdir else 'default-pipeline'
@@ -898,7 +898,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                         trlmsg += trlstr.format(row['imageName'])
                         print(trlmsg)
                         _updateTrlFile(trlfile, trlmsg)
-                        return None
+                        return None, None
             except Exception as err:
                 # Something went wrong with alignment to GAIA, so report this in
                 # trailer file
@@ -910,7 +910,7 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                     traceback.print_exc()
                 else:
                     print("WARNING: {}".format(err))
-                return None
+                return None, None
 
             _updateTrlFile(trlfile, trlmsg)
             # Write the perform_align log to the trailer file...(this will delete the _alignlog)


### PR DESCRIPTION
The comparison of the dataset's point-sources to the absolute astrometry reference sources from the GAIA catalogs can provide another measure of the quality of the pipeline processing.  These changes add those residuals to the set of Q&A JSON files that can be generated for pipeline processed datasets.   The comparison implemented here relies on the cross-matching of the point sources actually used for the pipeline alignment with the GAIA reference sources. 

This work addresses [Jira ticket HLA-369](https://jira.stsci.edu/browse/HLA-369). 