### PR TITLE
Update pipeline graphics to only plot valid data

### DIFF
--- a/drizzlepac/haputils/pipeline_graphics.py
+++ b/drizzlepac/haputils/pipeline_graphics.py
@@ -406,6 +406,9 @@ def build_astrometry_plots(pandas_file,
                        'y': residsCDS.data[resids_columns[1]][i],
                        'xr': residsCDS.data[resids_columns[2]][i],
                        'yr': residsCDS.data[resids_columns[3]][i]}
+        
+        if np.isnan(resids_dict['x']).all():
+            continue
         cds = ColumnDataSource(resids_dict)
 
         rms_x = float(fitCDS.data[RESULTS_COLUMNS[0]][i])
@@ -425,6 +428,8 @@ def build_astrometry_plots(pandas_file,
                             'y': gaiaresidsCDS.data[gaia_resids_columns[1]][i],
                             'xr': gaiaresidsCDS.data[gaia_resids_columns[2]][i],
                             'yr': gaiaresidsCDS.data[gaia_resids_columns[3]][i]}
+        if np.isnan(gaia_resids_dict['x']).all():
+            continue
         gaia_cds = ColumnDataSource(gaia_resids_dict)
 
         gaia_rms_x = float(gaiafitCDS.data[gaia_fit_columns[0]][i])


### PR DESCRIPTION
Interpretation of the JSON files can sometimes involve reading in data for images where there were no matching or cross-matched sources.  In those cases, the pipeline graphics code should simply skip over those exposures data to avoid throwing an Exception, which is what gets done in these changes to the plotting logic.  