### PR TITLE
Revert "Updated NSIGMA for source identification to 7.5"

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -627,7 +627,7 @@ class HAPPointCatalog(HAPCatalogBase):
                     if sources is None:
                         sources = reg_sources
                     else:
-                        sources = vstack([sources, reg_sources])
+                        sources = vstack( [sources, reg_sources])
 
             # If there are no detectable sources in the total detection image, return as there is nothing more to do.
             if not sources:

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.03,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.07,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.03,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.07,

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 7.5,
+    "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.05,


### PR DESCRIPTION
Reverts spacetelescope/drizzlepac#806.

Continued testing indicates this change to the NSIGMA parameter may be too aggressive in addressing over-population of the catalogs.