### PR TITLE
Only try to generate QA JSONs for data with sources

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -194,10 +194,13 @@ def create_astrometric_catalog(inputs, catalog="GAIADR2", output="ref_cat.ecsv",
                                epoch=epoch,
                                catalog=catalog)
 
+    if not ref_table:
+        return ref_table
+
     # weed out sources which are not accurate (no proper motions in catalog)
     if epoch and hasattr(ref_table, 'mask') and 'pmra' in ref_table.colnames:
         ref_table = ref_table[~ref_table.mask['pmra']]
-        
+    
     colnames = ('ra', 'dec', 'mag', 'objID')
     if not full_catalog:
         ref_table = ref_table[colnames]

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -503,9 +503,10 @@ def run_all(input, files, catalogs=None, log_level=logutil.logging.NOTSET):
     json_timestamp = datetime.now().strftime("%m/%d/%YT%H:%M:%S")
     json_time_since_epoch = time.time()
 
-    good_files = [f for f in files if f in catalogs.extracted_sources]
+    good_files = files
     src_catalogs = None
     if catalogs is not None:
+        good_files = [f for f in files if f in catalogs.extracted_sources]
         src_catalogs = [catalogs.extracted_sources[f] for f in good_files]
         
     json_files = determine_alignment_residuals(input, good_files,

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -503,11 +503,12 @@ def run_all(input, files, catalogs=None, log_level=logutil.logging.NOTSET):
     json_timestamp = datetime.now().strftime("%m/%d/%YT%H:%M:%S")
     json_time_since_epoch = time.time()
 
+    good_files = [f for f in files if f in catalogs.extracted_sources]
     src_catalogs = None
     if catalogs is not None:
-        src_catalogs = [catalogs.extracted_sources[f] for f in files]
+        src_catalogs = [catalogs.extracted_sources[f] for f in good_files]
         
-    json_files = determine_alignment_residuals(input, files,
+    json_files = determine_alignment_residuals(input, good_files,
                                               catalogs=src_catalogs,
                                               json_timestamp=json_timestamp,
                                               json_time_since_epoch=json_time_since_epoch,

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1019,21 +1019,22 @@ def generate_gaia_catalog(hap_obj, columns_to_remove=None):
     # generate catalog of GAIA sources
     gaia_table = au.create_astrometric_catalog(img_list, gaia_only=True, use_footprint=True)
 
-    # trim off specified columns, but 
-    #    only if the specified columns already exist in the table
-    #
-    if columns_to_remove:
-        existing_cols = [col for col in columns_to_remove if col in gaia_table.colnames]
-        gaia_table.remove_columns(existing_cols)
+    if len(gaia_table) > 0:
+        # trim off specified columns, but 
+        #    only if the specified columns already exist in the table
+        #
+        if columns_to_remove:
+            existing_cols = [col for col in columns_to_remove if col in gaia_table.colnames]
+            gaia_table.remove_columns(existing_cols)
 
-    # remove sources outside image footprint
-    outwcs = wcsutil.HSTWCS(hap_obj.drizzle_filename, ext=1)
-    x, y = outwcs.all_world2pix(gaia_table['RA'], gaia_table['DEC'], 1)
-    imghdu = fits.open(hap_obj.drizzle_filename)
-    in_img_data = imghdu['WHT'].data.copy()
-    in_img_data = np.where(in_img_data == 0, np.nan, in_img_data)
-    mask = au.within_footprint(in_img_data, outwcs, x, y)
-    gaia_table = gaia_table[mask]
+        # remove sources outside image footprint
+        outwcs = wcsutil.HSTWCS(hap_obj.drizzle_filename, ext=1)
+        x, y = outwcs.all_world2pix(gaia_table['RA'], gaia_table['DEC'], 1)
+        imghdu = fits.open(hap_obj.drizzle_filename)
+        in_img_data = imghdu['WHT'].data.copy()
+        in_img_data = np.where(in_img_data == 0, np.nan, in_img_data)
+        mask = au.within_footprint(in_img_data, outwcs, x, y)
+        gaia_table = gaia_table[mask]
 
     # Report results to log
     if len(gaia_table) == 0:


### PR DESCRIPTION
These changes address issues identified during DSB regression testing when using the QA code with the astrometry/pipeline processing.  This change only tries to generate QA results (JSON files) for input exposures that actually had identifiable sources useful for alignment, since the code now relies on the pipeline processing results for the inputs data for the QA results.  