### PR TITLE
Try another fit to GAIA if necessary

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -311,8 +311,23 @@ class FilterProduct(HAPProduct):
                 log.debug("Abbreviated reference catalog displayed below\n{}".format(ref_catalog))
                 align_table.reference_catalogs[self.refname] = ref_catalog
                 if len(ref_catalog) > align_utils.MIN_CATALOG_THRESHOLD:
-                    align_table.perform_fit(method_name, catalog_name, ref_catalog,
-                                           fitgeom=fitgeom)
+                    fit_again = False
+                    try:
+                        align_table.perform_fit(method_name, catalog_name, ref_catalog,
+                                                fitgeom=fitgeom)
+                    except Exception:
+                        log.info('Problem with initial fit...')
+                        fit_again = True
+
+                    # If there was a problem with the first fit...
+                    if fit_again:
+                        log.info("Trying 'DEFAULT' fit to {} instead.".format(catalog_name))
+                        # Try one more time with slightly different cross-matching algorithm
+                        method_name = 'default'
+                        align_table.configure_fit()
+                        align_table.perform_fit(method_name, catalog_name, ref_catalog,
+                                                fitgeom=fitgeom)
+
                     align_table.select_fit(catalog_name, method_name)
                     align_table.apply_fit(headerlet_filenames=headerlet_filenames,
                                          fit_label=fit_label)

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -138,6 +138,8 @@ def characterize_gaia_distribution(hap_obj, json_timestamp=None, json_time_since
     # if log_level is either 'DEBUG' or 'NOTSET', write out GAIA sources to DS9 region file
     if log_level <= logutil.logging.DEBUG:
         reg_file = "{}_gaia_sources.reg".format(hap_obj.drizzle_filename[:-9])
+        cname = gaia_table.colnames[0]
+        gaia_table.rename_column(cname, "#{}".format(cname))  # Make reg file DS9-compatible
         gaia_table.write(reg_file, format='ascii.csv')
         log.debug("Wrote GAIA source RA and Dec positions to DS9 region file '{}'".format(reg_file))
 
@@ -1110,7 +1112,7 @@ def generate_gaia_catalog(hap_obj, columns_to_remove=None):
 def compare_photometry(drizzle_list, json_timestamp=None, json_time_since_epoch=None,
                        log_level=logutil.logging.NOTSET):
     """Compare photometry measurements for sources cross matched between the Point and Segment catalogs.
- 
+
     DEPRECATED
 
     Report the magnitudes, as well as the mean difference, standard deviation of the mean, and median


### PR DESCRIPTION
Some datasets end up causing 'tweakwcs' to throw an Exception when attempting to perform a fit to GAIA after doing a relative fit amongst the input images.  This update adds logic to trap that Exception from `tweakwcs.align__wcs`, resets the AlignmentTable instance by calling the `configure_fit` method, then tries another fit using the `default` to the reference catalog.  

This is still not guaranteed to work for all datasets, but for visit `ibjc44`, it results in a successful fit finally being applied.

In addition, a very minor fix was also included to update the GAIA catalog DS9 `.reg` file generated in debug mode by making the column header row a comment.  