### PR TITLE
Set the gain to a value of 1.0 when processing ACS/SBC data

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -766,6 +766,13 @@ class HAPPointCatalog(HAPCatalogBase):
 
         # Create the list of photometric apertures to measure
         phot_apers = [CircularAperture(pos_xy, r=r) for r in self.aper_radius_list_pixels]
+
+        # Perform aperture photometry - the input data should NOT be background subtracted
+        # Make sure to account for the fact that SBC does not have a "gain" value
+        gain = self.gain
+        if self.image.keyword_dict["detector"] == "SBC":
+            gain = 1.0
+
         # Perform aperture photometry
         photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers,
                                                                 bg_apers,
@@ -774,7 +781,7 @@ class HAPPointCatalog(HAPCatalogBase):
                                                                 photplam=self.image.keyword_dict['photplam'],
                                                                 error_array=self.image.bkg_rms_ra,
                                                                 bg_method=self.param_dict['salgorithm'],
-                                                                epadu=self.gain)
+                                                                epadu=gain)
 
         # calculate and add RA and DEC columns to table
         ra, dec = self.transform_list_xy_to_ra_dec(photometry_tbl["X-Center"], photometry_tbl["Y-Center"], self.imgname)  # TODO: replace with all_pix2sky or somthing at a later date
@@ -1484,6 +1491,12 @@ class HAPSegmentCatalog(HAPCatalogBase):
             phot_apers = [CircularAperture(pos_xy, r=r) for r in self.aper_radius_list_pixels]
 
             # Perform aperture photometry - the input data should NOT be background subtracted
+            # Make sure to account for the fact that SBC does not have a "gain" value
+            gain = self.gain
+            if self.image.keyword_dict["detector"] == "SBC":
+                gain = 1.0
+
+            # Perform aperture photometry - the input data should NOT be background subtracted
             photometry_tbl = photometry_tools.iraf_style_photometry(phot_apers,
                                                                     bg_apers,
                                                                     data=input_image,
@@ -1491,7 +1504,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                                     photplam=self.image.keyword_dict['photplam'],
                                                                     error_array=self.image.bkg_rms_ra,
                                                                     bg_method=self.param_dict['salgorithm'],
-                                                                    epadu=self.gain)
+                                                                    epadu=gain)
 
             # Capture data computed by the photometry tools and append to the output table
             filter_measurements_table['FluxAp1'][good_rows_index] = photometry_tbl['FluxAp1']


### PR DESCRIPTION
Ensure the photometry routine has a value of 1.0 for the ACS/SBC gain to avoid values being set to nan and causing
all of the sources to be trimmed from the output catalogs.