### PR TITLE
fix align test, update Jenkins job title

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -20,7 +20,7 @@ data_config.match_prefix = '(.*)_result' // .json is appended automatically
 bc = new BuildConfig()
 bc.nodetype = 'linux'
 bc.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
-bc.name = '3.6'
+bc.name = '3.7'
 bc.conda_channels = ['http://ssb.stsci.edu/astroconda']
 bc.conda_packages = ['python=3.7']
 bc.build_cmds = ["pip install numpy astropy codecov pytest-cov",

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -204,7 +204,7 @@ def updatewcs_with_shift(image, reference, wcsname='TWEAK', reusename=False,
     if isinstance(image, fits.HDUList):
         open_image = False
         filename = image.filename()
-        if image.fileinfo(0)['filemode'] is 'update':
+        if image.fileinfo(0)['filemode'] == 'update':
             image_update = True
         else:
             image_update = False

--- a/tests/hap/test_align.py
+++ b/tests/hap/test_align.py
@@ -77,7 +77,7 @@ class TestAlignMosaic(BaseHLATest):
         # Examine the output table to extract the RMS for the entire fit and the compromised
         # information
         if dataset_table:
-            total_rms = dataset_table['total_rms'][0]
+            total_rms = dataset_table.filtered_table['total_rms'][0]
 
         assert 0.0 < total_rms <= RMS_LIMIT
 
@@ -108,7 +108,7 @@ class TestAlignMosaic(BaseHLATest):
         # Examine the output table to extract the RMS for the entire fit and the compromised
         # information
         if dataset_table:
-            total_rms = dataset_table['total_rms'][0]
+            total_rms = dataset_table.filtered_table['total_rms'][0]
 
         assert 0.0 < total_rms <= RMS_LIMIT
 
@@ -171,7 +171,7 @@ class TestAlignMosaic(BaseHLATest):
         # Examine the output table to extract the RMS for the entire fit and the compromised
         # information
         if dataset_table:
-            total_rms = dataset_table['total_rms'][0]
+            total_rms = dataset_table.filtered_table['total_rms'][0]
 
         assert 0.0 < total_rms <= RMS_LIMIT
 
@@ -218,7 +218,7 @@ class TestAlignMosaic(BaseHLATest):
         # Examine the output table to extract the RMS for the entire fit and the compromised
         # information
         if dataset_table:
-            total_rms = dataset_table['total_rms'][0]
+            total_rms = dataset_table.filtered_table['total_rms'][0]
 
         assert 0.0 < total_rms <= RMS_LIMIT
 
@@ -235,6 +235,6 @@ class TestAlignMosaic(BaseHLATest):
         # Examine the output table to extract the RMS for the entire fit and the compromised
         # information
         if dataset_table:
-            total_rms = dataset_table['total_rms'][0]
+            total_rms = dataset_table.filtered_table['total_rms'][0]
 
         assert 0.0 < total_rms <= RMS_LIMIT


### PR DESCRIPTION
This PR allows the tests in `test_align.py` to run so comparison with `truth` results can be done.
With this the Jenkins tests are now running and failing with trivial differences. The truth files need to be updated.