### PR TITLE
Updated NSIGMA for source identification to 7.5

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -626,7 +626,7 @@ class HAPPointCatalog(HAPCatalogBase):
                     if sources is None:
                         sources = reg_sources
                     else:
-                        sources = vstack( [sources, reg_sources])
+                        sources = vstack([sources, reg_sources])
 
             # If there are no detectable sources in the total detection image, return as there is nothing more to do.
             if not sources:

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.03,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.07,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 10.0,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 10.0,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.03,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.07,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 7.5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,


### PR DESCRIPTION
Simply update to the default value for the `nsigma` parameter in the catalog generation step from 5.0 to 7.5. 