### PR TITLE
Refine auto kernel

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -498,7 +498,7 @@ def compute_2d_background(imgarr, box_size, win_size,
     return bkg_background, bkg_median, bkg_rms, bkg_rms_median
 
 def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
-                      good_fwhm=[1.0, 4.0], num_fwhm=3,
+                      good_fwhm=[1.0, 4.0], num_fwhm=30,
                       isolation_size=11, saturation_limit=70000.):
     """Build kernel for use in source detection based on image PSF
     This algorithm looks for an isolated point-source that is non-saturated to use as a template

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -588,6 +588,7 @@ def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
                         kernel = None
                     else:
                         log.debug("Determined FWHM from sample PSF of {:.2f}".format(kernel_fwhm))
+                        log.debug("  based on good range of FWHM:  {:.1f} to {:.1f}".format(good_fwhm[0], good_fwhm[1]))
                         if good_fwhm[1] > kernel_fwhm > good_fwhm[0]:  # This makes it hard to work with sub-sampled data (WFPC2?)
                             fwhm = kernel_fwhm
                             kernel_psf = True
@@ -1712,6 +1713,12 @@ def determine_focus_index(img, sigma=1.5):
        This returns a single value that serves as an indication of the
        sharpness of the image based on the max pixel value from the image
        after applying a Laplacian-of-Gaussian filter with sigma.
+
+       Implementation based on discussion from:
+       https://stackoverflow.com/questions/7765810/is-there-a-way-to-detect-if-an-image-is-blurry
+
+       as supported by:
+       Pertuz, S., et.al., 2013, Pattern Recognition, 46:1415–1432
 
        This index needs to be based on 'max' value in order to avoid
        field-dependent biases, since the 'max' value will correspond

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -498,7 +498,7 @@ def compute_2d_background(imgarr, box_size, win_size,
     return bkg_background, bkg_median, bkg_rms, bkg_rms_median
 
 def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
-                      good_fwhm=[1.0, 4.0], num_fwhm=30,
+                      good_fwhm=[1.0, 4.0], num_fwhm=3,
                       isolation_size=11, saturation_limit=70000.):
     """Build kernel for use in source detection based on image PSF
     This algorithm looks for an isolated point-source that is non-saturated to use as a template

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -107,6 +107,7 @@ class CatalogImage:
         k, self.kernel_fwhm = astrometric_utils.build_auto_kernel(self.data,
                                                                   self.wht_image,
                                                                   good_fwhm=good_fwhm,
+                                                                  num_fwhm=30,
                                                                   threshold=self.bkg_rms_ra,
                                                                   fwhm=fwhmpsf / self.imgwcs.pscale)
         (self.kernel, self.kernel_psf) = k
@@ -398,7 +399,8 @@ class HAPCatalogs:
                                 self.param_dict['negative_percent'],
                                 self.param_dict['negative_threshold'],
                                 self.param_dict['nsigma_clip'],
-                                self.param_dict['maxiters'])
+                                self.param_dict['maxiters'],
+                                self.param_dict['good_fwhm'])
 
         # Initialize all catalog types here...
         # This does NOT identify or measure sources to create the catalogs at this point...

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -92,7 +92,8 @@ class CatalogImage:
                      negative_percent=15.0,
                      negative_threshold=-0.5,
                      nsigma_clip=3.0,
-                     maxiters=3):
+                     maxiters=3,
+                     good_fwhm=[1.5, 3.5]):
 
         if self.bkg_background_ra is None:
             self.compute_background(box_size, win_size,
@@ -105,6 +106,7 @@ class CatalogImage:
 
         k, self.kernel_fwhm = astrometric_utils.build_auto_kernel(self.data,
                                                                   self.wht_image,
+                                                                  good_fwhm=good_fwhm,
                                                                   threshold=self.bkg_rms_ra,
                                                                   fwhm=fwhmpsf / self.imgwcs.pscale)
         (self.kernel, self.kernel_psf) = k

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -707,7 +707,7 @@ class HAPPointCatalog(HAPCatalogBase):
                 # apply mask for each separate range of WHT values
                 region = image * mask['mask']
                 # Compute separate threshold for each 'region'
-                reg_rms = self.image.bkg_rms_ra * mask['mask'] / mask['rel_weight']
+                reg_rms = self.image.bkg_rms_ra * np.sqrt(mask['mask'] / mask['rel_weight'].max())
                 reg_rms_median = np.nanmedian(reg_rms[reg_rms > 0])
 
                 # find ALL the sources!!!

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -1,6 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
+    "good_fwhm": [1.5, 3.5],
     "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -1,6 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
+    "good_fwhm": [1.5, 3.5],
     "nsigma": 3.0,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -1,6 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
+    "good_fwhm": [1.5, 3.5],
     "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -1,6 +1,7 @@
 {
     "bkg_box_size": 27,
     "bkg_filter_size": 3,
+    "good_fwhm": [1.5, 3.5],
     "nsigma": 5,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,


### PR DESCRIPTION
These changes enable more control over how the code determines the FWHM and kernel from the PSFs actually found in the image being processed.  This includes:

- adds 'good_fwhm' range to the catalog generation config files as a controllable parameter
- increases the number of attempts to find a valid PSF by a factor of 10 

This was implemented to address problems with WFC3/IR data returning measured FWHM based on nearly saturated sources which apparently have a skewed PSF with a FWHM much greater than the actual PSF found for high S/N but non-saturated sources.   

This was tested using data from `icnw34` to return a FWHM closer to 1.1 instead of 3.45.    