### PR TITLE
Update Drizzlepac to work with non-IDC-updated WCSs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+3.2.1 (unreleased)
+==================
+
+- Update ``AstroDrizzle`` to work with data which have not been updated using
+  the IDCTAB. [#902]
+  
 3.2.0 (7-Dec-2020)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,11 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-3.1.9 (unreleased)
+3.2.0 (7-Dec-2020)
 ==================
+
+This version provides the first operational implementation of the single-visit
+mosaic processing used to create the single-visit mosaics products.
 
 - revise naming convention for the StaticMask file so that it has a
   dataset-specific name instead of a generic common name. [#876]

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -376,6 +376,9 @@ def do_blot(source, source_wcs, blot_wcs, exptime, coeffs = True,
     ymin = 1
     xmax, ymax = source_wcs.pixel_shape
 
+    if blot_wcs.idcscale is None:
+        blot_wcs.idcscale = blot_wcs.pscale
+
     # compute the undistorted 'natural' plate scale for this chip
     if coeffs:
         wcslin = distortion.utils.make_orthogonal_cd(blot_wcs)

--- a/drizzlepac/wcs_functions.py
+++ b/drizzlepac/wcs_functions.py
@@ -280,7 +280,13 @@ def make_outputwcs(imageObjectList, output, configObj=None, perfect=False):
                 cw.cpdis2 = None
                 cw.det2im = None
             undistort = False
+        # Insure that information is available for output_wcs to always work
+        for chip in chip_wcs:
+            if chip.idcscale is None:
+                chip.idcscale = chip.pscale
+
         hstwcs_list += chip_wcs
+        
     if not undistort and len(hstwcs_list) == 1:
         default_wcs = hstwcs_list[0].deepcopy()
     else:

--- a/drizzlepac/wcs_functions.py
+++ b/drizzlepac/wcs_functions.py
@@ -284,9 +284,11 @@ def make_outputwcs(imageObjectList, output, configObj=None, perfect=False):
         for chip in chip_wcs:
             if chip.idcscale is None:
                 chip.idcscale = chip.pscale
+                warn_str = "{}: Data from {} was NOT updated with the distortion model from {}!"
+                print(warn_str.format("WARNING", chip.filename, chip.idctab))
 
         hstwcs_list += chip_wcs
-        
+
     if not undistort and len(hstwcs_list) == 1:
         default_wcs = hstwcs_list[0].deepcopy()
     else:


### PR DESCRIPTION
These changes allow AstroDrizzle to process data which has not been updated using the IDCTAB and avoids the Exception with 'wcs.idcscale / 3600.'.  The distorted WCS plate scale gets assigned as the 'model' plate scale 'wcs.idcscale' with these changes.   These changes allowed data from `j8eg060t0` to process without being updated by the IDCTAB reference file.  

The consequence of this change will be that data which has not been updated, and was expected to be updated, will not be using distortion model specified in the reference files.  This makes the WCSNAME keyword more important, and may impact re-processing done on the data either by the user or the automated pipeline.  