### PR TITLE
MVM: output from poller utility should only contain specified sky cells when input from a "pipeline" poller file

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -139,13 +139,13 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
                        log_level=logutil.logging.INFO):
     """
     Run the HST Advanced Products (HAP) generation code.  This routine is the sequencer or
-    controller which invokes the high-level functionality to process the single visit data.
+    controller which invokes the high-level functionality to process the multi-visit data.
 
     Parameters
     ----------
     input_filename: string
-        The 'poller file' where each line contains information regarding an exposures taken
-        during a single visit.
+        The 'poller file' where each line contains information regarding an exposures considered
+        part of the multi-visit.
 
     diagnostic_mode : bool, optional
         Allows printing of additional diagnostic information to the log.  Also, can turn on
@@ -167,8 +167,8 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         available during the processing session.  The default is None.
 
     phot_mode : str, optional
-        Which algorithm should be used to generate the sourcelists? 'aperture' for aperture photometry;
-        'segment' for segment map photometry; 'both' for both 'segment' and 'aperture'. Default value is 'both'.
+        Which algorithm should be used to generate the sourcelists? 'aperture' for aperture (point) photometry;
+        'segment' for isophotal photometry; 'both' for both 'segment' and 'aperture'. Default value is 'both'.
 
     log_level : int, optional
         The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
@@ -197,7 +197,7 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
     total_obj_list = []
     product_list = []
     try:
-        # Parse the poller file and generate the the obs_info_dict, as well as the total detection
+        # Parse the MVM poller file and generate the the obs_info_dict, as well as the total detection
         # product lists which contain the ExposureProduct, FilterProduct, and TotalProduct objects
         # A poller file contains visit data for a single instrument.  The TotalProduct discriminant
         # is the detector.  A TotalProduct object is comprised of FilterProducts and ExposureProducts
@@ -207,12 +207,12 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         obs_info_dict, total_obj_list = poller_utils.interpret_mvm_input(input_filename, log_level,
                                                                          layer_method='all')
 
-        # Generate the name for the manifest file which is for the entire visit.  It is fine
+        # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
         # to use only one of the Total Products to generate the manifest name as the name is not
         # dependent on the detector.
         # Example: instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
         manifest_name = total_obj_list[0].manifest_name
-        log.info("\nGenerate the manifest name for this visit.")
+        log.info("\nGenerate the manifest name for this multi-visit.")
         log.info("The manifest will contain the names of all the output products.")
 
         # The product_list is a list of all the output products which will be put into the manifest file

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -197,7 +197,7 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0):
     Parameters
     -----------
     results : str or list
-        Input poller file name or Python list of dataset names to be processed as a single visit.
+        Input poller file name or Python list of dataset names to be processed for a multi-visit.
         Dataset names have to be either the filename of a singleton (non-associated exposure) or the
         name of an ASN file (e.g., jabc01010_asn.fits).
 
@@ -222,18 +222,17 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0):
 
     Notes
     -------
-    Interpret the database query for a given obset to prepare the returned
-    values for use in generating the names of all the expected output products.
+    Interpret the contents of the MVM poller file for the values to use in generating
+    the names of all the expected output products.
 
     Input will have format of:
-
-        ib4606c5q_flc.fits,11665,B46,06,1.0,F555W,UVIS,/ifs/archive/ops/hst/public/ib46/ib4606c5q/ib4606c5q_flc.fits
+        ib4606c5q_flc.fits,11665,B46,06,1.0,F555W,UVIS,skycell-p2381x05y09,NEW,/ifs/archive/ops/hst/public/ib46/ib4606c5q/ib4606c5q_flc.fits
 
         which are
-        filename, proposal_id, program_id, obset_id, exptime, filters, detector, pathname, skycell_ids, skycell_processed
+        filename, proposal_id, program_id, obset_id, exptime, filters, detector, skycell-p<PPPP>x<XX>y<YY>, [OLD|NEW], pathname
 
     The SkyCell ID will be included in this input information to allow for
-    grouping of exposures into the same SkyCell layer based on filter, exptime and year.
+    grouping of exposures into the same SkyCell layer based on filter, exptime, and year.
 
     Output dict will have only have definitions for each defined sky cell layer to
     be either created or updated based on the input exposures being processed.
@@ -251,7 +250,7 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0):
         .
         .
         .
-        obs_info_dict["layer 01": {"info": '11665 06 wfc3 uvis f555w long 2011 drc',
+        obs_info_dict["layer 02": {"info": '11665 06 wfc3 uvis f555w long 2011 drc',
                                    "files": ['ib4606c9q_flc.fits', 'ib4606ceq_flc.fits']}
         .
         .


### PR DESCRIPTION
The "pipeline" MVM poller file specifies the skycell for each entry in the file.  In actuality, every entry has the same skycell id in the file.  The poller utility supports input not only from a poller file, but also a list of filenames where the skycell ids are computed.  The output table from the poller utility when MVM and input comes from a poller file, needs to be trimmed to contain only the specified sky cells.