### PR TITLE
Initial draft of catalog rejection description

### DIFF
--- a/doc/source/catalog_generation.rst
+++ b/doc/source/catalog_generation.rst
@@ -411,6 +411,9 @@ Also note that we reject both the point and segment catalogs if either one fails
 behind that is that since the catalogs are based on the same image, it is unlikely that one catalog will be
 good and the other contaminated.
 
+Should the catalogs fail this test, neither type of catalogs will be written out to disk for this visit.
+
+
 3.3.2 Single-image CR Rejection
 """"""""""""""""""""""""""""""""
 An algorithm has been implemented to identify and ignore cosmic-rays in single exposures.  This algorithm has

--- a/doc/source/catalog_generation.rst
+++ b/doc/source/catalog_generation.rst
@@ -373,7 +373,29 @@ output product.
   This rejection criteria is NOT applied to WFC3/IR or ACS/SBC data since they are not affected by cosmic-rays
   in the same way as the other detectors.
 
-3.3.1 Rejection Criteria
+3.3.1 Single-image CR Rejection Algorithm
+"""""""""""""""""""""""""""""""""""""""""""
+An algorithm has been implemented to identify and ignore cosmic-rays in single exposures.  This algorithm has
+been used for ignoring cosmic-rays during the image alignment code used to determine the *a posteriori*
+alignment to GAIA.
+
+This algorithm starts by evaluating the central moments of all sources from the segment catalog.
+Any source where the maximum central moment (as determined by
+`photutils.segmentation.SourceProperties <https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.SourceProperties.html#photutils.segmentation.SourceProperties>`_
+is 0 for both X and Y moments gets identified as cosmic-rays.  This indicates that the source has a
+concentration of flux greater than a point-source and most probably represents a 'head-on cosmic-ray'.
+
+In addition to these 'head-on cosmic-rays', 'glancing cosmic-rays' produce streaks across the detector.
+Those are identified by identifying sources with a minimum width (semiminor_axis) less than the FWHM of a point source
+and an elongation > 2.  The width and elongation are also properties defined by
+`photutils.segmentation.SourceProperties <https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.SourceProperties.html#photutils.segmentation.SourceProperties>`_.
+The combination of these criteria allows for the identification of a vast majority of cosmic-rays.  The DQ array
+of the single exposure then gets updated to flag those pixels identified as cosmic-rays based on these criteria.
+These DQ flags are then ONLY applied when creating the TotalProduct to limit the contribution of cosmic-rays
+from the total detection image.  These flags are NOT used to generate any other product in order to avoid
+affecting the photometry or astrometry of any source from the total detection image any more than necessary.
+
+3.3.2 Rejection Criteria
 """""""""""""""""""""""""
 The rejection criteria has been defined so that if either the point source catalog or the segment catalog fails,
 then both catalogs are rejected and deleted.
@@ -412,29 +434,6 @@ behind that is that since the catalogs are based on the same image, it is unlike
 good and the other contaminated.
 
 Should the catalogs fail this test, neither type of catalogs will be written out to disk for this visit.
-
-
-3.3.2 Single-image CR Rejection
-""""""""""""""""""""""""""""""""
-An algorithm has been implemented to identify and ignore cosmic-rays in single exposures.  This algorithm has
-been used for ignoring cosmic-rays during the image alignment code used to determine the *a posteriori*
-alignment to GAIA.
-
-This algorithm starts by evaluating the central moments of all sources from the segment catalog.
-Any source where the maximum central moment (as determined by
-`photutils.segmentation.SourceProperties <https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.SourceProperties.html#photutils.segmentation.SourceProperties>`_
-is 0 for both X and Y moments gets identified as cosmic-rays.  This indicates that the source has a
-concentration of flux greater than a point-source and most probably represents a 'head-on cosmic-ray'.
-
-In addition to these 'head-on cosmic-rays', 'glancing cosmic-rays' produce streaks across the detector.
-Those are identified by identifying sources with a minimum width (semiminor_axis) less than the FWHM of a point source
-and an elongation > 2.  The width and elongation are also properties defined by
-`photutils.segmentation.SourceProperties <https://photutils.readthedocs.io/en/stable/api/photutils.segmentation.SourceProperties.html#photutils.segmentation.SourceProperties>`_.
-The combination of these criteria allows for the identification of a vast majority of cosmic-rays.  The DQ array
-of the single exposure then gets updated to flag those pixels identified as cosmic-rays based on these criteria.
-These DQ flags are then ONLY applied when creating the TotalProduct to limit the contribution of cosmic-rays
-from the total detection image.  These flags are NOT used to generate any other product in order to avoid
-affecting the photometry or astrometry of any source from the total detection image any more than necessary.
 
 
 Segment Photometric Catalog Generation

--- a/doc/source/runsinglehap.rst
+++ b/doc/source/runsinglehap.rst
@@ -4,7 +4,7 @@
 API for runsinglehap
 ====================
 The task ``runsinglehap`` serves as the primary interface for processing data
-from a single-visit into a uniform set of images.  
+from a single-visit into a uniform set of images.
 
 .. automodule:: drizzlepac.runsinglehap
 
@@ -13,7 +13,7 @@ from a single-visit into a uniform set of images.
 
 Supporting code
 ===============
-These modules and functions provide the core functionality for the single-visit 
+These modules and functions provide the core functionality for the single-visit
 processing.
 
 .. _product_api:
@@ -32,6 +32,11 @@ drizzlepac.haputils.product
 drizzlepac.haputils.poller_utils
 --------------------------------
 .. automodule:: drizzlepac.haputils.poller_utils
+.. autofunction:: drizzlepac.haputils.poller_utils.interpret_obset_input
+.. autofunction:: drizzlepac.haputils.poller_utils.parse_obset_tree
+.. autofunction:: drizzlepac.haputils.poller_utils.build_obset_tree
+.. autofunction:: drizzlepac.haputils.poller_utils.build_poller_table
+
 
 
 .. _catalog_utils_api:
@@ -39,13 +44,12 @@ drizzlepac.haputils.poller_utils
 drizzlepac.haputils.catalog_utils
 ----------------------------------
 .. automodule:: drizzlepac.haputils.catalog_utils
+.. autoclass:: drizzlepac.haputils.catalog_utils.CatalogImage
+.. autoclass:: drizzlepac.haputils.catalog_utils.HAPCatalogs
+.. autoclass:: drizzlepac.haputils.catalog_utils.HAPCatalogBase
+.. autoclass:: drizzlepac.haputils.catalog_utils.HAPPointCatalog
+.. autoclass:: drizzlepac.haputils.catalog_utils.HAPSegmentCatalog
 
-
-.. _sourcelist_generation_api:
-
-drizzlepac.haputils.sourcelist_generation
-------------------------------------------
-.. automodule:: drizzlepac.haputils.sourcelist_generation
 
 
 .. _photometry_tools_api:
@@ -53,6 +57,9 @@ drizzlepac.haputils.sourcelist_generation
 drizzlepac.haputils.photometry_tools
 -------------------------------------
 .. automodule:: drizzlepac.haputils.photometry_tools
+.. autofunction:: drizzlepac.haputils.photometry_tools.iraf_style_photometry
+.. autofunction:: drizzlepac.haputils.photometry_tools.compute_phot_error
+.. autofunction:: drizzlepac.haputils.photometry_tools.convert_flux_to_abmag
 
 
 
@@ -61,4 +68,5 @@ drizzlepac.haputils.photometry_tools
 drizzlepac.haputils.processing_utils
 -------------------------------------
 .. automodule:: drizzlepac.haputils.processing_utils
-
+.. autofunction:: drizzlepac.haputils.processing_utils.refine_product_headers
+.. autofunction:: drizzlepac.haputils.processing_utils.compute_sregion

--- a/drizzlepac/haputils/photometry_tools.py
+++ b/drizzlepac/haputils/photometry_tools.py
@@ -112,9 +112,9 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, photflam, photplam
     final_stacked = np.stack([x, y, phot["id"].data], axis=1)
     # n_aper = 0
     name_list = 'Flux', 'FluxErr', 'Mag', 'MagErr'
-    for aper_string  in ['Ap1', 'Ap2']:
+    for aper_string in ['Ap1', 'Ap2']:
         for col_name in name_list:
-            names.append("{}{}".format(col_name,aper_string))
+            names.append("{}{}".format(col_name, aper_string))
 
     # for item in list(phot.keys()):
     #     if item.startswith("aperture_sum_") and not item.startswith("aperture_sum_err_"):
@@ -191,7 +191,7 @@ def compute_phot_error(flux_variance, bg_phot, bg_method, ap_area, epadu=1.0):
         an array of flux errors
     """
 
-    bg_variance_terms = (ap_area * bg_phot['aperture_std'] ** 2.) * (1. + ap_area/bg_phot['aperture_area'])
+    bg_variance_terms = (ap_area * bg_phot['aperture_std'] ** 2.) * (1. + ap_area / bg_phot['aperture_area'])
     variance = flux_variance / epadu + bg_variance_terms
     flux_error = variance ** .5
     return flux_error
@@ -224,6 +224,6 @@ def convert_flux_to_abmag(in_flux, photflam, photplam):
     stmag = -2.5 * np.log10(f_lambda) - 21.10
 
     # Convert STMAG to ABMAG
-    abmag =  stmag - 5.0 * np.log10(photplam) + 18.6921
+    abmag = stmag - 5.0 * np.log10(photplam) + 18.6921
 
     return abmag

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -38,7 +38,7 @@ def get_rules_file(product):
 
     if new_rules_name not in os.listdir('.'):
         shutil.copy(rules_filename, new_rules_filename)
-        #shutil.copy(rules_filename, os.getcwd())
+
     return new_rules_name
 
 def refine_product_headers(product, total_obj_list):
@@ -158,12 +158,10 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
                     name_col.append(expname)
                 else:
                     # Convert input exposure names into HAP names
-                    foundit = False
                     for tot_obj in total_obj_list:
                         for exposure in tot_obj.edp_list:
                             if rootname in exposure.full_filename:
                                 name_col.append(exposure.drizzle_filename)
-                                foundit = True
                                 break
 
     # define new column with HAP expname


### PR DESCRIPTION
An initial draft of text describing the basic algorithm implemented to determine whether to reject the catalogs based on contributions from cosmic-rays.  This description includes the description of the single-image cosmic-ray rejection algorithm that is applied to the single image filter product exposures to partially mitigate the effects of cosmic-ray contamination in the total detection image.  

In addition, the API documentation for the runsinglehap interface was updated to include pointers to the current set of classes and functions in the primary SVM modules.  

Finally, a few small Flake8 (PEP8) corrections were included for some of the code being documented in the runsinglehap API docs.  