### PR TITLE
Rename static mask

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ of the list).
 3.1.9 (unreleased)
 ==================
 
+- revise naming convention for the StaticMask file so that it has a
+  dataset-specific name instead of a generic common name. [#876]
+
 - Update ``runastrodriz`` to work under Windows while adding documentation
   to tell the user to run with ``num_cores`` set to 1.  [#794]
 
@@ -27,7 +30,7 @@ of the list).
 3.1.8 (11-Aug-2020)
 ==================
 
-A number of changes have been implemented to either correct problems or 
+A number of changes have been implemented to either correct problems or
 improve the processed results.  The most significant of the changes are:
 
   - rscale only used for alignment.

--- a/drizzlepac/acsData.py
+++ b/drizzlepac/acsData.py
@@ -15,8 +15,8 @@ class ACSInputImage(imageObject):
 
     SEPARATOR = '_'
 
-    def __init__(self,filename=None,group=None):
-        super().__init__(filename, group=group)
+    def __init__(self,filename=None, output=None, group=None):
+        super().__init__(filename, output=output, group=group)
         # define the cosmic ray bits value to use in the dq array
         self.cr_bits_value = 4096
         self._instrument=self._image["PRIMARY"].header["INSTRUME"]
@@ -50,9 +50,8 @@ class ACSInputImage(imageObject):
         ny=sci_chip._naxis1
         nx=sci_chip._naxis2
         detnum = sci_chip.detnum
-        instr=self._instrument
 
-        sig = (instr + self._detector, (nx, ny), int(chip))  # signature is a tuple
+        sig = (self.outroot, (nx, ny), int(chip))  # signature is a tuple
         sci_chip.signature=sig  # signature is a tuple
 
     def getdarkcurrent(self,extver):
@@ -89,8 +88,8 @@ class ACSInputImage(imageObject):
 
 
 class WFCInputImage(ACSInputImage):
-    def __init__(self, filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename=None,  output=None, group=None):
+        super().__init__(filename, output=output, group=group)
         self.full_shape = (4096, 2048)
         self._detector=self._image["PRIMARY"].header["DETECTOR"]
 
@@ -147,8 +146,8 @@ class WFCInputImage(ACSInputImage):
 
 
 class HRCInputImage (ACSInputImage):
-    def __init__(self, filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename=None,  output=None, group=None):
+        super().__init__(filename, output=output, group=group)
         self._detector = self._image['PRIMARY'].header["DETECTOR"]
         self.full_shape = (1024, 1024)
         amp = self._image['PRIMARY'].header["CCDAMP"]
@@ -208,8 +207,8 @@ class HRCInputImage (ACSInputImage):
 
 
 class SBCInputImage (ACSInputImage):
-    def __init__(self, filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename=None,  output=None, group=None):
+        super().__init__(filename, output=output, group=group)
         self.full_shape = (1024, 1024)
         self._detector = self._image['PRIMARY'].header["DETECTOR"]
 

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -966,7 +966,7 @@ class imageObject(baseImageObject):
         only to the specific chip.
     """
 
-    def __init__(self,filename,group=None,inmemory=False):
+    def __init__(self,filename, output=None, group=None,inmemory=False):
         super().__init__(filename)
 
         #filutil open returns a fits object
@@ -980,6 +980,7 @@ class imageObject(baseImageObject):
         #self._rootname=self._image['PRIMARY'].header["ROOTNAME"]
         self._rootname=fileutil.buildNewRootname(filename)
         self.outputNames=self._setOutputNames(self._rootname)
+        self.outroot = output.split('_')[0] if output else filename.split('_')[0]
 
         # flag to indicate whether or not to write out intermediate products
         # to disk (default) or keep everything in memory

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -981,7 +981,8 @@ class imageObject(baseImageObject):
         self._rootname=fileutil.buildNewRootname(filename)
         self.outputNames=self._setOutputNames(self._rootname)
         self.outroot = output.split('_')[0] if output else filename.split('_')[0]
-
+        self.outroot = self.outroot.lower()
+        
         # flag to indicate whether or not to write out intermediate products
         # to disk (default) or keep everything in memory
         self.inmemory = inmemory

--- a/drizzlepac/nicmosData.py
+++ b/drizzlepac/nicmosData.py
@@ -15,8 +15,8 @@ class NICMOSInputImage(imageObject):
 
     SEPARATOR = '_'
 
-    def __init__(self, filename=None):
-        super().__init__(filename)
+    def __init__(self, filename=None, output=None):
+        super().__init__(filename, output=output)
         self.timeExt = 'TIME'
 
         # define the cosmic ray bits value to use in the dq array
@@ -47,9 +47,8 @@ class NICMOSInputImage(imageObject):
         ny=sci_chip._naxis1
         nx=sci_chip._naxis2
         detnum = sci_chip.detnum
-        instr=self._instrument
 
-        sig=(instr+str(self._detector),(nx,ny),int(detnum)) #signature is a tuple
+        sig=(self.outroot,(nx,ny),int(detnum)) #signature is a tuple
         sci_chip.signature=sig #signature is a tuple
 
 
@@ -211,8 +210,8 @@ class NICMOSInputImage(imageObject):
 
 
 class NIC1InputImage(NICMOSInputImage):
-    def __init__(self, filename=None):
-        super().__init__(filename)
+    def __init__(self, filename=None, output=None):
+        super().__init__(filename, output=output)
         self._effGain = 1. #get the gain from the detector subclass
         self._detector = self._image["PRIMARY"].header["CAMERA"]
         self.proc_unit = "native"
@@ -276,8 +275,8 @@ class NIC1InputImage(NICMOSInputImage):
 
 
 class NIC2InputImage(NICMOSInputImage):
-    def __init__(self,filename=None):
-        super().__init__(filename)
+    def __init__(self,filename=None, output=None):
+        super().__init__(filename, output=output)
         self._effGain=1. #measured
         self._detector=self._image["PRIMARY"].header["CAMERA"]
         self.proc_unit = "native"
@@ -348,8 +347,8 @@ class NIC2InputImage(NICMOSInputImage):
 
 
 class NIC3InputImage(NICMOSInputImage):
-    def __init__(self, filename=None):
-        super().__init__(filename)
+    def __init__(self, filename=None, output=None):
+        super().__init__(filename, output=output)
         self._detector=self._image["PRIMARY"].header["CAMERA"] #returns 1,2,3
         self._effGain = 1.
         self.proc_unit = "native"

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -197,6 +197,7 @@ def setCommonInput(configObj, createOutwcs=True):
         virtual = False
 
     imageObjectList = createImageObjectList(files, instrpars,
+                                            output=asndict['output'],
                                             group=configObj['group'],
                                             undistort=undistort,
                                             inmemory=virtual)
@@ -328,7 +329,7 @@ def checkMultipleFiles(input):
     f,i,o,a=buildFileList(input)
     return len(f) > 1
 
-def createImageObjectList(files,instrpars,group=None,
+def createImageObjectList(files, instrpars, output=None, group=None,
                             undistort=True, inmemory=False):
     """ Returns a list of imageObject instances, 1 for each input image in the list of input filenames.
     """
@@ -336,7 +337,7 @@ def createImageObjectList(files,instrpars,group=None,
     mtflag = False
     mt_refimg = None
     for img in files:
-        image = _getInputImage(img,group=group)
+        image = _getInputImage(img, output=output, group=group)
         image.setInstrumentParameters(instrpars)
         image.compute_wcslin(undistort=undistort)
         if 'MTFLAG' in image._image['PRIMARY'].header:
@@ -371,7 +372,7 @@ def applyContextPar(imageObjectList,contextpar):
     for img in imageObjectList:
         img.updateContextImage(contextpar)
 
-def _getInputImage (input,group=None):
+def _getInputImage (input, output=None, group=None):
     """ Factory function to return appropriate imageObject class instance"""
     # extract primary header and SCI,1 header from input image
     sci_ext = 'SCI'
@@ -414,19 +415,19 @@ def _getInputImage (input,group=None):
     try:
         if _instrument == 'ACS':
             from . import acsData
-            if _detector == 'HRC': return acsData.HRCInputImage(input,group=group)
-            if _detector == 'WFC': return acsData.WFCInputImage(input,group=group)
-            if _detector == 'SBC': return acsData.SBCInputImage(input,group=group)
+            if _detector == 'HRC': return acsData.HRCInputImage(input, output=output, group=group)
+            if _detector == 'WFC': return acsData.WFCInputImage(input, output=output, group=group)
+            if _detector == 'SBC': return acsData.SBCInputImage(input, output=output, group=group)
         if _instrument == 'NICMOS':
             from . import nicmosData
-            if _detector == 1: return nicmosData.NIC1InputImage(input)
-            if _detector == 2: return nicmosData.NIC2InputImage(input)
-            if _detector == 3: return nicmosData.NIC3InputImage(input)
+            if _detector == 1: return nicmosData.NIC1InputImage(input, output=output)
+            if _detector == 2: return nicmosData.NIC2InputImage(input, output=output)
+            if _detector == 3: return nicmosData.NIC3InputImage(input, output=output)
 
 
         if _instrument == 'WFPC2':
             from . import wfpc2Data
-            return wfpc2Data.WFPC2InputImage(input,group=group)
+            return wfpc2Data.WFPC2InputImage(input, output=output, group=group)
         """
             if _detector == 1: return wfpc2Data.PCInputImage(input)
             if _detector == 2: return wfpc2Data.WF2InputImage(input)
@@ -435,13 +436,13 @@ def _getInputImage (input,group=None):
         """
         if _instrument == 'STIS':
             from . import stisData
-            if _detector == 'CCD': return stisData.CCDInputImage(input,group=group)
-            if _detector == 'FUV-MAMA': return stisData.FUVInputImage(input,group=group)
-            if _detector == 'NUV-MAMA': return stisData.NUVInputImage(input,group=group)
+            if _detector == 'CCD': return stisData.CCDInputImage(input, output=output, group=group)
+            if _detector == 'FUV-MAMA': return stisData.FUVInputImage(input, output=output, group=group)
+            if _detector == 'NUV-MAMA': return stisData.NUVInputImage(input, output=output, group=group)
         if _instrument == 'WFC3':
             from . import wfc3Data
-            if _detector == 'UVIS': return wfc3Data.WFC3UVISInputImage(input,group=group)
-            if _detector == 'IR': return wfc3Data.WFC3IRInputImage(input,group=group)
+            if _detector == 'UVIS': return wfc3Data.WFC3UVISInputImage(input, output=output, group=group)
+            if _detector == 'IR': return wfc3Data.WFC3IRInputImage(input, output=output, group=group)
 
     except ImportError:
         msg = 'No module implemented for '+str(_instrument)+'!'

--- a/drizzlepac/stisData.py
+++ b/drizzlepac/stisData.py
@@ -16,8 +16,8 @@ class STISInputImage (imageObject):
 
     SEPARATOR = '_'
 
-    def __init__(self,filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self,filename=None, output=None, group=None):
+        super().__init__(filename, output=output, group=group)
 
         # define the cosmic ray bits value to use in the dq array
         self.cr_bits_value = 8192
@@ -107,15 +107,14 @@ class STISInputImage (imageObject):
         ny=sci_chip._naxis1
         nx=sci_chip._naxis2
         detnum = sci_chip.detnum
-        instr=self._instrument
 
-        sig=(instr+self._detector,(nx,ny),int(detnum)) #signature is a tuple
+        sig=(self.outroot,(nx,ny),int(detnum)) #signature is a tuple
         sci_chip.signature=sig #signature is a tuple
 
 
 class CCDInputImage(STISInputImage):
-    def __init__(self, filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename=None, output=None, group=None):
+        super().__init__(filename, output=output, group=group)
 
         self.full_shape = (1024, 1024)
         self._detector=self._image["PRIMARY"].header["DETECTOR"]
@@ -187,10 +186,10 @@ class CCDInputImage(STISInputImage):
 
 
 class NUVInputImage(STISInputImage):
-    def __init__(self, filename, group=None):
+    def __init__(self, filename, output=None, group=None):
         self.effGain = 1.0
 
-        super().__init__(filename, group=None)
+        super().__init__(filename, output=output, group=group)
 
         self._detector=self._image["PRIMARY"].header["DETECTOR"]
 
@@ -302,9 +301,9 @@ class NUVInputImage(STISInputImage):
 
 
 class FUVInputImage(STISInputImage):
-    def __init__(self,filename=None,group=None):
+    def __init__(self, filename=None, output=None, group=None):
         self.effGain=1.0
-        super().__init__(filename, group=group)
+        super().__init__(filename, output=output, group=group)
         self._detector=self._image["PRIMARY"].header["DETECTOR"]
 
         # no cte correction for STIS/FUV-MAMA so set cte_dir=0.

--- a/drizzlepac/wfc3Data.py
+++ b/drizzlepac/wfc3Data.py
@@ -15,8 +15,8 @@ class WFC3InputImage(imageObject):
 
     SEPARATOR = '_'
 
-    def __init__(self, filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename=None, output=None, group=None):
+        super().__init__(filename, output=output, group=group)
 
         # define the cosmic ray bits value to use in the dq array
         self.cr_bits_value = 4096
@@ -36,14 +36,13 @@ class WFC3InputImage(imageObject):
         ny = sci_chip._naxis1
         nx = sci_chip._naxis2
         detnum = sci_chip.detnum
-        instr = self._instrument
-        sig = (instr + self._detector, (nx, ny), int(chip)) #signature is a tuple
+        sig = (self.outroot, (nx, ny), int(chip)) #signature is a tuple
         sci_chip.signature=sig #signature is a tuple
 
 
 class WFC3UVISInputImage(WFC3InputImage):
-    def __init__(self,filename=None,group=None):
-        super().__init__(filename, group=group)
+    def __init__(self,filename=None, output=None, group=None):
+        super().__init__(filename, output=output, group=group)
 
         # define the cosmic ray bits value to use in the dq array
         self.full_shape = (4096,2051)
@@ -143,8 +142,8 @@ class WFC3UVISInputImage(WFC3InputImage):
 
 class WFC3IRInputImage(WFC3InputImage):
 
-    def __init__(self, filename=None, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename=None,  output=None, group=None):
+        super().__init__(filename, output=output, group=group)
         self.timeExt = 'TIME'
 
         # define the cosmic ray bits value to use in the dq array

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -33,8 +33,8 @@ class WFPC2InputImage (imageObject):
 
     SEPARATOR = '_'
 
-    def __init__(self, filename, group=None):
-        super().__init__(filename, group=group)
+    def __init__(self, filename, output=None, group=None):
+        super().__init__(filename, output=output, group=group)
         # define the cosmic ray bits value to use in the dq array
         self.cr_bits_value = 4096
         self._instrument=self._image["PRIMARY"].header["INSTRUME"]
@@ -305,8 +305,7 @@ class WFPC2InputImage (imageObject):
         ny = sci_chip._naxis1
         nx = sci_chip._naxis2
         detnum = sci_chip.detnum
-        instr = self._instrument
-        sig = (instr + WFPC2_DETECTOR_NAMES[detnum], (nx, ny), chip) #signature is a tuple
+        sig = (self.outroot, (nx, ny), chip) #signature is a tuple
         sci_chip.signature=sig #signature is a tuple
 
     def _setchippars(self):


### PR DESCRIPTION
These changes implement a new naming convention for the common static mask file that gets used by `astrodrizzle.AstroDrizzle()`.  The new name is based on the original input provided to astrodrizzle, and if it is ASN file, the filename defined in the ASN file as the 'output' product.  This results in a dataset unique name for the static mask based on the original input file which will not be confused with the static mask for any other dataset being processed in the same directory.  