### PR TITLE
Fix a bug in tweakback due to which updated WCS's name is ignored

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
+3.2.1 (unreleased)
+==================
+
+- Fix a bug in ``tweakback`` that may cause incorrect "updated" WCS to be
+  picked up from the drizzled image. [#913]
+
 3.1.9 (unreleased)
 ==================
 


### PR DESCRIPTION
From the work on helpdesk issue INC0164467 it became clear that tweakback is ignoring updated WCS's name provided by `wcsname` parameter. This PR fixes this CRITICAL (IMO) bug.

In most situations _this will go unnoticed_ but in some situations, for example when drizzled image contains remnants of the OPUS WCS as described in https://github.com/spacetelescope/drizzlepac/issues/863 this will cause a crash. This (going unnoticed) makes fixing that issue even more important. CC: @stsci-hack @nden