### PR TITLE
Revise MVM manifest name to be more generic

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -672,7 +672,7 @@ class SkyCellProduct(HAPProduct):
         layer_scale = layer[1]
 
         self.info = '_'.join(['hst', skycell_name, instrument, detector, filter_str, layer_str])
-
+        self.manifest_info = '_'.join(['hst', skycell_name, instrument, detector, filter_str])
         self.exposure_name = skycell_name
         self.product_basename = self.info
 
@@ -690,7 +690,7 @@ class SkyCellProduct(HAPProduct):
         # to create it as an attribute of a TotalProduct as it is independent of
         # the detector in use.
         # instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
-        self.manifest_name = '_'.join([self.product_basename, "manifest.txt"])
+        self.manifest_name = '_'.join([self.manifest_info, "manifest.txt"])
 
         # Define HAPLEVEL value for this product
         self.haplevel = 3


### PR DESCRIPTION
This simple change makes the MVM manifest name more generic, removing the layer label, so that one manifest file will be more appropriately named for the entire input MVM poller file.  

This will partially address [HLA-455](https://jira.stsci.edu/browse/HLA-455).