### PR TITLE
Insure IPPPSSOO keyword has correct value

### DIFF
--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -87,7 +87,7 @@ def refine_product_headers(product, total_obj_list):
     # Compute numexp as number of exposures NOT chips
     input_exposures = list(set([kw[1].split('[')[0] for kw in phdu['d*data'].items()]))
     if level == 1:
-        ipppssoots = [fname.split('_')[0] for fname in input_exposures]
+        ipppssoots = [fits.getval(fname, 'rootname') for fname in input_exposures]
         phdu['ipppssoo'] = ';'.join(ipppssoots)
     phdu['numexp'] = len(input_exposures)
 


### PR DESCRIPTION
The value of the IPPPSSOO keyword in the header of the SVM exposure drizzle product now gets defined to remain as the original 'ipppssoot' value from the calibrated input (*flc.fits/*flt.fits file) exposure.  

This is a required change to insure that these products can be correctly managed by the archive.  This change was successfully tested using the SVM dataset `ib2t06`.