### PR TITLE
MNT: Move tables to test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ TESTS_REQUIRE = [
     'ci_watson',
     'crds',
     'pytest',
-    'pytest-remotedata'
+    'pytest-remotedata',
+    'tables',
 ]
 
 setup(
@@ -105,7 +106,6 @@ setup(
         'photutils>=0.7',
         'lxml',
         'PyPDF2',
-        'tables',
         'scikit-image>=0.14.2',
         'PyYAML',
     ],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ TESTS_REQUIRE = [
     'crds',
     'pytest',
     'pytest-remotedata',
-    'tables',
+    'tables'
 ]
 
 setup(


### PR DESCRIPTION
Second attempt of #778. Complements #780. cc @jhunkeler and @rendinam 

>  we now use as part of our pipeline processing testing code

Since it is used in testing code, then perhaps it should be optional dependency for testing only?

Fix #777 

