### PR TITLE
Fix problem defining masks for use in point catalog generation

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -839,8 +839,7 @@ class HAPPointCatalog(HAPCatalogBase):
                 # Compute separate threshold for each 'region'
                 reg_rms = self.image.bkg_rms_ra * np.sqrt(mask['mask'] / mask['rel_weight'].max())
                 reg_rms_median = np.nanmedian(reg_rms[reg_rms > 0])
-                wht_scale = np.nanmedian(np.sqrt((mask['mask'] / mask['rel_weight'].max())[mask['mask'] > 0]))
-                log.info("Mask {}: rel = {},  wht_scale = {}".format(mask['wht_limit'], mask['rel_weight'].max(), wht_scale))
+                log.info("Mask {}: rel = {}".format(mask['wht_limit'], mask['rel_weight'].max()))
 
                 # find ALL the sources!!!
                 if self.param_dict["starfinder_algorithm"] == "dao":

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -657,7 +657,7 @@ class HAPCatalogBase:
         self.tp_sources = tp_sources
 
         # create mask to reject any sources located less than 10 pixels from a image/chip edge
-        wht_image = self.image.data.copy()
+        wht_image = np.nan_to_num(self.image.data, 0.0)
         binary_inverted_wht = np.where(wht_image == 0, 1, 0)
         self.exclusion_mask = ndimage.binary_dilation(binary_inverted_wht, iterations=10)
 
@@ -839,7 +839,7 @@ class HAPPointCatalog(HAPCatalogBase):
                 # Compute separate threshold for each 'region'
                 reg_rms = self.image.bkg_rms_ra * np.sqrt(mask['mask'] / mask['rel_weight'].max())
                 reg_rms_median = np.nanmedian(reg_rms[reg_rms > 0])
-                wht_scale = np.nanmedian(np.sqrt(mask['mask'] / mask['rel_weight'].max()))
+                wht_scale = np.nanmedian(np.sqrt((mask['mask'] / mask['rel_weight'].max())[mask['mask'] > 0]))
                 log.info("Mask {}: rel = {},  wht_scale = {}".format(mask['wht_limit'], mask['rel_weight'].max(), wht_scale))
 
                 # find ALL the sources!!!

--- a/drizzlepac/haputils/quality_analysis.py
+++ b/drizzlepac/haputils/quality_analysis.py
@@ -525,7 +525,7 @@ def run_all(input, files, catalogs=None, log_level=logutil.logging.NOTSET):
 
     if catalogs is not None:
         try:
-            if not 'json_files' in locals(): # create empty list if there's an exception thrown by determine_alignment_residuals
+            if not 'json_files' in locals():  # create empty list if there's an exception thrown by determine_alignment_residuals
                 json_files = []
             gaia_files = determine_gaia_residuals(catalogs,
                                                   json_timestamp=json_timestamp,


### PR DESCRIPTION
Changes were needed to correctly interpret the weight region masks (only median non-zero pixels) and to correctly treat any NaNs in the total image when creating the exclusion masks. 

These changes allow the point-catalog to detect sources again, as confirmed by testing with the data from visit `ibe809`.

