### PR TITLE
update version of python to >=3.7

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -22,7 +22,7 @@ bc.nodetype = 'linux'
 bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc.name = '3.6'
 bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc.conda_packages = ['python=3.6']
+bc.conda_packages = ['python=3.7']
 bc.build_cmds = ["pip install numpy astropy codecov pytest-cov",
 		 "pip install --upgrade -e '.[test]'",
                  "pip freeze"]

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -10,8 +10,8 @@ jobs:
 
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
+      Python39:
+        python.version: '3.9'
       Python37:
         python.version: '3.7'
       Python38:

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -10,8 +10,8 @@ jobs:
 
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      # Python39:
+      #   python.version: '3.9'
       Python37:
         python.version: '3.7'
       Python38:

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'Topic :: Scientific/Engineering :: Astronomy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=[
         'astropy>=4.0.0',
         'fitsblender',


### PR DESCRIPTION
The next release of astropy will not support Python 3.6. This PR changes the min Python version to
` >= 3.7`. 
Changing the version will help also with running the regression tests with dev dependencies.
Is there a reason not to update?
This is in support of AL-453.