### PR TITLE
Fix SVM GAIA catalog bugs

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -195,7 +195,7 @@ def create_astrometric_catalog(inputs, catalog="GAIADR2", output="ref_cat.ecsv",
                                catalog=catalog)
 
     # weed out sources which are not accurate (no proper motions in catalog)
-    if epoch and hasattr(ref_table, 'mask'):
+    if epoch and hasattr(ref_table, 'mask'):  # and 'pmra' in ref_table.colnames:
         ref_table = ref_table[~ref_table['pmra'].mask]
         
     colnames = ('ra', 'dec', 'mag', 'objID')

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -195,8 +195,8 @@ def create_astrometric_catalog(inputs, catalog="GAIADR2", output="ref_cat.ecsv",
                                catalog=catalog)
 
     # weed out sources which are not accurate (no proper motions in catalog)
-    if epoch and hasattr(ref_table, 'mask'):  # and 'pmra' in ref_table.colnames:
-        ref_table = ref_table[~ref_table['pmra'].mask]
+    if epoch and hasattr(ref_table, 'mask') and 'pmra' in ref_table.colnames:
+        ref_table = ref_table[~ref_table.mask['pmra']]
         
     colnames = ('ra', 'dec', 'mag', 'objID')
     if not full_catalog:

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -2,7 +2,6 @@ import os
 import shutil
 
 from matplotlib import pyplot as plt
-from scipy import ndimage
 from scipy.ndimage import morphology
 import numpy as np
 import astropy
@@ -29,8 +28,6 @@ PCELL_STRLEN = 4
 SKYCELL_NAME_FMT = f"skycell-p{{:{str(PCELL_STRLEN).zfill(2)}d}}x{{:02d}}y{{:02d}}"
 SKYCELL_NXY = 50
 SKYCELL_OVERLAP = 256
-
-NDIMAGE_STRUCT2 = ndimage.generate_binary_structure(2, 2)
 
 
 def get_sky_cells(visit_input, input_path=None, scale=None, cell_size=None):

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1019,9 +1019,12 @@ def generate_gaia_catalog(hap_obj, columns_to_remove=None):
     # generate catalog of GAIA sources
     gaia_table = au.create_astrometric_catalog(img_list, gaia_only=True, use_footprint=True)
 
-    # trim off specified columns
+    # trim off specified columns, but 
+    #    only if the specified columns already exist in the table
+    #
     if columns_to_remove:
-        gaia_table.remove_columns(columns_to_remove)
+        existing_cols = [col for col in columns_to_remove if col in gaia_table.colnames]
+        gaia_table.remove_columns(existing_cols)
 
     # remove sources outside image footprint
     outwcs = wcsutil.HSTWCS(hap_obj.drizzle_filename, ext=1)


### PR DESCRIPTION
This set of changes resolves a couple of bugs identified during SVM testing; namely,

- only remove columns from astrometric catalog if specified columns are found in the table to start with
- only apply mask for 'pmra' column if 'pmra' column exists

These errors almost entirely affect use of EPOCH when obtaining the GAIA catalog from the web-service.