### PR TITLE
Re-organize/streamline background computation algorithms

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -58,6 +58,13 @@ class CatalogImage:
         else:
             self.ghd_product = "fdp"
 
+        # Get various configuration variables needed for the background computation
+        # MDD FIX
+        self._negative_percent = self.param_dict["sourcex"]["negative_percent"]
+        self._negative_threshold = self.param_dict["sourcex"]["negative_threshold"]
+        self._nsigma_clip = self.param_dict["sourcex"]["nsigma_clip"]
+        self._maxiters = self.param_dict["sourcex"]["maxiters"]
+
         # Fits file read
         self.data = self.imghdu[('SCI', 1)].data
         self.wht_image = self.imghdu['WHT'].data.copy()
@@ -131,11 +138,18 @@ class CatalogImage:
             bkg_rms_image median value
         """
         # Report configuration values to log
+        # MDD Fix here new config parameters info
         log.info("")
-        log.info("Computation of image background - Input Parameters")
+        log.info("Background Computation")
         log.info("File: {}".format(self.imgname))
-        log.info("Box size: {}".format(box_size))
-        log.info("Window size: {}".format(win_size))
+        log.info("Sigma-clipped Background Configuration variables")
+        log.info("  Negative threshold: {}".format(self._negative_threshold))
+        log.info("  Negative percent: {}".format(self._negative_percent))
+        log.info("  Nsigma: {}".format(self._nsigma_clip))
+        log.info("  Number of iterations: {}".format(self._maxiters))
+        log.info("Background2D Configuration Variables")
+        log.info("  Box size: {}".format(box_size))
+        log.info("  Window size: {}".format(win_size))
 
         # SExtractorBackground ans StdBackgroundRMS are the defaults
         bkg = None
@@ -146,10 +160,11 @@ class CatalogImage:
         imgdata[np.isnan(imgdata)] = 0
 
         # Create mask to reject any sources located less than 10 pixels from a image/chip edge
+        # to be used for the sigma-clipping
         binary_inverted_wht = np.where(imgdata == 0, 1, 0)
         self.exclusion_mask = ndimage.binary_dilation(binary_inverted_wht, iterations=10)
 
-        # MDD FIX - put in config
+        # MDD FIX - put in config file
         self._nsigma_clip = 3.0
         self._maxiters = 3.0
         # Compute a sigma-clipped background which returns only single values for mean,
@@ -162,101 +177,81 @@ class CatalogImage:
 
         log.info("Sigma-clipped Statistics. Background mean: {}  median: {}  std: {}".format(bkg_mean, bkg_median, bkg_std))
 
-        # If the configuration variable has been set to force a sigma-clipped
-        # background determination, then just compute a full two-dimensional background
-        # image based upon the median value.
-        if self.param_dict["dao"]["simple_bkg"]:
+        # Compute Pearson’s second coefficient of skewness - this is a criterion
+        # for possibly computing a two-dimensional background fit
+        bkg_skew = 3.0 * (bkg_mean - bkg_median) / bkg_std
 
-            # Generate a two-dimensional image with the attributes of the input data, but
-            # a value of segm_bkg_median for all pixels
-            self.bkg_background_ra = np.full_like(imgdata, bkg_median)
-            self.bkg_rma_ra = np.full_like(imgdata, bkg_std)
-            self.bkg_median = bkg_median.copy()
-            self.bkg_rms_median = bkg_std.copy()
+        # Generate two-dimensional background and rms images with the attributes of
+        # the input data, but the content based on the sigma-clipped statistics. 
+        # bkg_median ==> background and bkg_std ==> background rms
+        self.bkg_background_ra = np.full_like(imgdata, bkg_median)
+        self.bkg_rma_ra = np.full_like(imgdata, bkg_std)
+        self.bkg_median = bkg_median.copy()
+        self.bkg_rms_median = bkg_std.copy()
 
-            image -= self.bkg_background
+        # If the configuration variable "simple_bkg" is False, OR the background image
+        # skew is less than the threshold, compute a two-dimensional background fit.
+        # MDD Fix - update config file
+        if not self.param_dict["dao"]["simple_bkg"] or bkg_skew < self._bkg_skew_threshold:
 
-        # Need to evaluate the sigma-clipped statistics
-        else:
+            # Create the mask to ignore pixels with the value of 0
+            mask = (imgdata == 0)
 
-            # Compute Pearson’s second coefficient of skewness
-            bkg_skew = 3.0 * (bkg_mean - bkg_median) / bkg_std
+            exclude_percentiles = [10, 25, 50, 75]
+            for percentile in exclude_percentiles:
+                log.info("Percentile in use: {}".format(percentile))
+                try:
+                    bkg = Background2D(imgdata, (box_size, box_size), filter_size=(win_size, win_size),
+                                       bkg_estimator=bkg_estimator(),
+                                       bkgrms_estimator=rms_estimator(),
+                                       exclude_percentile=percentile, edge_method="pad",
+                                       mask=mask)
 
-            # If the skew is less than the threshold, then Background2D should be computed.  
-            # If the Background2D generates too many negative values in the background-subtracted
-            # image, OR no Background2D can be computed successfully, generate a full
-            # two-dimensional background image from the sigma-clipped values.
-            if bkg_skew < self._bkg_skew_threshold:
+                    # Apply the coverage mask to the returned background image
+                    bkg.background *= ~mask
 
-                # Create the mask to ignore pixels with the value of 0
-                mask = (imgdata == 0)
+                except Exception:
+                    bkg = None
+                    continue
 
-                exclude_percentiles = [10, 25, 50, 75]
-                for percentile in exclude_percentiles:
-                    log.info("Percentile in use: {}".format(percentile))
-                    try:
-                        bkg = Background2D(imgdata, (box_size, box_size), filter_size=(win_size, win_size),
-                                           bkg_estimator=bkg_estimator(),
-                                           bkgrms_estimator=rms_estimator(),
-                                           exclude_percentile=percentile, edge_method="pad",
-                                           mask=mask)
+                if bkg is not None:
+                    bkg_background_ra = bkg.background
+                    bkg_rms_ra = bkg.background_rms
+                    bkg_rms_median = bkg.background_rms_median
+                    bkg_median = bkg.background_median
+                    break
 
-                        # Apply the coverage mask to the returned background image
-                        bkg.background *= ~mask
-
-                    except Exception:
-                        bkg = None
-                        continue
-
-                    if bkg is not None:
-                        self.bkg_background_ra = bkg.background.copy()
-                        self.bkg_rms_ra = bkg.background_rms.copy()
-                        self.bkg_rms_median = bkg.background_rms_median.copy()
-                        self.bkg_median = bkg.background_median.copy()
-                        break
-
-            # If use of Background2D was successful in determining a background, the
-            # background-subtracted image has to be evaluated for the number of negative values
+            # If computation of a two-dimensional background image was successful, compute the
+            # background-subtracted image and evaluate it for the number of negative values.
+            # 
+            # If bkg is None, use the sigma-clipped statistics for the background.
+            # If bkd is not None, but the background-subtracted image is too negative, use the
+            # sigma-clipped statistics for the background.
             if bkg is not None:
-                imgdata_bkgsub = imgdata - self.bkg_background_ra
+                imgdata_bkgsub = imgdata - bkg_background_ra
 
                 # Determine how much of the illuminated portion of the background subtracted
                 # image is negative
                 illum_mask = self.exclusion_mask < 1
                 total_illum_mask = illum_mask.sum()
-                illum_data = imgarr_bkgsub * illum_mask
+                illum_data = imgdata_bkgsub * illum_mask
                 negative_mask = illum_data < self._negative_threshold
                 total_negative_mask = negative_mask.sum()
                 negative_ratio = total_negative_mask / total_illum_mask
-                log.info("Percent ratio of negative pixels in background subtracted image to total illuminated pixels: {0:.2f}".format(100.0 * negative_ratio))
 
                 # If the background subtracted image has too many negative values which may be
-                # indicative of large negative regions, so the Background2d computed background
-                # should not be used.  Instead compute a full two-dimensional image from the
-                # sigma-clipped background median value
+                # indicative of large negative regions, the two-dimensional computed background
+                # fit image should NOT be used.  Use the sigma-clipped data instead.
                 if negative_ratio * 100.0 > self._negative_percent:
                     log.info("Percentage of negative values {0:.2f} in the background subtracted image exceeds the threshold of {1:.2f}.".format(100.0 * negative_ratio, self._negative_percent))
-                    log.info("Using the alternate sigma-clippling algorithm to determine the background estimate (median).")
+                    log.info("Use the background image determined from the sigma-clipped statistics.")
 
-
-
-        # MDD - restart here
-
-
-        # If it were not possible to determine a background using Background2D, default to the
-        # sigma-clipped background computed at the outset
-        if bkg is None:
-            log.info("Background2D failure detected. Using alternative background calculation instead....")
-            mask = make_source_mask(imgdata, nsigma=2, npixels=5, dilate_size=11)
-            sigcl_mean, sigcl_median, sigcl_std = sigma_clipped_stats(imgdata, sigma=3.0, mask=mask, maxiters=9)
-            bkg_median = sigcl_median
-            bkg_rms_median = sigcl_std
-            # create background frame shaped like imgdata populated with sigma-clipped median value
-            bkg_background_ra = np.full_like(imgdata, sigcl_median)
-            # create background frame shaped like imgdata populated with sigma-clipped standard deviation value
-            bkg_rms_ra = np.full_like(imgdata, sigcl_std)
-
-
+                # Update the class variables with the background fit data
+                else:
+                    self.bkg_background_ra = bkg_background_ra.copy()
+                    self.bkg_rms_ra = bkg_rms_ra.copy()
+                    self.bkg_rms_median = bkg_rms_median.copy()
+                    self.bkg_median = bkg_median.copy()
 
         log.info("Computation of image background complete")
         log.info("Found: ")
@@ -264,10 +259,6 @@ class CatalogImage:
         log.info("    Median RMS background: {}".format(bkg_rms_median))
         log.info("")
 
-        self.bkg_background_ra = bkg_background_ra.copy()
-        self.bkg_rms_ra = bkg_rms_ra.copy()
-        self.bkg_rms_median = bkg_rms_median.copy()
-        self.bkg_median = bkg_median.copy()
         del bkg, bkg_background_ra, bkg_rms_ra, bkg_rms_median, bkg_median
 
     def _get_header_data(self):
@@ -357,6 +348,14 @@ class HAPCatalogs:
                 raise ValueError
 
         self.types = types
+
+        # Get various configuration variables needed for the background computation
+        # MDD FIX
+        # need to rework interface to compute_background and build_kernel
+        #self._negative_percent = self.param_dict["sourcex"]["negative_percent"]
+        #self._negative_threshold = self.param_dict["sourcex"]["negative_threshold"]
+        #self._nsigma_clip = self.param_dict["sourcex"]["nsigma_clip"]
+        #self._maxiters = self.param_dict["sourcex"]["maxiters"]
 
         # Compute the background for this image
         self.image = CatalogImage(fitsfile, log_level)
@@ -970,10 +969,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
         self._rw2d_nsigma = self.param_dict["sourcex"]["rw2d_nsigma"]
         self._max_biggest_source = self.param_dict["sourcex"]["max_biggest_source"]
         self._max_source_fraction = self.param_dict["sourcex"]["max_source_fraction"]
-        self._negative_percent = self.param_dict["sourcex"]["negative_percent"]
-        self._negative_threshold = self.param_dict["sourcex"]["negative_threshold"]
-        self._nsigma_clip = self.param_dict["sourcex"]["nsigma_clip"]
-        self._maxiters = self.param_dict["sourcex"]["maxiters"]
 
         # Columns to include from the computation of source properties to save
         # computation time from computing values which are not used
@@ -991,12 +986,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Default kernel which may be the custom kernel based upon the actual image
         # data or a Gaussian 2D kernel. This may be over-ridden in identify_sources().
         self.kernel = self.image.kernel
-
-        # Attributes computed in identify_sources() only if the original background
-        # subtracted image is determined to have too many negative values.
-        # and the associated background rms
-        self.final_segment_background = None
-        self.final_segment_background_rms = None
 
         # Attribute computed when generating the segmentation image.  If the segmentation image
         # is deemed to be of poor quality, make sure to add documentation to the output catalog.
@@ -1035,10 +1024,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
             log.info("RickerWavelet kernel X- and Y-dimension: {}".format(self._rw2d_size))
             log.info("Percentage limit on the biggest source: {}".format(100.0 * self._max_biggest_source))
             log.info("Percentage limit on the source fraction over the image: {}".format(100.0 * self._max_source_fraction))
-            log.info("Sigma-clipped background determination negative threshold: {}".format(self._negative_threshold))
-            log.info("Sigma-clipped background determination negative percent: {}".format(self._negative_percent))
-            log.info("Sigma-clipped background determination nsigma: {}".format(self._nsigma_clip))
-            log.info("Sigma-clipped background determination number of iterations: {}".format(self._maxiters))
             log.info("")
             log.info("{}".format("=" * 80))
 
@@ -1048,20 +1033,10 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # The bkg is an object comprised of background and background_rms images, as well as
             # background_median and background_rms_median scalars. The background value used here
             # is the default background as computed via Background2D.
-            self.final_segment_background_rms = copy.deepcopy(self.image.bkg_rms_ra)
+            #self.image.bkg_rms_ra
 
             # The imgarr should be background subtracted to match the threshold which has no background
-            self.final_segment_background = copy.deepcopy(self.image.bkg_background_ra)
-            imgarr_bkgsub = imgarr - self.final_segment_background
-
-            # Determine how much of the illuminated portion of the background subtracted image is negative
-            illum_mask = self.exclusion_mask < 1
-            total_illum_mask = illum_mask.sum()
-            illum_data = imgarr_bkgsub * illum_mask
-            negative_mask = illum_data < self._negative_threshold
-            total_negative_mask = negative_mask.sum()
-            negative_ratio = total_negative_mask / total_illum_mask
-            log.info("Percent ratio of negative pixels in background subtracted image to total illuminated pixels: {0:.2f}".format(100.0 * negative_ratio))
+            imgarr_bkgsub = imgarr - self.image.bkg_background_ra
 
             # Write out diagnostic data
             if self.diagnostic_mode:
@@ -1077,41 +1052,11 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 outname = self.imgname.replace(".fits", "_bkgsub.fits")
                 fits.PrimaryHDU(data=imgarr_bkgsub).writeto(outname)
 
-                # Background-subtracted image as mask of the negative values
-                outname = self.imgname.replace(".fits", "_bkgsub_neg.fits")
-                fits.PrimaryHDU(data=negative_mask.astype(np.uint16)).writeto(outname)
-
-            # If the background subtracted image has too many negative values which may be indicative
-            # of large negative regions, compute a single sigma-clipped background median value (constituted as
-            # a two-dimensional image) to use instead of a two-dimensional image whose values vary by position
-            if negative_ratio * 100.0 > self._negative_percent:
-                log.info("Percentage of negative values {0:.2f} in the background subtracted image exceeds the threshold of {1:.2f}.".format(100.0 * negative_ratio, self._negative_percent))
-                log.info("Using the alternate sigma-clippling algorithm to determine the background estimate (median).")
-
-                # Compute a sigma-clipped background which returns only single values for mean, median, and standard deviations
-                segm_bkg_mean, segm_bkg_median, segm_bkg_std = sigma_clipped_stats(imgarr,
-                                                                                   self.exclusion_mask,
-                                                                                   sigma=self._nsigma_clip,
-                                                                                   cenfunc='median',
-                                                                                   maxiters=self._maxiters)
-                log.info("Background mean: {}  median: {}  std: {}".format(segm_bkg_mean, segm_bkg_median, segm_bkg_std))
-
-                # Generate a two-dimensional image with the attributes of the input data, but
-                # a value of segm_bkg_median for all pixels
-                self.final_segment_background = np.full_like(self.image.data, segm_bkg_median)
-
-                # Over-write the stale values for the background and background rms
-                self.final_segment_background_rms = np.full_like(self.image.data, segm_bkg_std)
-                HAPSegmentCatalog.using_sigma_clipped_bkg = True
-
-                # Now recompute the background subtracted image
-                imgarr_bkgsub = imgarr - self.final_segment_background
-
-            # Finally, compute the threshold to use for source detection
+            # Compute the threshold to use for source detection
             threshold = np.zeros_like(self.tp_masks[0]['rel_weight'])
             for wht_mask in self.tp_masks:
                 log.info("Using WHT masks as a scale on the RMS to compute threshold detection limit.")
-                threshold_item = self._nsigma * self.final_segment_background_rms * wht_mask['mask'] / wht_mask['rel_weight']
+                threshold_item = self._nsigma * self.mage.bkg_rms_ra * wht_mask['mask'] / wht_mask['rel_weight']
                 threshold_item[np.isnan(threshold_item)] = 0.0
                 threshold += threshold_item
             del(threshold_item)
@@ -1160,7 +1105,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
                 # Generate the new segmentation map with the new kernel
                 ncount_dandd += 1
-                threshold = self._rw2d_nsigma * self.final_segment_background_rms
+                threshold = self._rw2d_nsigma * self.image.bkg_rms_ra
                 rw2d_segm_img = self.detect_and_deblend_sources(imgarr_bkgsub,
                                                                 threshold,
                                                                 ncount_dandd,
@@ -1177,7 +1122,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
                 if self.diagnostic_mode:
                     outname = self.imgname.replace(".fits", "_rw2d_segment.fits")
-                    fits.PrimaryHDU(data=rw2d_kernel).writeto(outname)
+                    fits.PrimaryHDU(data=rw2d_segm_img).writeto(outname)
 
                 # Evaluate the new segmention image for completeness
                 self.is_big_island = False
@@ -1196,7 +1141,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 # sources in the total drizzled image.  All the actual measurements are done on the filtered drizzled
                 # images using the coordinates determined from the total drizzled image.
                 self.segm_img = copy.deepcopy(rw2d_segm_img)
-                self.source_cat = source_properties(imgarr_bkgsub, self.segm_img, background=self.final_segment_background,
+                self.source_cat = source_properties(imgarr_bkgsub, self.segm_img, background=self.bkg_background_ra,
                                                     filter_kernel=rw2d_kernel, wcs=self.image.imgwcs)
 
             # Situation where the image was not deemed to be crowded
@@ -1205,7 +1150,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 # sources in the total drizzled image.  All the actual measurements are done on the filtered drizzled
                 # images using the coordinates determined from the total drizzled image.
                 self.segm_img = copy.deepcopy(custom_segm_img)
-                self.source_cat = source_properties(imgarr_bkgsub, self.segm_img, background=self.final_segment_background,
+                self.source_cat = source_properties(imgarr_bkgsub, self.segm_img, background=self.bkg_background_ra,
                                                     filter_kernel=self.image.kernel, wcs=self.image.imgwcs)
 
             # Convert source_cat which is a SourceCatalog to an Astropy Table - need the data in tabular

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -12,10 +12,15 @@
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold": 0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.073,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -8,14 +8,19 @@
     "aperture_2": 0.125,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
-    "scale": 1.5,
+    "scale": 100.0,
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold": 0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.065,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -12,10 +12,15 @@
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold": 0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.076,
         "TWEAK_THRESHOLD": null,
         "bthresh": 1.5
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -8,14 +8,19 @@
     "aperture_2": 0.45,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
-    "scale": 1.5,
+    "scale": 100.0,
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold": 0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.14,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -12,10 +12,15 @@
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold": 0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.076,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -12,10 +12,15 @@
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold":0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.073,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -8,14 +8,19 @@
     "aperture_2": 0.125,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
-    "scale": 1.5,
+    "scale": 100.0,
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold":0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.065,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -12,10 +12,15 @@
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold":0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.076,
         "TWEAK_THRESHOLD": null,
         "bthresh": 1.5
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -8,14 +8,19 @@
     "aperture_2": 0.45,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
-    "scale": 1.5,
+    "scale": 100.0,
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold":0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.14,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/user_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -12,10 +12,15 @@
     "sensitivity": 0.95,
     "region_size": 11,
     "flag_trim_value": 5,
+    "simple_bkg": false,
+    "negative_threshold": -0.5,
+    "negative_percent": 15.0,
+    "nsigma_clip": 3.0,
+    "maxiters":3,
+    "bkg_skew_threshold":0.5,
     "dao": {
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
-        "simple_bkg": false,
         "TWEAK_FWHMPSF": 0.076,
         "TWEAK_THRESHOLD": 3.0,
         "bthresh": 5.0
@@ -29,10 +34,6 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075,
-        "negative_threshold": 0.0,
-        "negative_percent": 15.0,
-        "nsigma_clip": 3.0,
-        "maxiters":2
+        "max_source_fraction": 0.075
     }
 }


### PR DESCRIPTION
Re-organize and streamline the various background computation algorithms to provide a general resource for all source detection algorithms.  Move the majority of the existing code into the compute_background method of CatalogImage class, and clean up the residue in the HAP[Point | Segment]Catalog classes.  Updated the parameters files as necessary and appropriate.