### PR TITLE
Remove hard-coded values for the "good" FWHM search range 

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -112,10 +112,8 @@ class CatalogImage:
                                     nsigma_clip=nsigma_clip,
                                     maxiters=maxiters)
 
-        if self.keyword_dict['detector'].upper() == 'IR':
-            good_fwhm = [1.0, 2.0]
-        else:
-            good_fwhm = [2.0, 3.5]
+        log.info("Attempt to determine FWHM based upon input data within a good FWHM range of {:.1f} to {:.1f}.".format(good_fwhm[0], good_fwhm[1]))
+        log.info("If no good FWHM candidate is identified, a value of {:.1f} will be used instead.".format(fwhmpsf/self.imgwcs.pscale))
         k, self.kernel_fwhm = astrometric_utils.build_auto_kernel(self.data,
                                                                   self.wht_image,
                                                                   good_fwhm=good_fwhm,


### PR DESCRIPTION
The hard-coded values for the FWHM search range in the build_kernel method of the CatalogImage class have been removed, and the values which are read from the detector-specific configuration files are used instead.  These values, as well as the default FWHM value used when no good candidate PSFs are found in the input image, are reported as log.info just before the call to build_auto_kernel.
