### PR TITLE
Revise SkyCell API

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -571,6 +571,7 @@ class SkyCell(object):
             the exact pixel size in arcseconds/pixel should be used.
 
         """
+<<<<<<< Updated upstream
         # Interpret scale term, if provided
         self.scale = SUPPORTED_SCALES.get(scale, None) if isinstance(scale, str) else scale
 
@@ -581,6 +582,12 @@ class SkyCell(object):
             self.y_index = y
             self.sky_cell_id = SKYCELL_NAME_FMT.format(projection_cell.cell_id, x, y)
             self.projection_cell = projection_cell
+=======
+        self.x_index = x
+        self.y_index = y
+        self.sky_cell_id = SKYCELL_NAME_FMT.format(projection_cell.cell_id, x, y)
+        self.projection_cell = projection_cell
+>>>>>>> Stashed changes
 
         self.members = []
         self.overlap = self.projection_cell.sc_overlap  # overlap between sky cells
@@ -588,16 +595,16 @@ class SkyCell(object):
 
         self._build_wcs()
 
-    def _from_name(self, name):
+    @classmethod
+    def from_name(cls, name) -> SkyCell:
         # parse name into projection cell and sky cell designations
         sc_names = name.split('-')
         scell_id = sc_names[1]
         pcell_id = int(scell_id[1:5])
+        x = int(scell_id[6:8])
+        y = int(scell_id[9:11])
 
-        self.x_index = int(scell_id[6:8])
-        self.y_index = int(scell_id[9:11])
-        self.projection_cell = ProjectionCell(index=pcell_id)
-        self.sky_cell_id = name
+        return cls(projection_cell=pcell_id, x=x, y=y)
 
     def __repr__(self):
         return "SkyCell object: {}".format(self.sky_cell_id)

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -586,7 +586,7 @@ class SkyCell(object):
         self._build_wcs()
 
     @classmethod
-    def from_name(cls, name) -> SkyCell:
+    def from_name(cls, name, scale="fine") -> SkyCell:
         # parse name into projection cell and sky cell designations
         sc_names = name.split('-')
         scell_id = sc_names[1]
@@ -594,7 +594,7 @@ class SkyCell(object):
         x = int(scell_id[6:8])
         y = int(scell_id[9:11])
 
-        return cls(projection_cell=pcell_id, x=x, y=y)
+        return cls(projection_cell=pcell_id, x=x, y=y, scale=scale)
 
     def __repr__(self):
         return "SkyCell object: {}".format(self.sky_cell_id)

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -546,7 +546,7 @@ class ProjectionCell(object):
 
 class SkyCell(object):
 
-    def __init__(self, name=None, projection_cell=None, x=None, y=None, scale="fine"):
+    def __init__(self, projection_cell=None, x=None, y=None, scale="fine"):
         """Define sky cell at position x,y within projection cell.
 
         Parameters
@@ -571,23 +571,13 @@ class SkyCell(object):
             the exact pixel size in arcseconds/pixel should be used.
 
         """
-<<<<<<< Updated upstream
         # Interpret scale term, if provided
         self.scale = SUPPORTED_SCALES.get(scale, None) if isinstance(scale, str) else scale
 
-        if name:
-            self._from_name(name)
-        else:
-            self.x_index = x
-            self.y_index = y
-            self.sky_cell_id = SKYCELL_NAME_FMT.format(projection_cell.cell_id, x, y)
-            self.projection_cell = projection_cell
-=======
         self.x_index = x
         self.y_index = y
         self.sky_cell_id = SKYCELL_NAME_FMT.format(projection_cell.cell_id, x, y)
         self.projection_cell = projection_cell
->>>>>>> Stashed changes
 
         self.members = []
         self.overlap = self.projection_cell.sc_overlap  # overlap between sky cells

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -586,7 +586,7 @@ class SkyCell(object):
         self._build_wcs()
 
     @classmethod
-    def from_name(cls, name, scale="fine") -> SkyCell:
+    def from_name(cls, name, scale="fine"):
         # parse name into projection cell and sky cell designations
         sc_names = name.split('-')
         scell_id = sc_names[1]

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -901,7 +901,7 @@ def build_poller_table(input, log_level, poller_type='svm'):
     if poller_type == 'mvm' and is_poller_file:
         pipeline_skycell_id = input_table[0]['skycell_id']
         scells = {}
-        skycell_obj = cell_utils.SkyCell(name=pipeline_skycell_id)
+        skycell_obj = cell_utils.SkyCell.from_name(pipeline_skycell_id)
         skycell_obj.members = filenames
         scells[pipeline_skycell_id] = skycell_obj
         scell_files = cell_utils.interpret_scells(scells)

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -699,7 +699,7 @@ class SkyCellProduct(HAPProduct):
         self.edp_list = []
         self.new_to_layer = 0
         self.regions_dict = {}
-        self.skycell = cell_utils.SkyCell(name=skycell_name, scale=layer_scale)
+        self.skycell = cell_utils.SkyCell.from_name(skycell_name, scale=layer_scale)
         self.configobj_pars = None
 
         log.debug("SkyCell object {}/{}/{} created.".format(self.instrument, self.detector, self.filters))


### PR DESCRIPTION
This change to the SkyCell API removes the overloaded set of input parameters in favor of using a decorator classmethod.  