### PR TITLE
Fix crash in tweakreg when updatehdr is false

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,13 +14,21 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-3.1.8 (Aug-2020)
+
+3.1.9 (unreleased)
 ==================
 
-A number of changes have been implemented to either correct problems or 
+- Fixed a bug in ``TweakReg`` due to which ``TweakReg`` would crash when
+  ``updatehdr`` was set to `False`. [#801]
+
+
+3.1.8 (11-Aug-2020)
+===================
+
+A number of changes have been implemented to either correct problems or
 improve the processed results.  The most significant of the changes are:
 
-  - rscale only used for alignment. 
+  - rscale only used for alignment.
   - a minimum of 6 sources now gets used for alignment
   - no proper motions used in astrometric (GAIA) catalog when attempting a posteriori fitting
   - chip-to-chip alignment errors were corrected

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -461,7 +461,7 @@ def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=Fals
                 f"WCSNAME '{wcsname}' already present in '{fname}'. A unique "
                 "value for the 'wcsname' parameter needs to be specified."
             )
-    else:
+    elif close_file or image.fileinfo(0) is None or image.fileinfo(0)['filemode'] == 'update':
         altwcs.archive_wcs(image, [extnum], wcsname=pri_wcsname, mode=altwcs.ArchiveMode.AUTO_RENAME)
 
     # Update Primary WCS:


### PR DESCRIPTION
Fixes a crash in `TweakReg` when `updatehdr` was set to `False` because the code would attempt to archive the Primary WCS of a read-only file.

Fixes #800