### PR TITLE
Create more specific static mask name

### DIFF
--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -980,9 +980,9 @@ class imageObject(baseImageObject):
         #self._rootname=self._image['PRIMARY'].header["ROOTNAME"]
         self._rootname=fileutil.buildNewRootname(filename)
         self.outputNames=self._setOutputNames(self._rootname)
-        self.outroot = output.split('_')[0] if output else filename.split('_')[0]
+        self.outroot = '_'.join(output.split('_')[:-1]) if output else '_'.join(filename.split('_')[:-1])
         self.outroot = self.outroot.lower()
-        
+
         # flag to indicate whether or not to write out intermediate products
         # to disk (default) or keep everything in memory
         self.inmemory = inmemory


### PR DESCRIPTION
Renaming the static mask file needed to be done in a more generic manner, not specifically tailored to pipeline IPPPSSOOT filenames.  This small change insures that the whole specified output filename gets used instead of just the first portion.  