### PR TITLE
Populate HAP keywords in copied HAP input files

### DIFF
--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -161,7 +161,7 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
                     for tot_obj in total_obj_list:
                         for exposure in tot_obj.edp_list:
                             if rootname in exposure.full_filename:
-                                name_col.append(exposure.drizzle_filename)
+                                name_col.append(exposure.product_basename)
                                 break
 
     # define new column with HAP expname

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -522,7 +522,7 @@ class ExposureProduct(HAPProduct):
 
         # Add HAP keywords as required by pipeline processing
         with fits.open(edp_filename, mode='update') as edp_hdu:
-            edp_hdu[0].header['HAPLEVEL'] = (0, 'Classificaion level of this product')
+            edp_hdu[0].header['HAPLEVEL'] = (0, 'Classification level of this product')
             edp_hdu[0].header['IPPPSSOO'] = edp_hdu[0].header['ROOTNAME']
             edp_hdu[0].header['FILENAME'] = edp_filename
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -520,8 +520,11 @@ class ExposureProduct(HAPProduct):
         except PermissionError:
             pass
 
-        # Add HAPLEVEL keyword as required by pipeline processing
-        fits.setval(edp_filename, 'HAPLEVEL', value=0, comment='Classificaion level of this product')
+        # Add HAP keywords as required by pipeline processing
+        with fits.open(edp_filename, mode='update') as edp_hdu:
+            edp_hdu[0].header['HAPLEVEL'] = (0, 'Classificaion level of this product')
+            edp_hdu[0].header['IPPPSSOO'] = edp_hdu[0].header['ROOTNAME']
+            edp_hdu[0].header['FILENAME'] = edp_filename
 
         return edp_filename
 


### PR DESCRIPTION
A number of keywords need to be updated/added to the HAP input files when they are created as copies of the original calibrated pipeline (FLT/FLC) files.  These changes include:

- updating 'FILENAME' with the new HAP filename to replace the original 'ipppssoot'-based filename
- adding the 'IPPPSSOO' keyword to the primary header 
- updating the 'HAPEXPNAME' column in the HAP DRZ product HDRTAB table with the basename, not full filename.

These changes address the issues identified in try to define the correct release date for the HAP products. 