### PR TITLE
Fix logic for SVM with multiple detectors and possiblity of detection of no sources

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -102,6 +102,9 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
     phot_mode = phot_mode.lower()
     input_phot_mode = phot_mode
     for total_product_obj in total_obj_list:
+        # Make sure this is re-initialized for the new total product
+        phot_mode = input_phot_mode
+
         # Instantiate filter catalog product object
         total_product_catalogs = HAPCatalogs(total_product_obj.drizzle_filename,
                                              total_product_obj.configobj_pars.get_pars('catalog generation'),

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -974,6 +974,13 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                               source_box=self._size_source_box,
                                                               mask=mask)
 
+            # Check if custom_segm_image is None indicating there are no detectable sources in the 
+            # total detection image.  If value is None, a warning has already been issued.  Issue
+            # a final message and return.
+            if custom_segm_img is None:
+                log.warning("End processing for the Segmentation Catalog due to no sources detected with Custom or Gaussian kernel.")
+                return None
+
             # Determine if the input image is actually a crowded field or contains large islands based upon
             # characteristics of the segmentation image.  If either of these are true, it would be better
             # to use the RickerWavelet2DKernel to identify sources.  The deblended segmentation image and
@@ -1011,6 +1018,13 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                                 filter_kernel=rw2d_kernel,
                                                                 source_box=self._size_source_box,
                                                                 mask=mask)
+
+                # Check if rw2d_segm_image is None indicating there are no detectable sources in the 
+                # total detection image.  If value is None, a warning has already been issued.  Issue
+                # a final message and return.
+                if rw2d_segm_img is None:
+                    log.warning("End processing for the Segmentation Catalog due to no sources detected with RickerWavelet Kernel.")
+                    return None
 
                 # Evaluate the new segmention image for completeness
                 self.is_big_island = False

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -979,7 +979,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # a final message and return.
             if custom_segm_img is None:
                 log.warning("End processing for the Segmentation Catalog due to no sources detected with Custom or Gaussian kernel.")
-                return None
+                return
 
             # Determine if the input image is actually a crowded field or contains large islands based upon
             # characteristics of the segmentation image.  If either of these are true, it would be better
@@ -1024,7 +1024,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 # a final message and return.
                 if rw2d_segm_img is None:
                     log.warning("End processing for the Segmentation Catalog due to no sources detected with RickerWavelet Kernel.")
-                    return None
+                    return
 
                 # Evaluate the new segmention image for completeness
                 self.is_big_island = False


### PR DESCRIPTION
- Ensure the phot_mode variable is reset to its input setting for every total product
  being processed.  The phot_mode can be modified during processing if one of the
  source detection algorithms does not find any sources.
- Bubble up the stack the "no sources detected" warning for the segmentation algorithm
  and return to the invoking algorithm.