### PR TITLE
Handle empty images in alignment

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -731,6 +731,11 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
     segm = detect_sources(imgarr, segment_threshold, npixels=source_box,
                           filter_kernel=kernel, connectivity=4)
 
+    # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0
+    if segm is None or segm.nlabels == 0:
+        log.info("No detected sources!")
+        return None, None
+
     log.debug("Creating segmentation map for {} ".format(outroot))
     if kernel is not None:
         kernel_area = ((kernel.shape[0] // 2) ** 2) * np.pi
@@ -756,11 +761,6 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         log.info("Looking for crowded sources using smaller kernel with shape: {}".format(kernel.shape))
         segm = detect_sources(imgarr, segment_threshold, npixels=source_box,
                             filter_kernel=kernel)
-
-    # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0
-    if segm is None or segm.nlabels == 0:
-        log.info("No detected sources!")
-        return None, None
 
     if deblend:
         segm = deblend_sources(imgarr, segm, npixels=5,

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1705,10 +1705,16 @@ class HAPSegmentCatalog(HAPCatalogBase):
             True/False value indicating if the largest source or the total combination of
             all detected sources took up an abnormally high portion of the image (aka 'big islands').
         """
-        # segm_img is a SegmentationImage
-        nbins = segm_img.max_label
+
         log.info("")
         log.info("Analyzing segmentation image.")
+
+        if segm_img is None:
+            log.info("Segmentation image is blank.")
+            return False
+
+        # segm_img is a SegmentationImage
+        nbins = segm_img.max_label
         log.info("Number of sources from segmentation map: %d", nbins)
 
         if nbins == 0:


### PR DESCRIPTION
SVM testing on 2020-08-13 revealed problems with dealing with blank images during alignment as noted in [Jira Ticket HLA-404](https://jira.stsci.edu/browse/HLA-404).  These changes address the issues identified with  single visit dataset 'ib2t06' by recognizing blank images before trying to interpret segmentation of the image in 'astrometric_utils' and 'catalog_utils'.  

This will close #767 when merged.