### PR TITLE
Fix runastrodriz errors

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -404,7 +404,7 @@ def perform_align(input_list, archive=False, clobber=False, debug=False, update_
                         delta_dt = (current_dt - starting_dt).total_seconds()
                         log.info('Processing time of [STEP 5]: {} sec'.format(delta_dt))
                         alignment_table.close()
-                        return (alignment_table.filtered_table)
+                        return alignment_table
                 else:
                     log.info("{} Cross matching and "
                          "fitting {}".format("-" * 20, "-" * 47))

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -513,6 +513,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                     _trlmsg += 'A priori alignment FAILED! No a priori astrometry correction applied.\n'
             _updateTrlFile(_trlfile, _trlmsg)
 
+        aposteriori_table=None
         if align_to_gaia:
             _trlmsg = _timestamp('Starting a posteriori alignment')
             _trlmsg += __trlmarker__
@@ -676,7 +677,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     # interpret envvar variable, if specified
     qa_switch = _get_envvar_switch(envvar_qa_stats_name)
 
-    if qa_switch:
+    if qa_switch and dcorr == 'PERFORM':
 
         # Generate quality statistics for astrometry if specified
         calfiles = _calfiles_flc if _calfiles_flc else _calfiles


### PR DESCRIPTION
Some datasets do not get drizzled while other datasets do not result in successful aposteriori solutions, and both were causing runastrodriz to throw an Exception during processing.  The code has been updated with:

- update to align to return the full alignment table upon errors (this was already happening for most error cases, but somehow this slipped through).
- update logic to only run QA test results when DRIZCORR was turned on to avoid trying to generate test results for data with no valid measurable sources.  

These address the error cases encountered in astrometry testing on 2020-07-24.