### PR TITLE
WIP: Too many resources are used even when and MVM poller file is used as input

### DIFF
--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -861,7 +861,6 @@ def build_poller_table(input, log_level, poller_type='svm'):
         skycell_obj = cell_utils.SkyCell(name=pipeline_skycell_id)
         skycell_obj.members = filenames
         scells[pipeline_skycell_id] = skycell_obj
-        log.debug("MVM and poller file. scells: {}".format(scells))
         scell_files = cell_utils.interpret_scells(scells)
         log.debug("MVM and poller file. scell_files: {}".format(scell_files))
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -861,9 +861,9 @@ def build_poller_table(input, log_level, poller_type='svm'):
         skycell_obj = cell_utils.SkyCell(name=pipeline_skycell_id)
         skycell_obj.members = filenames
         scells[pipeline_skycell_id] = skycell_obj
-        print("type: {} scells: {}".format(type(scells), scells))
+        log.debug("MVM and poller file. scells: {}".format(scells))
         scell_files = cell_utils.interpret_scells(scells)
-        print("type: {} scell_files: {}".format(type(scell_files), scell_files))
+        log.debug("MVM and poller file. scell_files: {}".format(scell_files))
 
     # If processing a list of files, evaluate each input dataset for the information needed
     # for the poller file

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -851,10 +851,19 @@ def build_poller_table(input, log_level, poller_type='svm'):
         cols[cname] = []
     cols['filename'] = usable_datasets
 
-    if poller_type == 'mvm':
-        # determine sky-cell ID for input exposures now...
-        scells = cell_utils.get_sky_cells(usable_datasets)
+    # If MVM processing and a poller file is the input, this implies there is
+    # only one skycell of interest for all the listed filenames in the poller
+    # file. Establish the WCS, but no need for discovery of overlapping skycells
+    # as would be the case for an input list of filenames.
+    if poller_type == 'mvm' and is_poller_file:
+        pipeline_skycell_id = input_table[0]['skycell_id']
+        scells = {}
+        skycell_obj = cell_utils.SkyCell(name=pipeline_skycell_id)
+        skycell_obj.members = filenames
+        scells[pipeline_skycell_id] = skycell_obj
+        print("type: {} scells: {}".format(type(scells), scells))
         scell_files = cell_utils.interpret_scells(scells)
+        print("type: {} scell_files: {}".format(type(scell_files), scell_files))
 
     # If processing a list of files, evaluate each input dataset for the information needed
     # for the poller file


### PR DESCRIPTION
Replaced cell_utils.get_sky_cells call which does time-consuming and
memory-consuming discovery with more rudimentary functions given that for
poller file input the output sky cell is already defined.