### PR TITLE
Erode the footprint mask to ensure false sources are not detected along any boundary

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -228,7 +228,8 @@ class CatalogImage:
 
         # In order to compute the proper statistics on the input data, need to use the footprint
         # mask to get the actual data - illuminated portion (True), non-illuminated (False).
-        self.footprint_mask = self.num_images_mask > 0
+        footprint_mask = self.num_images_mask > 0
+        self.footprint_mask = ndimage.binary_erosion(footprint_mask, iterations=10)
         self.inv_footprint_mask = np.invert(self.footprint_mask)
 
         # If the image contains a lot of values identically equal to zero (as in some SBC images),


### PR DESCRIPTION
Erode the footprint_mask to avoid detection of sources along any boundary where the boundary is approximately 10 pixels deep.