### PR TITLE
Change analyze error to warning

### DIFF
--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -80,7 +80,7 @@ def analyze_wrapper(input_file_list, log_level=logutil.logging.NOTSET):
 
     # Extract only the filenames of viable images for processing (i.e., doProcess == 1)
     if filtered_table['doProcess'].sum() == 0:
-        log.error("No viable images in single/multiple visit table - no processing done.\n")
+        log.warning("No viable images in single/multiple visit table - no processing done.\n")
     else:
         # Get the list of all "good" files to use for the alignment
         process_list = filtered_table['imageName'][np.where(filtered_table['doProcess'])]


### PR DESCRIPTION
The error message generated by 'haputils.analyze' when no exposures meet the criteria for processing causes the pipeline to think there was a problem needing reprocessing.  This message has simply been reset to a warning instead so that the trailer file still records what processing was not done and why without causing problems for pipeline processing. 