### PR TITLE
Get QA to not crash with blank images

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -194,13 +194,14 @@ class AlignmentTable:
 
         self.imglist = []
         for group_id, image in enumerate(self.process_list):
-            img = amutils.build_wcscat(image, group_id,
-                                       self.extracted_sources[image])
-            # add the name of the image to the imglist object
-            for im in img:
-            #    im.meta['name'] = image
-                log.debug('im.meta[name] = {}'.format(im.meta['name']))
-            self.imglist.extend(img)
+            if image in self.extracted_sources:
+                img = amutils.build_wcscat(image, group_id,
+                                           self.extracted_sources[image])
+                # add the name of the image to the imglist object
+                for im in img:
+                #    im.meta['name'] = image
+                    log.debug('im.meta[name] = {}'.format(im.meta['name']))
+                self.imglist.extend(img)
 
         self.group_id_dict = {}
         for image in self.imglist:

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -126,6 +126,10 @@ def determine_alignment_residuals(input, files,
             numsci = countExtn(hdu)
             nums = 0
             img_cats = {}
+            if hdu[("SCI", chip)].data.max() == 0.0:
+                log.info("SKIPPING point-source finding for blank image: {}".format(hdu.filename()))
+                continue
+            log.info("Determining point-sources for {}".format(hdu.filename()))
             for chip in range(numsci):
                 chip += 1
                 img_cats[chip] = amutils.extract_point_sources(hdu[("SCI", chip)].data, nbright=max_srcs)


### PR DESCRIPTION
This addresses the remainder of the issues related to the Exceptions thrown in the 2020-08-13 test results.  Specifically:
- align_utils/configure_fit:  Only try to obtain a fit for an image which had a successful fit
- astrometric_utils/build_auto_kernel:  
    - Clean up logic for handling empty images by computing threshold correctly for comparing to the kernel mean depending on what form of threshold is provided as input
    - Do not try to take the len() of None when reporting number of peaks found
- astrometric_utils/sigma_clipped_bkg:  Explicitly return a value of 0 for blank images without trying to evaluate the blank image itself
- quality_analysis/determine_alignment_residuals:  Skip quick point-source identification for blank images

These changes were tested against these datasets which originally reported Exceptions in the 2020-08-13 test run:
 - ib2t06
 - idnm0u
 - ja2h01
 - jdmy02

This should complete the work against #767 .