### PR TITLE
Add HAPLEVEL as attribute to HAPProduct class

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -112,7 +112,7 @@ def create_drizzle_products(total_obj_list):
         fits_files = fnmatch.filter(product_list, "*dr?.fits")
         for filename in fits_files:
             log.info("    {}".format(filename))
-            # proc_utils.refine_product_headers(filename, total_obj_list)
+            proc_utils.refine_product_headers(filename, total_obj_list)
     except Exception:
         log.critical("Trouble updating drizzle products for CAOM.")
         exc_type, exc_value, exc_tb = sys.exc_info()

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -66,7 +66,14 @@ def refine_product_headers(product, total_obj_list):
     phdu['filename'] = product
 
     # Determine level of the product
-    level = 1 if len(phdu['rootname'].split('_')[-1]) > 6 else 2
+    # Get the level directly from the product instance
+    level = None
+    for tdp in total_obj_list:
+        level = tdp.find_member(product).haplevel
+        if level:
+            break
+    if level is None:
+        level = 1
 
     # Update PINAME keyword
     phdu['piname'] = phdu['pr_inv_l']

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -2,6 +2,14 @@
 
     Classes which define the total ("white light" image), filter, and exposure
     drizzle products.
+
+    These products represent different levels of processing with the levels noted in the
+    'HAPLEVEL' keyword.  The 'HAPLEVEL' values are:
+
+      * 1 : calibrated (FLT/FLC) input images and exposure level drizzle products with improved astrometry
+      * 2 : filter and total products combined using the improved astrometry,
+            consistent pixel scale, and oriented to North.
+      * 3 : (future) multi-visit mosaics aligned to common tangent plane
 """
 import logging
 import sys
@@ -142,7 +150,7 @@ class TotalProduct(HAPProduct):
         # the detector in use.
         # instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
         self.manifest_name = '_'.join([instrument, filename[1:4], obset_id, "manifest.txt"])
-       
+
         # Define HAPLEVEL value for this product
         self.haplevel = 2
 
@@ -157,11 +165,11 @@ class TotalProduct(HAPProduct):
         """ Return member instance with filename 'name' """
         desired_member = None
         for member in [self] + self.edp_list + self.fdp_list:
-            if name == member.drizzle_filename: 
+            if name == member.drizzle_filename:
                 desired_member = member
                 break
         return desired_member
-            
+
     def add_member(self, edp):
         """ Add an ExposureProduct object to the list - composition.
         """
@@ -186,7 +194,7 @@ class TotalProduct(HAPProduct):
         # of this directory is now obsolete.
         drizzle_pars["preserve"] = False
         drizzle_pars['rules_file'] = self.rules_file
-        
+
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "
                   "have been updated for the drizzle step of the total drizzle product."
                   .format(meta_wcs, self.trl_logname))
@@ -247,7 +255,7 @@ class FilterProduct(HAPProduct):
         """ Return member instance with filename 'name' """
         desired_member = None
         for member in [self] + self.edp_list:
-            if name == member.drizzle_filename: 
+            if name == member.drizzle_filename:
                 desired_member = member
                 break
         return desired_member
@@ -472,13 +480,13 @@ class ExposureProduct(HAPProduct):
 
         log.info("Copying {} to SVM input: \n    {}".format(filename, edp_filename))
         shutil.copy(filename, edp_filename)
-        
+
         # Add HAPLEVEL keyword as required by pipeline processing
         fits.setval(edp_filename, 'HAPLEVEL', value=0, comment='Classificaion level of this product')
 
         return edp_filename
-        
-        
+
+
 class SkyCellProduct(HAPProduct):
     """ A SkyCell Product is a mosaic comprised of images acquired
         during a multiple visits with one instrument, one detector, a single filter,
@@ -527,7 +535,7 @@ class SkyCellProduct(HAPProduct):
         """ Return member instance with filename 'name' """
         desired_member = None
         for member in [self] + self.edp_list:
-            if name == member.drizzle_filename: 
+            if name == member.drizzle_filename:
                 desired_member = member
                 break
         return desired_member
@@ -539,7 +547,7 @@ class SkyCellProduct(HAPProduct):
         self.new_to_layer += edp.new_process
 
     def generate_metawcs(self):
-        self.meta_wcs = self.skycell.wcs 
+        self.meta_wcs = self.skycell.wcs
         return self.meta_wcs
 
     def align_to_gaia(self, catalog_name='GAIADR2', headerlet_filenames=None, output=True,
@@ -645,4 +653,3 @@ class SkyCellProduct(HAPProduct):
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Sky-cell layer image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
         shutil.move(self.trl_logname, self.trl_filename)
-

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -62,6 +62,9 @@ class HAPProduct:
         # this attribute is updated in the hapsequncer.py module (run_hla_processing()).
         self.configobj_pars = None
 
+        # Define HAPLEVEL value for this product
+        self.haplevel = 1
+
         # Initialize attributes for use in generating the output products
         self.meta_wcs = None
         self.mask = None
@@ -139,6 +142,9 @@ class TotalProduct(HAPProduct):
         # the detector in use.
         # instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
         self.manifest_name = '_'.join([instrument, filename[1:4], obset_id, "manifest.txt"])
+       
+        # Define HAPLEVEL value for this product
+        self.haplevel = 2
 
         # These attributes will be populated during processing
         self.edp_list = []
@@ -147,6 +153,15 @@ class TotalProduct(HAPProduct):
 
         log.debug("Total detection object {}/{} created.".format(self.instrument, self.detector))
 
+    def find_member(self, name):
+        """ Return member instance with filename 'name' """
+        desired_member = None
+        for member in [self] + self.edp_list + self.fdp_list:
+            if name == member.drizzle_filename: 
+                desired_member = member
+                break
+        return desired_member
+            
     def add_member(self, edp):
         """ Add an ExposureProduct object to the list - composition.
         """
@@ -219,11 +234,24 @@ class FilterProduct(HAPProduct):
         self.drizzle_filename = self.product_basename + "_" + self.filetype + ".fits"
         self.refname = self.product_basename + "_ref_cat.ecsv"
 
+        # Define HAPLEVEL value for this product
+        self.haplevel = 2
+
         # These attributes will be populated during processing
         self.edp_list = []
         self.regions_dict = {}
 
         log.debug("Filter object {}/{}/{} created.".format(self.instrument, self.detector, self.filters))
+
+    def find_member(self, name):
+        """ Return member instance with filename 'name' """
+        desired_member = None
+        for member in [self] + self.edp_list:
+            if name == member.drizzle_filename: 
+                desired_member = member
+                break
+        return desired_member
+
 
     def add_member(self, edp):
         """ Add an ExposureProduct object to the list - composition.
@@ -364,6 +392,9 @@ class ExposureProduct(HAPProduct):
 
         self.regions_dict = {}
 
+        # Define HAPLEVEL value for this product
+        self.haplevel = 1
+
         # This attribute is set in poller_utils.py
         self.is_singleton = False
 
@@ -371,6 +402,13 @@ class ExposureProduct(HAPProduct):
         self.new_process = True
 
         log.info("Exposure object {} created.".format(self.full_filename[0:9]))
+
+    def find_member(self, name):
+        """ Return member instance with filename 'name' """
+        if name == self.drizzle_filename:
+            return self
+        else:
+            return None
 
     def __getattribute__(self, name):
         if name in ["generate_footprint_mask", "generate_metawcs", "meta_wcs", "mask_kws", "mask"]:
@@ -473,6 +511,8 @@ class SkyCellProduct(HAPProduct):
         # instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
         self.manifest_name = '_'.join(['hst', self.product_basename, "manifest.txt"])
 
+        # Define HAPLEVEL value for this product
+        self.haplevel = 3
 
         # These attributes will be populated during processing
         self.edp_list = []
@@ -482,6 +522,15 @@ class SkyCellProduct(HAPProduct):
         self.configobj_pars = None
 
         log.debug("SkyCell object {}/{}/{} created.".format(self.instrument, self.detector, self.filters))
+
+    def find_member(self, name):
+        """ Return member instance with filename 'name' """
+        desired_member = None
+        for member in [self] + self.edp_list:
+            if name == member.drizzle_filename: 
+                desired_member = member
+                break
+        return desired_member
 
     def add_member(self, edp):
         """ Add an ExposureProduct object to the list - composition.

--- a/drizzlepac/runmultihap.py
+++ b/drizzlepac/runmultihap.py
@@ -80,7 +80,7 @@ def perform(input_filename, **kwargs):
         kwargs['log_level'] = logutil.logging.INFO
 
     # execute hapsequencer.run_hap_processing()
-    return_value = hapsequencer.run_hap_processing(input_filename, **kwargs)
+    return_value = hapmultisequencer.run_mvm_processing(input_filename, **kwargs)
 
     return return_value
 


### PR DESCRIPTION
This change adds the HAPLEVEL keyword value as an attribute of the HAPProduct class.  A new method, find_member, was also added to the Filter, Exposure, and SkyCell product classes as well to support use from within the 'refine_product_headers' function.  These changes allow 'refine_product_headers' to add the correct value of the HAPLEVEL keyword to each of the drizzle products which gets created.  

In addition, the 'runmultihap' interface was fixed to actually call the 'hapmultisequencer' module for correctly processing MVM data.  

This will close #786.  