### PR TITLE
Get single-image CR algorithm working

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -358,7 +358,7 @@ class HAPImage:
         self.catalog_table = {}
 
         # Switch to turn on/off use of single-image CR detection/removal
-        self.crclean = crclean
+        self.crclean = False
 
     def build_wht_image(self):
         if not self.num_wht:

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1059,13 +1059,13 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 outname = self.imgname.replace(".fits", "_bkgsub.fits")
                 fits.PrimaryHDU(data=imgarr_bkgsub).writeto(outname)
 
-            #threshold = np.zeros_like(self.tp_masks[0]['rel_weight'])
-            #for wht_mask in self.tp_masks:
+            # threshold = np.zeros_like(self.tp_masks[0]['rel_weight'])
+            # for wht_mask in self.tp_masks:
             #    log.info("Using WHT masks as a scale on the RMS to compute threshold detection limit.")
             #    threshold_item = self._nsigma * self.image.bkg_rms_ra * wht_mask['mask'] / wht_mask['rel_weight']
             #    threshold_item[np.isnan(threshold_item)] = 0.0
             #    threshold += threshold_item
-            #del(threshold_item)
+            # del(threshold_item)
             # Compute the threshold to use for source detection
             threshold = self.compute_threshold(self._nsigma, self.image.bkg_rms_ra)
 
@@ -1252,7 +1252,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         threshold = np.zeros_like(self.tp_masks[0]['rel_weight'])
         for wht_mask in self.tp_masks:
             log.info("Using WHT masks as a scale on the RMS to compute threshold detection limit.")
-            threshold_item = nsigma * bkg_rms * wht_mask['mask'] / wht_mask['rel_weight']
+            threshold_item = nsigma * bkg_rms * np.sqrt(wht_mask['mask'] / wht_mask['rel_weight'])
             threshold_item[np.isnan(threshold_item)] = 0.0
             threshold += threshold_item
         del(threshold_item)

--- a/drizzlepac/haputils/graph_utils.py
+++ b/drizzlepac/haputils/graph_utils.py
@@ -164,7 +164,7 @@ class HAPFigure:
         # the build_glyph() routine is invoked.
         self.glyph_color = 'blue'
         self.color = 'blue'
-        self.size = 10
+        self.size = 6
         self.legend_group = ''
         self.legend_label = ''
         self.fill_alpha = 0.5
@@ -367,9 +367,9 @@ class HAPFigure:
                 Default is 'black'
 
             Note: Hover tooltips are typically turned off for these figures.
-            There is an assumption the 'x', 'y', 'dx', and 'dy' columns exist 
+            There is an assumption the 'x', 'y', 'dx', and 'dy' columns exist
             in the ColumnDataSource.
-         
+
 
         """
         # Get/set optional attributes
@@ -390,7 +390,7 @@ class HAPFigure:
 
         # Generate a fixed, closed range ...
         xyrange = Range1d(0, xy_max)
-  
+
         # ... and we want the figure to have a square aspect ratio
         self.fig.x_range = xyrange
         self.fig.y_range = xyrange
@@ -402,7 +402,7 @@ class HAPFigure:
         mag = xy_segment / 0.1
         legend_text = '0.1 pixels'
 
-        # The 'delta_*' values are the length of the vector - the computed 
+        # The 'delta_*' values are the length of the vector - the computed
         # difference between [x|y] and [x|y]-reference
         delta_x = np.array(sourceCDS.data['dx'])
         delta_y = np.array(sourceCDS.data['dy'])
@@ -416,7 +416,7 @@ class HAPFigure:
         # Define coordinates for the legend of the vector plot which
         # displays the scale
         x_legend = xy_segment
-        xreference_legend = xy_segment * 2  # == xy_segment + xy_segment, because origin=(0,0) 
+        xreference_legend = xy_segment * 2  # == xy_segment + xy_segment, because origin=(0,0)
         y_legend = xy_segment
 
         # adhoc
@@ -444,7 +444,7 @@ class HAPFigure:
                          y1=y_legend,
                          color='black',
                          line_width=line_width)
-        
+
         self.fig.text(x=x_legend,
                       y=y_legend/2.0,
                       # Use of 'value' here was unexpected.  text=[legend_text] will also work.

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -579,7 +579,8 @@ def parse_obset_tree(det_tree, log_level):
                                                                                                                    tdp_obj.instrument,
                                                                                                                    tdp_obj.detector))
             # Identify what exposures should use single-image CR identification algorithm
-            if len(filt_obj.edp_list) == 1:
+            is_ccd = not (filt_obj.instrument.lower() == 'wfc3' and filt_obj.detector.lower() == 'ir')
+            if is_ccd and len(filt_obj.edp_list) == 1:
                 for e in filt_obj.edp_list:
                     e.crclean = True
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -37,14 +37,14 @@ POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
 POLLER_DTYPE = ('str', 'int', 'str', 'str', 'float', 'object', 'str', 'str')
 
 MVM_POLLER_COLNAMES = ['filename', 'proposal_id', 'program_id', 'obset_id',
-                       'exptime', 'filters', 'detector', 'pathname', 
+                       'exptime', 'filters', 'detector', 'pathname',
                        'skycell_id', 'skycell_new']
-MVM_POLLER_DTYPE = ('str', 'int', 'str', 'str', 
+MVM_POLLER_DTYPE = ('str', 'int', 'str', 'str',
                     'float', 'object', 'str', 'str',
                     'str', 'int')
-                    
+
 BOOL_STR_DICT = {'TRUE':True, 'FALSE':False, 'T':True, 'F':False, '1':True, '0':False}
-                  
+
 EXP_LABELS = {2: 'long', 1: 'med', 0: 'short', None: 'all'}
 EXP_LIMITS = [0, 15, 120]
 SUPPORTED_EXP_METHODS = {'kmeans', 'hard'}
@@ -134,7 +134,7 @@ def interpret_obset_input(results, log_level):
     log.debug("Parse the observation set tree and create the exposure, filter, and total detection objects.")
     obset_dict, tdp_list = parse_obset_tree(obset_tree, log_level)
 
-    # This little bit of code adds an attribute to single exposure objects that is True 
+    # This little bit of code adds an attribute to single exposure objects that is True
     # if a given filter only contains one input (e.g. n_exp = 1)
     for tot_obj in tdp_list:
         for filt_obj in tot_obj.fdp_list:
@@ -223,8 +223,8 @@ def interpret_mvm_input(results, log_level, exp_limit=2.0):
 
         which are
         filename, proposal_id, program_id, obset_id, exptime, filters, detector, pathname, skycell_ids, skycell_processed
-    
-    The SkyCell ID will be included in this input information to allow for 
+
+    The SkyCell ID will be included in this input information to allow for
     grouping of exposures into the same SkyCell layer based on filter, exptime and year.
 
     Output dict will have only have definitions for each defined sky cell layer to
@@ -254,7 +254,7 @@ def interpret_mvm_input(results, log_level, exp_limit=2.0):
     log.setLevel(log_level)
 
     log.debug("Interpret the poller file for the observation set.")
-    obset_table = build_poller_table(results, log_level, 
+    obset_table = build_poller_table(results, log_level,
                                      poller_type='mvm')
 
     # Add INSTRUMENT column
@@ -262,11 +262,11 @@ def interpret_mvm_input(results, log_level, exp_limit=2.0):
     # convert input to an Astropy Table for parsing
     obset_table.add_column(Column([instr] * len(obset_table)), name='instrument')
 
-    # Add Date column    
+    # Add Date column
     years = [int(fits.getval(f, 'date-obs').split('-')[0]) for f in obset_table['filename']]
     obset_table.add_column(Column(years), name='year_layer')
 
-    # Sort the rows of the table in an effort to optimize the number of quality 
+    # Sort the rows of the table in an effort to optimize the number of quality
     # sources found in the initial images
     obset_table = sort_poller_table(obset_table)
 
@@ -279,15 +279,15 @@ def interpret_mvm_input(results, log_level, exp_limit=2.0):
     # Now create the output product objects
     log.debug("Parse the observation set tree and create the exposure, filter, and total detection objects.")
     obset_dict, tdp_list = parse_mvm_tree(obset_tree, log_level)
-    
+
     # Now we need to merge any pre-existing layer products with the new products
     # This will add the exposure products from the pre-existing definitions of
-    # the overlapping sky cell layers with those defined for the new exposures 
-    # 
+    # the overlapping sky cell layers with those defined for the new exposures
+    #
     # obset_dict, tdp_list = merge_mvm_trees(obset_tree, layer_tree, log_level)
-    
 
-    # This little bit of code adds an attribute to single exposure objects that is True 
+
+    # This little bit of code adds an attribute to single exposure objects that is True
     # if a given filter only contains one input (e.g. n_exp = 1)
     for filt_obj in tdp_list:
         if len(filt_obj.edp_list) == 1:
@@ -332,7 +332,7 @@ def build_mvm_tree(obset_table):
         if det not in obset_tree:
             obset_tree[det] = {}
             obset_tree[det][layer] = [(row_info, filename)]
-            obset_tree[det][layer_all] = [(row_info_all, filename)]           
+            obset_tree[det][layer_all] = [(row_info_all, filename)]
         else:
             det_node = obset_tree[det]
             if layer not in det_node:
@@ -351,7 +351,7 @@ def build_mvm_tree(obset_table):
 def create_mvm_info(row):
     """Build info string for a row from the obset table"""
     info_list = [str(row['skycell_id']), row['instrument'],
-                 row['detector'], row['filters'], 
+                 row['detector'], row['filters'],
                  str(row['exp_layer']), str(row['year_layer']),
                  str(row['skycell_new'])]
     # info_list = [str(row['proposal_id']), "{}".format(row['obset_id']), row['instrument'],
@@ -391,14 +391,14 @@ def parse_mvm_tree(det_tree, log_level):
     filetype = ''
     # Setup products for each detector used
     #
-    # det_tree = {'UVIS': {'f200lp': [('skycell_p1234_x01y01 WFC3 UVIS IACS01T9Q F200LP 1', 'iacs01t9q_flt.fits'), 
-    #                     ('skycell_p1234_x01y01 WFC3 UVIS IACS01TBQ F200LP 1', 'iacs01tbq_flt.fits')]}, 
+    # det_tree = {'UVIS': {'f200lp': [('skycell_p1234_x01y01 WFC3 UVIS IACS01T9Q F200LP 1', 'iacs01t9q_flt.fits'),
+    #                     ('skycell_p1234_x01y01 WFC3 UVIS IACS01TBQ F200LP 1', 'iacs01tbq_flt.fits')]},
     #             'IR': {'f160w': [('skycell_p1234_x01y01 WFC3 IR IACS01T4Q F160W 1', 'iacs01t4q_flt.fits')]}}
-    
+
     for filt_tree in det_tree.values():
         det_indx += 1
         # Find all filters used...
-        # filt_tree = {'f200lp': [('skycell_p1234_x01y01 WFC3 UVIS IACS01T9Q F200LP 1', 'iacs01t9q_flt.fits'), 
+        # filt_tree = {'f200lp': [('skycell_p1234_x01y01 WFC3 UVIS IACS01T9Q F200LP 1', 'iacs01t9q_flt.fits'),
         #            ('skycell_p1234_x01y01 WFC3 UVIS IACS01TBQ F200LP 1', 'iacs01tbq_flt.fits')]}
 
         for filter_files in filt_tree.values():
@@ -429,7 +429,7 @@ def parse_mvm_tree(det_tree, log_level):
                 prod_list = prod_info.split(" ")
                 layer = (prod_list[3], prod_list[4], prod_list[5])
                 ftype = prod_list[-1]
-                
+
                 # Create a single exposure product object
                 sep_obj = ExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
                                           filename[1], prod_list[3], ftype, log_level)
@@ -447,7 +447,7 @@ def parse_mvm_tree(det_tree, log_level):
                     obset_products[fprod]['info'] = prod_info
 
                     # Create a filter product object for this instrument/detector
-                    # FilterProduct(prop_id, obset_id, instrument, detector, 
+                    # FilterProduct(prop_id, obset_id, instrument, detector,
                     #               filename, filters, filetype, log_level)
                     filt_obj = SkyCellProduct(str(0), str(0), prod_list[1], prod_list[2],
                                              prod_list[0], layer, ftype, log_level)
@@ -461,7 +461,7 @@ def parse_mvm_tree(det_tree, log_level):
 
             # Add this filter object to the list for creating that layer BUT
             # ONLY if there are new exposures being processed for this layer,
-            # 
+            #
             if filt_obj.new_to_layer > 0:
                 # Append filter object to the list of filter objects for this specific total product object
                 log1 = "Attach the sky cell layer object {}"
@@ -578,10 +578,16 @@ def parse_obset_tree(det_tree, log_level):
             log.debug("Attach the filter object {} to its associated total detection product object {}/{}.".format(filt_obj.filters,
                                                                                                                    tdp_obj.instrument,
                                                                                                                    tdp_obj.detector))
+            # Identify what exposures should use single-image CR identification algorithm
+            if len(filt_obj.edp_list) == 1:
+                for e in filt_obj.edp_list:
+                    e.crclean = True
+
             tdp_obj.add_product(filt_obj)
 
         # Add the total product object to the list of TotalProducts
         tdp_list.append(tdp_obj)
+
 
     # Done... return dict and object product list
     return obset_products, tdp_list
@@ -593,10 +599,10 @@ def define_exp_layers(obset_table, method='hard', exp_limit=None):
     # Add 'exp_layer' column to table
     if method not in SUPPORTED_EXP_METHODS:
         raise ValueError("Please use a supported method: {}".format(SUPPORTED_EXP_METHODS))
-    
+
     if method == 'kmeans':
         # Use pre-defined limits on exposure times for clusters
-    
+
         exptime_range = obset_table['exptime'].max() / obset_table['exptime'].min()
 
         if exp_limit is not None and exptime_range > exp_limit:
@@ -610,10 +616,10 @@ def define_exp_layers(obset_table, method='hard', exp_limit=None):
         # Use pre-defined limits for selecting layer members
         # Subtraction by 1 puts the range from 0-2 to be consistent with KMeans
         exp_layer = np.digitize(obset_table['exptime'], EXP_LIMITS) - 1
-        
+
     # Add column to the table as labelled values ('short', 'med', 'long', 'all')
     obset_table['exp_layer'] = [EXP_LABELS[e] for e in exp_layer]
-            
+
     return obset_table
 
 # ------------------------------------------------------------------------------
@@ -721,9 +727,9 @@ def build_poller_table(input, log_level, poller_type='svm'):
             # Convert string column into a Bool column
             # The input poller file reports True if it has been reprocessed.
             # This code interprets that as False since it is NOT new, so the code
-            # inverts the meaning from the pipeline poller file.  
+            # inverts the meaning from the pipeline poller file.
             if poller_type == 'mvm':
-                input_table['skycell_new'] = [int(not BOOL_STR_DICT[str(val).upper()]) for val in input_table['skycell_new']] 
+                input_table['skycell_new'] = [int(not BOOL_STR_DICT[str(val).upper()]) for val in input_table['skycell_new']]
             is_poller_file = True
 
         elif len(input_table.columns) == 1:
@@ -762,7 +768,7 @@ def build_poller_table(input, log_level, poller_type='svm'):
             datasets += files
     else:
         datasets = filenames
-        
+
     # Each image, whether from a poller file or from an input list needs to be
     # analyzed to ensure it is viable for drizzle processing.  If the image is not
     # viable, it should not be included in the output "poller" table.
@@ -780,7 +786,7 @@ def build_poller_table(input, log_level, poller_type='svm'):
     if poller_type == 'mvm':
         # determine sky-cell ID for input exposures now...
         scells = cell_utils.get_sky_cells(usable_datasets)
-        scell_files = cell_utils.interpret_scells(scells) 
+        scell_files = cell_utils.interpret_scells(scells)
 
     # If processing a list of files, evaluate each input dataset for the information needed
     # for the poller file
@@ -802,14 +808,14 @@ def build_poller_table(input, log_level, poller_type='svm'):
                 cols['filters'].append(filters)
         if poller_type == 'mvm':
             # interpret_scells returns:
-            #  {'filename1':{'<sky cell id1>': SkyCell1, 
+            #  {'filename1':{'<sky cell id1>': SkyCell1,
             #               '<sky cell id2>':SkyCell2,
             #               'id': "<sky cell id1>;<sky cell id2>"},
             #   'filename2': ...}
-            # This preserves 1 entry per filename, while providing info on 
+            # This preserves 1 entry per filename, while providing info on
             # multiple SkyCell's for each filename as appropriate.
             #
-            cols['skycell_id'] = [scell_files[fname]['id'] for fname in cols['filename']]                 
+            cols['skycell_id'] = [scell_files[fname]['id'] for fname in cols['filename']]
             cols['skycell_new'] = [1]*len(cols['filename'])
 
         #
@@ -836,7 +842,7 @@ def build_poller_table(input, log_level, poller_type='svm'):
     # If 'mvm' poller file, expand any multiple skycell entries into separate rows
     #
     if poller_type == 'mvm':
-        # A new row will need to be added for each additional SkyCell that the 
+        # A new row will need to be added for each additional SkyCell that the
         # file overlaps...
         #
         poller_table['skycell_obj'] = [None]*len(poller_table)
@@ -859,7 +865,7 @@ def build_poller_table(input, log_level, poller_type='svm'):
                             poller_rows = poller_table[poller_table['filename'] == name]
                             sobj0 = poller_rows['skycell_obj'][0]
                             # Select only 1 row regardless of how many we have already
-                            # added for this filename (in case file overlapped more than 
+                            # added for this filename (in case file overlapped more than
                             # 2 sky cells at once).
                             poller_row = poller_rows[poller_rows['skycell_obj'] == sobj0]
                             # make copy of row for this filename
@@ -869,7 +875,7 @@ def build_poller_table(input, log_level, poller_type='svm'):
                             # append new row to table
                             new_poller_table.add_row(poller_row[0])
         poller_table = new_poller_table
-        
+
     return poller_table
 
 
@@ -933,12 +939,12 @@ def sort_poller_table(obset_table):
         row['flam'] = photflam
 
     # Determine the rank order the data with a primary key of photflam and a secondary key
-    # of exposure time (in seconds).  The primary and secondary keys both need 
+    # of exposure time (in seconds).  The primary and secondary keys both need
     # to be sorted in descending order.  Use the rank to sort
     # the original input table for output.
-    # Unfortunately, there are cases where the default works better; namely, 
+    # Unfortunately, there are cases where the default works better; namely,
     # fields with few point sources which are bright that are saturated in the
-    # longer exposure time images (like j8cw03 and j8cw53).  
+    # longer exposure time images (like j8cw03 and j8cw53).
     # rank = np.lexsort((-expanded_obset_table['flam'], -expanded_obset_table['exptime']))
     # Original implementation:
     # rank = np.lexsort((expanded_obset_table['exptime'], -expanded_obset_table['flam']))

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -371,7 +371,6 @@ class FilterProduct(HAPProduct):
 
         if len(edp_filenames) == 1:
             drizzle_pars['resetbits'] = "0"  # Use any pixels already flagged as CRs
-            drizzle_pars['final_fillval'] = 0
 
         astrodrizzle.AstroDrizzle(input=edp_filenames,
                                   output=self.drizzle_filename,

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -14,7 +14,7 @@ These DataFrames can then be concatenated using:
 >>> allpd = pdtab.concat([pdtab2, pdtab3])
 
 where 'pdtab2' and 'pdtab3' are DataFrames generated from other datasets.  For
-more information on how to merge DataFrames, see 
+more information on how to merge DataFrames, see
 
 https://pandas.pydata.org/pandas-docs/stable/user_guide/merging.html
 
@@ -24,7 +24,7 @@ from:
 https://programminghistorian.org/en/lessons/visualizing-with-bokeh
 
 
-From w3schools.com to go with sample Bokeh code from bottom of 
+From w3schools.com to go with sample Bokeh code from bottom of
 https://docs.bokeh.org/en/latest/docs/user_guide/bokehjs.html:
 
 <p>Click the button to open a new window called "MsgWindow" with some text.</p>
@@ -64,12 +64,12 @@ MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
-                            
+
 __taskname__ = 'quality_analysis'
 
-def determine_alignment_residuals(input, files, 
+def determine_alignment_residuals(input, files,
                                   catalogs=None,
-                                  max_srcs=2000, 
+                                  max_srcs=1000,
                                   json_timestamp=None,
                                   json_time_since_epoch=None,
                                   log_level=logutil.logging.INFO):
@@ -86,7 +86,7 @@ def determine_alignment_residuals(input, files,
         pipeline can work on both CTE-corrected and non-CTE-corrected files,
         but this comparison will only be performed on CTE-corrected
         products when available.
-        
+
     catalogs : list, optional
         List of dictionaries containing the source catalogs for each input chip.
         The list NEEDS to be in the same order as the filenames given in `files`.
@@ -115,7 +115,7 @@ def determine_alignment_residuals(input, files,
         being performed.
     """
     log.setLevel(log_level)
-    
+
     if catalogs is None:
         # Open all files as HDUList objects
         hdus = [fits.open(f) for f in files]
@@ -126,7 +126,7 @@ def determine_alignment_residuals(input, files,
             numsci = countExtn(hdu)
             nums = 0
             img_cats = {}
-            if hdu[("SCI", chip)].data.max() == 0.0:
+            if hdu[("SCI", 1)].data.max() == 0.0:
                 log.info("SKIPPING point-source finding for blank image: {}".format(hdu.filename()))
                 continue
             log.info("Determining point-sources for {}".format(hdu.filename()))
@@ -147,7 +147,7 @@ def determine_alignment_residuals(input, files,
             num_srcs.append(num_img)
 
 
-    if len(num_srcs) == 0 or (len(num_srcs) > 0 and  max(num_srcs) <= 3):
+    if len(num_srcs) == 0 or (len(num_srcs) > 0 and max(num_srcs) <= 3):
         log.warning("Not enough sources identified in input images for comparison")
         return []
 
@@ -162,7 +162,7 @@ def determine_alignment_residuals(input, files,
     try:
         # perform relative fitting
         matchlist = tweakwcs.align_wcs(imglist, None,
-                                       minobj=6, 
+                                       minobj=6,
                                        match=match,
                                        expand_refcat=False)
         del matchlist
@@ -171,16 +171,16 @@ def determine_alignment_residuals(input, files,
             # Try without 2dHist use to see whether we can get any matches at all
             match = tweakwcs.TPMatch(searchrad=5, separation=4.0,
                                      tolerance=1.0, use2dhist=False)
-            matchlist = tweakwcs.align_wcs(imglist, None, 
+            matchlist = tweakwcs.align_wcs(imglist, None,
                                            minobj=6,
                                            match=match,
                                            expand_refcat=False)
             del matchlist
 
-        except Exception:    
+        except Exception:
             log.warning("Problem encountered during matching of sources")
             return []
-            
+
     # Check to see whether there were any successful fits...
     align_success = False
     for img in imglist:
@@ -188,8 +188,8 @@ def determine_alignment_residuals(input, files,
         img.meta['wcsname'] = wcsname
         img.meta['fit_info']['aligned_to'] = imglist[0].meta['filename']
         img.meta['reference_catalog'] = None
-        
-    for img in imglist:        
+
+    for img in imglist:
         if img.meta['fit_info']['status'] == 'SUCCESS' and '-FIT' in wcsname:
             align_success = True
             break
@@ -207,9 +207,9 @@ def determine_alignment_residuals(input, files,
 
     return resids_files
 
-def generate_output_files(resids_dict, 
-                         json_timestamp=None, 
-                         json_time_since_epoch=None, 
+def generate_output_files(resids_dict,
+                         json_timestamp=None,
+                         json_time_since_epoch=None,
                          exclude_fields=['group_id'],
                          calling_name='determine_alignment_residuals',
                          json_rootname='astrometry_resids',
@@ -219,7 +219,7 @@ def generate_output_files(resids_dict,
     """Write out results to JSON files, one per image"""
     resids_files = []
     for image in resids_dict:
-        # Remove any extraneous information from output 
+        # Remove any extraneous information from output
         for field in exclude_fields:
             del resids_dict[image]['fit_results'][field]
         # Define name for output JSON file...
@@ -305,7 +305,7 @@ def extract_residuals(imglist):
                 # Get the reference positions from the external reference catalog
                 ref_ra = chip.meta['reference_catalog']['RA']
                 ref_dec = chip.meta['reference_catalog']['DEC']
-        
+
         if group_id not in group_dict:
             group_dict[group_name] = {}
             group_dict[group_name]['fit_results'] = {'group_id': group_id,
@@ -325,7 +325,7 @@ def extract_residuals(imglist):
             img_x, img_y, max_indx, chip_mask = get_tangent_positions(chip, img_indx,
                                                                       start_indx=cum_indx)
             cum_indx += max_indx
-            
+
             # Extract X, Y for sources from reference image
             ref_x, ref_y = chip.world_to_tanp(ref_ra[ref_indx][chip_mask], ref_dec[ref_indx][chip_mask])
             group_dict[group_name]['fit_results'].update(
@@ -433,7 +433,7 @@ def match_to_gaia(imcat, refcat, product, output, searchrad=5.0):
 
 
 def determine_gaia_residuals(fit_catalogs,
-                             json_timestamp=None, 
+                             json_timestamp=None,
                              json_time_since_epoch=None,
                              log_level=logutil.logging.NOTSET):
     # Report on the results of the actual alignment fit used for defining the
@@ -443,7 +443,7 @@ def determine_gaia_residuals(fit_catalogs,
 
     selected_fit = fit_catalogs.selected_fit
     resids = {}
-    
+
     for img in selected_fit:
         # The same fits is reported for each chip in a multi-chip image
         if img in resids:
@@ -522,7 +522,7 @@ def run_all(input, files, catalogs=None, log_level=logutil.logging.NOTSET):
         log.warning("Alignment residuals determination encountered a problem.")
         log.exception("message")
         log.warning("Continuing to next test...")
-        
+
     if catalogs is not None:
         try:
             if not 'json_files' in locals(): # create empty list if there's an exception thrown by determine_alignment_residuals

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n4.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_astrodrizzle_any_n6.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_any_n6.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_astrodrizzle_blue_n6.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 3.0,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.07,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n4.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_astrodrizzle_any_n6.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n4.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_astrodrizzle_grism_n4.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -1,7 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
-    "nsigma": 5,
+    "nsigma": 3.0,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n4.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_n6.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n2.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n4.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_astrodrizzle_any_pre2012_n6.json
@@ -102,7 +102,7 @@
     },
     "STATE OF INPUT FILES": {
         "restore": false,
-        "preserve": true,
+        "preserve": false,
         "overwrite": false,
         "clean": true
     },


### PR DESCRIPTION
This PR implements the following changes to the SVM processing code:

- apply single-image cosmic-ray(CR) rejection by updating DQ arrays for sole exposure that defines a given FilterProduct 
    - The algorithm is the same one used for alignment
- update single-image CR rejection algorithm to also identify most CR streaks (not delta CRs)
- update default parameters for astrodrizzle to NOT reset CR bits for single exposures or for the total detection image
- improve the memory use for the SkyFootprint algorithm
- fix a few more Flake8 syntax warnings/errors 

These changes were demonstrated to improve the total detection image, and the single image filter products using the data from the visit 'ib6w62'.

This will close #795 .  
