### PR TITLE
Address problem of the deblend step taking too long

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1302,7 +1302,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                                max_source_fraction=self._rw2d_source_fraction)
 
             # If the science field via the segmentation map is deemed crowded or has big islands, compute the
-            # RickerWavelet2DKernel.  Still use the custom fwhm as it should be better than a generic fwhm.
+            # RickerWavelet2DKernel and perform the detect_segments() again. Still use the custom fwhm as it 
+            # should be better than a generic fwhm as it is based upon the data.
             # Note: the fwhm might be a default if the custom algorithm had to fall back to a Gaussian.
             if is_big_crowded:
                 log.info("")
@@ -1346,13 +1347,13 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 del custom_segm_img
 
             # SHOULD THERE BE ANOTHER CHECK ON BIG ISLANDS AND SOURCE FRACTION HERE and ITERATE - this can
-            # be a future improvement.
+            # be a future improvement.  There will need to be a scheme to handle what to do if the BI and SF
+            # are still too big.  This involves altering the background and/or threshold.
 
             # Deblend the segmentation image
             ncount += 1
             self.deblend_segments(segm_img,
                                   imgarr,
-                                  threshold,
                                   ncount,
                                   filter_kernel=self.image.kernel,
                                   source_box=self._size_source_box)

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.045,
-        "max_source_fraction": 0.15
+        "rw2d_biggest_source": 0.045,
+        "rw2d_source_fraction": 0.15
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.045,
-        "max_source_fraction": 0.15
+        "rw2d_biggest_source": 0.045,
+        "rw2d_source_fraction": 0.15
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075
+        "rw2d_biggest_source": 0.015,
+        "rw2d_source_fraction": 0.075
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 11,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.045,
-        "max_source_fraction": 0.15
+        "rw2d_biggest_source": 0.045,
+        "rw2d_source_fraction": 0.15
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "border": 10,
         "rw2d_size": 15,
         "rw2d_nsigma": 1.5,
-        "max_biggest_source": 0.015,
-        "max_source_fraction": 0.075
+        "rw2d_biggest_source": 0.015,
+        "rw2d_source_fraction": 0.075
     }
 }


### PR DESCRIPTION
The detect, deblend,  and kernel (Gaussian vs RickerWavelet) switching steps were re-organized to make better sense.  This relieves a majority of the issues (as well as any updates done by other folks with regard to the background determination) which caused deblending to take so long.