### PR TITLE
Utilize the weight image in the catalog creation algorithms

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1,8 +1,9 @@
 """This script contains code to support creation of photometric sourcelists using two techniques:
 aperture photometry and segmentation-map based photometry."""
-import sys
-import pickle  # FIX Remove
+
 import copy
+import pickle  # FIX Remove
+import sys
 
 import astropy.units as u
 from astropy.io import fits as fits
@@ -974,7 +975,12 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # The bkg is an object comprised of background and background_rms images, as well as
             # background_median and background_rms_median scalars.  Set a threshold above which
             # sources can be detected.
-            threshold = self._nsigma * self.image.bkg_rms_ra
+            threshold = np.zeros_like(self.tp_masks[0]['rel_weight'])
+            for wht_mask in self.tp_masks:
+                threshold_item = self._nsigma * self.image.bkg_rms_ra * wht_mask['mask'] / wht_mask['rel_weight']
+                threshold_item[np.isnan(threshold_item)] = 0.0
+                threshold += threshold_item
+            del(threshold_item)
 
             # The imgarr should be background subtracted to match the threshold which has no background
             imgarr_bkgsub = imgarr - self.image.bkg_background_ra

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -423,6 +423,21 @@ class HAPCatalogBase:
         self.source_cat = None  # catalog of sources and their properties
         self.tp_sources = tp_sources
 
+        # create mask to reject any sources located less than 10 pixels from a image/chip edge
+        wht_image = self.image.data.copy()
+        binary_inverted_wht = np.where(wht_image == 0, 1, 0)
+        self.exclusion_mask = ndimage.binary_dilation(binary_inverted_wht, iterations=10)
+
+        # Determine what regions we have for source identification
+        # Regions are defined as sections of the image which has the same
+        # max WHT within a factor of 2.0 (or so).
+        # make_wht_masks(whtarr, maskarr, scale=1.5, sensitivity=0.95, kernel=(11,11))
+        self.tp_masks = make_wht_masks(self.image.wht_image, self.exclusion_mask,
+                                       scale=self.param_dict['scale'],
+                                       sensitivity=self.param_dict['sensitivity'],
+                                       kernel=(self.param_dict['region_size'],
+                                               self.param_dict['region_size']))
+
     def identify_sources(self, **pars):
         pass
 
@@ -583,23 +598,8 @@ class HAPPointCatalog(HAPCatalogBase):
             log.info("")
             log.info("{}".format("=" * 80))
 
-            # create mask to reject any sources located less than 10 pixels from a image/chip edge
-            wht_image = self.image.data.copy()
-            binary_inverted_wht = np.where(wht_image == 0, 1, 0)
-            exclusion_mask = ndimage.binary_dilation(binary_inverted_wht, iterations=10)
-
-            # Determine what regions we have for source identification
-            # Regions are defined as sections of the image which has the same
-            # max WHT within a factor of 2.0 (or so).
-            # make_wht_masks(whtarr, maskarr, scale=1.5, sensitivity=0.95, kernel=(11,11))
-            tp_masks = make_wht_masks(self.image.wht_image, exclusion_mask,
-                                    scale=self.param_dict['scale'], 
-                                    sensitivity=self.param_dict['sensitivity'], 
-                                    kernel=(self.param_dict['region_size'],
-                                            self.param_dict['region_size']))
-            
             sources = None
-            for mask in tp_masks:
+            for mask in self.tp_masks:
                 # apply mask for each separate range of WHT values
                 region = image * mask['mask']
                 # Compute separate threshold for each 'region'
@@ -612,12 +612,12 @@ class HAPPointCatalog(HAPCatalogBase):
                                                                               reg_rms_median))
                     daofind = DAOStarFinder(fwhm=source_fwhm,
                                             threshold=self.param_dict['nsigma'] * reg_rms_median)
-                    reg_sources = daofind(region, mask=exclusion_mask)
+                    reg_sources = daofind(region, mask=self.exclusion_mask)
                 elif self.param_dict["starfinder_algorithm"] == "iraf":
                     log.info("IRAFStarFinder(fwhm={}, threshold={}*{})".format(source_fwhm, self.param_dict['nsigma'],
                                                                                self.image.bkg_rms_median))
                     isf = IRAFStarFinder(fwhm=source_fwhm, threshold=self.param_dict['nsigma'] * reg_rms_median)
-                    reg_sources = isf(region, mask=exclusion_mask)
+                    reg_sources = isf(region, mask=self.exclusion_mask)
                 else:
                     err_msg = "'{}' is not a valid 'starfinder_algorithm' parameter input in the catalog_generation parameters json file. Valid options are 'dao' for photutils.detection.DAOStarFinder() or 'iraf' for photutils.detection.IRAFStarFinder().".format(self.param_dict["starfinder_algorithm"])
                     log.error(err_msg)


### PR DESCRIPTION
- See JIRA ticket [HLA-411](https://jira.stsci.edu/browse/HLA-411)

**High-level summary**
- The 2-d source detection threshold array used for identification of sources for the segment catalog is now weighted by the relative fractional input image contribution (i. e. \<number of input images\>/\<max number of input images\> for any given pixel). This minimizes  background fluctuations in regions of the drizzle-combined image where there is low S/N due to there being relatively few contributing input images.
- This PR applies the functionality of  PR #785 to segment catalog source identification.

**Changelog**
- catalog_utils.py:
     - Moved creation of weight masks from HAPPointCatalog.identify_sources() (as local variable) to HAPCatalogBase.\_\_init\_\_() (as object attribute)
     - Segment catalog source detection threshold array now scaled by the relative weight masks computed by make_wht_masks().