### PR TITLE
Fix saturation mask application to input files

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -769,9 +769,19 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_lev
 
 def _get_envvar_switch(envvar_name, default=None):
     """
-    This private routine interprets the environment variable, SVM_QUALITY_TESTING,
-    if specified.  NOTE: This is a copy of the routine in runastrodriz.py.  This
-    code should be put in a common place.
+    This private routine interprets any environment variable, such as SVM_QUALITY_TESTING.
+
+    PARAMETERS
+    -----------
+    envvar_name : str
+        name of environment variable to be interpreted
+
+    default : str or None
+        Value to be used in case environment variable was not defined or set.
+
+    .. note :
+    This is a copy of the routine in runastrodriz.py.  This code should be put in a common place.
+
     """
     if envvar_name in os.environ:
         val = os.environ[envvar_name].lower()

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -575,7 +575,7 @@ class HAPImage:
                 outroot = None
 
             dqmask = self.build_dqmask(chip=chip)
-            sciarr = self.imghdu[("SCI", chip)].data
+            sciarr = self.imghdu[("SCI", chip)].data.copy()
             #  TODO: replace detector_pars with dict from OO Config class
             extract_pars = {'classify': alignment_pars['classify'],
                             'centering_mode': alignment_pars['centering_mode'],

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -488,10 +488,10 @@ def compute_2d_background(imgarr, box_size, win_size,
         log.info("Background2D failure detected. Using alternative background calculation instead....")
         mask = make_source_mask(imgarr, nsigma=2, npixels=5, dilate_size=11)
         sigcl_mean, sigcl_median, sigcl_std = sigma_clipped_stats(imgarr, sigma=3.0, mask=mask, maxiters=9)
-        bkg_median = sigcl_median
+        bkg_median = max(0.0, sigcl_median)
         bkg_rms_median = sigcl_std
         # create background frame shaped like imgarr populated with sigma-clipped median value
-        bkg_background = np.full_like(imgarr, sigcl_median)
+        bkg_background = np.full_like(imgarr, bkg_median)
         # create background frame shaped like imgarr populated with sigma-clipped standard deviation value
         bkg_rms = np.full_like(imgarr, sigcl_std)
 
@@ -723,11 +723,9 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         evaluating each of the identified segments (sources) from the chip.
     """
     # apply any provided dqmask for segmentation only
+    imgarr = img.copy()
     if dqmask is not None:
-        imgarr = img.copy()
         imgarr[dqmask] = 0
-    else:
-        imgarr = img
 
     if segment_threshold is None:
         dao_threshold, bkg = sigma_clipped_bkg(imgarr, sigma=4.0, nsigma=dao_nsigma)


### PR DESCRIPTION
The input (hst* FLT/FLC) files were having the SCI array corrupted by the computation of saturation masks around sources in the image during image alignment for single image filter product inputs that had their cosmic-rays identified.  These changes prevent the corruption of the SCI arrays by insuring that the masking of saturated sources only occurs on copies of the inputs.

In addition, the docstring for the `_get_envvar_switch()` from hapsequencer was updated and the sigma_clipped_stats median was limited to 0 in source finding for image alignment.  
   