### PR TITLE
Fix problems identified in Build 2020.4 testing 

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -209,11 +209,20 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
 
     """
     log.info("*** HAP PIPELINE Processing Version {!s} ({!s}) started at: {!s} ***\n".format(__version__, __version_date__, util._ptime()[0]))
+
+    if debug:
+        loglevel = logutil.logging.DEBUG
+    else:
+        loglevel = logutil.logging.INFO
+
     if runfile is not None:
+        loglevel = logutil.logging.DEBUG
         fh = logutil.logging.FileHandler(runfile)
-        fh.setLevel(logutil.logging.DEBUG)
+        fh.setLevel(loglevel)
         log.addHandler(fh)
         
+    log.setLevel(loglevel)
+    
     # 0: print git info
     if print_git_info:
         log.info("{} STEP 0: Display Git revision info  {}".format("-" * 20, "-" * 49))
@@ -252,7 +261,8 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
     
     try:
         # Instantiate AlignmentTable class with these input files
-        alignment_table = align_utils.AlignmentTable(imglist, **alignment_pars)
+        alignment_table = align_utils.AlignmentTable(imglist, log_level=loglevel,
+                                                     **alignment_pars)
         if alignment_table.process_list is None:
             log.warning("NO viable images to align.") 
             alignment_table.close()

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -538,9 +538,10 @@ def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
             kernel_wht = whtarr[kernel_pos[0] - wht_box:kernel_pos[0] + wht_box + 1,
                             kernel_pos[1] - wht_box:kernel_pos[1] + wht_box + 1].copy()
 
+            minsize = min(kernel.shape)
             # search square cut-out (of size 2 x wht_box + 1 pixels on a side) of weight image centered on peak coords for
             # zero-value pixels. Reject peak if any are found.
-            if len(np.where(kernel_wht == 0.)[0]) == 0:
+            if len(np.where(kernel_wht == 0.)[0]) == 0 and minsize > 11:
                 log.debug("Kernel source PSF located at [{},{}]".format(kernel_pos[1], kernel_pos[0]))
             else:
                 kernel = None
@@ -1508,8 +1509,10 @@ def build_wcscat(image, group_id, source_catalog):
     numsci = countExtn(hdulist)
     for chip in range(1, numsci + 1):
         w = wcsutil.HSTWCS(hdulist, ('SCI', chip))
+        imcat = None
+        if source_catalog:
+            imcat = source_catalog[chip]
 
-        imcat = source_catalog[chip]
         # rename xcentroid/ycentroid columns, if necessary, to be consistent with tweakwcs
         if imcat is None:
             imcat = Table(names=['xcentroid','ycentroid','mag'])

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -877,10 +877,10 @@ def verify_alignment(inlist, calfiles, calfiles_flc, trlfile,
                 full_table = align.perform_align(alignfiles, update_hdr_wcs=True, runfile=alignlog,
                                                   clobber=False, output=debug,
                                                   debug=debug, sat_flags=sat_flags)
-                align_table = full_table.filtered_table
-
-                if align_table is None:
+                if full_table is None:
                     raise Exception("No successful aposteriori fit determined.")
+
+                align_table = full_table.filtered_table
 
                 num_sources = align_table['matchSources'][0]
                 fraction_matched = num_sources / align_table['catalogSources'][0]


### PR DESCRIPTION
Data with some extreme fields-of-view or extreme problems exposed failures in some of the error handling with the alignment code.  These problems were seen in datasets ibm503tnq, idn110010, and idw101090.  The problems which were corrected were:

- failure to recognize when no sources were found while running 'build_auto_kernel'
- an empty entry is now always provided for all input files when configuring the fit in AlignmentTable
- the extracted PSF to be measured by 'find_fwhm' is checked to have a minimum size to allow 'find_fwhm' to not throw an Exception
- failure to find an aposteriori solution in runastrodriz gets caught with a check for None before trying to interpret the returned results

In addition, logging configuration for AlignmentTable was passed in and used to expand the log messages generated and saved during processing.
