### PR TITLE
Fix segment background determination and use

### DIFF
--- a/drizzlepac/devutils/alignment_viewer.py
+++ b/drizzlepac/devutils/alignment_viewer.py
@@ -144,12 +144,12 @@ class Datasets:
                     plt.close()
                     json_summary[os.path.basename(p)] = summary
             plt.ion()
-            
+
         with open(pdfname.replace('.pdf', '_summary.json'), 'w') as jsonfile:
             json.dump(json_summary, jsonfile)
-        
 
-def create_product_page(prodname, zoom_size=128, wcsname="", 
+
+def create_product_page(prodname, zoom_size=128, wcsname="",
                         gcolor='magenta', fsize=8):
     """Create a matplotlib Figure() object which summarizes this product FITS file."""
 
@@ -167,7 +167,7 @@ def create_product_page(prodname, zoom_size=128, wcsname="",
         wcstype = prod[1].header['wcstype']
         wcs = wcsutil.HSTWCS(prod, ext=1)
         hdrtab = prod['hdrtab'].data
-        filters = ';'.join([phdr[f] for f in phdr['filter*']]) 
+        filters = ';'.join([phdr[f] for f in phdr['filter*']])
         dateobs = phdr['date-obs']  # human-readable date
         expstart = phdr['expstart']  # MJD float value
         asnid = phdr.get('asn_id', '')
@@ -175,7 +175,7 @@ def create_product_page(prodname, zoom_size=128, wcsname="",
     center = (data.shape[0] // 2, data.shape[1] // 2)
     prod_path = os.path.split(prodname)[0]
 
-    data = np.nan_to_num(data, 0.0)
+    data = np.nan_to_num(data, nan=0.0)
 
     # Get GAIA catalog
     refcat = amutils.create_astrometric_catalog(prodname, existing_wcs=wcs,
@@ -243,15 +243,15 @@ def create_product_page(prodname, zoom_size=128, wcsname="",
     hdrtab_cols = hdrtab.columns.names
     mtflag = get_col_val(hdrtab, 'mtflag', default="")
     gyromode = get_col_val(hdrtab, 'gyromode', default='N/A')
-    
-        
+
+
     # populate JSON summary info
     summary = dict(wcsname=wcsname, targname=targname, asnid=asnid,
                     dateobs=dateobs, expstart=expstart,
                     instrument=(inst, det), exptime=texptime,
                     wcstype=wcstype, num_gaia=len(refx), filters=filters,
                     rms_ra=-1, rms_dec=-1, nmatch=-1, catalog="")
-    obs_kws = ['gyromode', 'fgslock', 'aperture', 'mtflag', 'subarray', 
+    obs_kws = ['gyromode', 'fgslock', 'aperture', 'mtflag', 'subarray',
                 'obstype', 'obsmode', 'scan_typ', 'photmode']
     for kw in obs_kws:
         summary[kw] = get_col_val(hdrtab, kw, default="")
@@ -278,14 +278,13 @@ def create_product_page(prodname, zoom_size=128, wcsname="",
             fig_summary.text(0.01, 0.35, "# matches: {}".format(nmatch), fontsize=fsize)
             fig_summary.text(0.01, 0.3, "Matched to {} catalog".format(catalog), fontsize=fsize)
         except:
-            fig_summary.text(0.01, 0.35, "No MATCH to GAIA") 
+            fig_summary.text(0.01, 0.35, "No MATCH to GAIA")
             print("Data without a match to GAIA: {},{}".format(inexp, wcsname))
-            
-    
+
+
     return fig, summary
-    
+
 def get_col_val(hdrtab, keyword, default=None):
     val = hdrtab[0][keyword.upper()] if keyword.upper() in hdrtab.columns.names else default
     if isinstance(val, bool) or isinstance(val, np.bool_): val = str(val)
     return val
-    

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -630,7 +630,7 @@ def find_fwhm(psf, default_fwhm):
                                                        niters=2)
     phot_results = itr_phot_obj(psf)
     # Insure none of the fluxes determined by photutils is np.nan
-    phot_results['flux_fit'] = np.nan_to_num(phot_results['flux_fit'].data, 0)
+    phot_results['flux_fit'] = np.nan_to_num(phot_results['flux_fit'].data, nan=0)
 
     if len(phot_results['flux_fit']) == 0:
         return None
@@ -1667,8 +1667,8 @@ def compute_similarity(image, reference):
     """
 
     # Insure NaNs are replaced with 0
-    image = np.nan_to_num(image[:], 0)
-    reference = np.nan_to_num(reference[:], 0)
+    image = np.nan_to_num(image[:], nan=0)
+    reference = np.nan_to_num(reference[:], nan=0)
 
     imgshape = (min(image.shape[0], reference.shape[0]),
                 min(image.shape[1], reference.shape[1]))
@@ -1816,7 +1816,7 @@ def get_align_fwhm(focus_dict, default_fwhm, src_size=11):
 
     # For sources near the edge of the image data, insure that any NaN's are converted to 0
     # This is necessary in order to allow FWHM to be determined
-    src = np.nan_to_num(src, 0)
+    src = np.nan_to_num(src, nan=0)
 
     # Normalize to total flux of 1 for FWHM determination
     kernel = src / src.sum()
@@ -1917,8 +1917,8 @@ def max_overlap_diff(total_mask, singlefiles, prodfile, sigma=2.0, scale=1, lsig
         sfile_region = sdata * soverlap
 
         # Insure all np.nan's are converted to zeros
-        drz_region = np.nan_to_num(drz_region, 0)
-        sfile_region = np.nan_to_num(sfile_region, 0)
+        drz_region = np.nan_to_num(drz_region, nan=0)
+        sfile_region = np.nan_to_num(sfile_region, nan=0)
 
         # Also compute focus index for the same region of the single drizzle file
         focus_val, focus_pos = determine_focus_index(sfile_region, sigma=sigma)

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1253,7 +1253,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             imgarr = copy.deepcopy(self.image.data)
 
             # The imgarr should be background subtracted to match the threshold which has no background
-            imgarr_bkgsub = imgarr - self.image.bkg_background_ra
+            imgarr_bkgsub = imgarr  # - self.image.bkg_background_ra
 
             # Write out diagnostic data
             if self.diagnostic_mode:

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1133,7 +1133,6 @@ class HAPPointCatalog(HAPCatalogBase):
             A table containing a subset of columns from a filter catalog.
 
         """
-        return
         # Evaluate self.sources (the total product list) even though len(self.sources) should not be possible
         if len(subset_table) == 0 or len(self.sources) == 0:
             log.error("No sources found in the current filter table nor in the total source table.")

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -16,7 +16,6 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_threshold": 0.0,
     "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
@@ -30,7 +29,7 @@
     },
     "sourcex": {
         "fwhm": 0.073,
-        "source_box": 7,
+        "source_box": 5,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075
+        "max_biggest_source": 0.045,
+        "max_source_fraction": 0.15
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -30,6 +30,7 @@
     "sourcex": {
         "fwhm": 0.073,
         "source_box": 5,
+        "segm_nsigma": 3.0,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -30,6 +30,7 @@
     "sourcex": {
         "fwhm": 0.065,
         "source_box": 5,
+        "segm_nsigma": 3.0,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -16,7 +16,6 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_threshold": 0.0,
     "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
@@ -30,7 +29,7 @@
     },
     "sourcex": {
         "fwhm": 0.065,
-        "source_box": 7,
+        "source_box": 5,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075
+        "max_biggest_source": 0.045,
+        "max_source_fraction": 0.15
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -9,7 +9,7 @@
     "aperture_2": 0.15,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
-    "scale": 1.5,
+    "scale": 3.0,
     "sensitivity": 0.95,
     "cr_residual": 0.05,
     "region_size": 11,
@@ -30,6 +30,7 @@
     "sourcex": {
         "fwhm": 0.13,
         "source_box": 5,
+        "segm_nsigma": 3.0,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -16,7 +16,6 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_threshold": 0.0,
     "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -30,6 +30,7 @@
     "sourcex": {
         "fwhm": 0.14,
         "source_box": 5,
+        "segm_nsigma": 3.0,
         "nlevels": 32,
         "contrast": 0.001,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -2,7 +2,7 @@
     "bkg_box_size": 13,
     "bkg_filter_size": 3,
     "good_fwhm": [0.9, 2.0],
-    "nsigma": 0.0,
+    "nsigma": 1.0,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,
@@ -29,11 +29,11 @@
     },
     "sourcex": {
         "fwhm": 0.14,
-        "source_box": 3,
+        "source_box": 5,
         "nlevels": 32,
-        "contrast": 0.005,
+        "contrast": 0.001,
         "border": 10,
-        "rw2d_size": 15,
+        "rw2d_size": 11,
         "rw2d_nsigma": 1.5,
         "max_biggest_source": 0.015,
         "max_source_fraction": 0.075

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -1,5 +1,5 @@
 {
-    "bkg_box_size": 27,
+    "bkg_box_size": 13,
     "bkg_filter_size": 3,
     "good_fwhm": [0.9, 2.0],
     "nsigma": 1.0,
@@ -16,7 +16,6 @@
     "flag_trim_value": 65368,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_threshold": 0.0,
     "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
@@ -30,7 +29,7 @@
     },
     "sourcex": {
         "fwhm": 0.14,
-        "source_box": 7,
+        "source_box": 3,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -9,7 +9,7 @@
     "aperture_2": 0.45,
     "salgorithm": "mode",
     "starfinder_algorithm": "dao",
-    "scale": 100.0,
+    "scale": 1.5,
     "sensitivity": 0.95,
     "cr_residual": 0.0,
     "region_size": 11,
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 11,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075
+        "max_biggest_source": 0.045,
+        "max_source_fraction": 0.15
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -2,7 +2,7 @@
     "bkg_box_size": 13,
     "bkg_filter_size": 3,
     "good_fwhm": [0.9, 2.0],
-    "nsigma": 1.0,
+    "nsigma": 0.0,
     "skyannulus_arcsec": 0.25,
     "dskyannulus_arcsec": 0.25,
     "aperture_1": 0.15,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -30,6 +30,7 @@
     "sourcex": {
         "fwhm": 0.076,
         "source_box": 5,
+        "segm_nsigma": 3.0,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -16,7 +16,6 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_threshold": 0.0,
     "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
@@ -30,7 +29,7 @@
     },
     "sourcex": {
         "fwhm": 0.076,
-        "source_box": 7,
+        "source_box": 5,
         "nlevels": 32,
         "contrast": 0.005,
         "border": 10,


### PR DESCRIPTION
These changes revise the computation of the background and how it gets used for determining the sources in the segment catalog.  The changes include:

- using the -1 * RMS of the background as the negative threshold
- removing the 'negative_threshold' parameter from the config files
- updated computation of sigma-clipped background to be less influenced by bright sources 
- revising the Background2D parameters for the WFC3/IR format (smaller box size)
- reduced the source box size for the segment catalog sources for all detectors to pick up smaller/fainter sources
- eliminate background subtraction prior to calling photutils segmentation code (avoids applying the background twice)

These changes were tested using dataset 'ia0m04' (hst_11099_04, WFC3/IR).  Original HAP segment catalog had <300 sources compared to HLA catalog of >1400 sources.  Revised HAP segment catalog now has >1000 sources. 
