### PR TITLE
Use WHT array to refine point catalog

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -591,7 +591,12 @@ class HAPPointCatalog(HAPCatalogBase):
             # Determine what regions we have for source identification
             # Regions are defined as sections of the image which has the same
             # max WHT within a factor of 2.0 (or so).
-            tp_masks = make_wht_masks(self.image.wht_image, exclusion_mask)
+            # make_wht_masks(whtarr, maskarr, scale=1.5, sensitivity=0.95, kernel=(11,11))
+            tp_masks = make_wht_masks(self.image.wht_image, exclusion_mask,
+                                    scale=self.param_dict['scale'], 
+                                    sensitivity=self.param_dict['sensitivity'], 
+                                    kernel=(self.param_dict['region_size'],
+                                            self.param_dict['region_size']))
             
             sources = None
             for mask in tp_masks:

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.125,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.125,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.15,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.45,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.15,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.125,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.125,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.15,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.45,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -8,6 +8,9 @@
     "aperture_2": 0.15,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
+    "scale": 1.5,
+    "sensitivity": 0.95,
+    "region_size": 11,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,


### PR DESCRIPTION
The weight array gets used in this set of changes to modify how the point source catalog gets computed.  It uses it to define which regions have nearly the same S/N (WHT) within a factor of 1.5.  The relative weight across the WHT array (relative to the max WHT value) gets computed and used to scale each region before computing the RMS.  This accounts for the lower S/N in lower WHT regions that causes background noise fluctuations to be scaled up in DRZ products.  This allows the algorithm to account for regions where fewer inputs contribute to the final output image.  

**This needs to be discussed and reviewed thoroughly before being merged.**  Initial results processing IBWB01 indicate that it significantly improves the actual detection rate by minimizing the number of faint, scaled background noise peaks identified as real sources.  