### PR TITLE
Create new apriori WCS for new IDCTAB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,11 @@ of the list).
 - Fix a bug in ``tweakback`` that may cause incorrect "updated" WCS to be
   picked up from the drizzled image. [#913]3.1.9 (unreleased)
 
+- Change ``runastrodriz`` to generate aligned products based only on
+  the IDCTAB specified in the input image headers, creating new a WCS
+  if no WCS was found in the astrometry database. [#922].  This requires
+  the installation of STWCS > 1.6.2.
+
 
 3.2.0 (7-Dec-2020)
 ==================

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -444,6 +444,8 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
         dGSinputDEC = float(refXMLtree.findtext('dGSinputDEC'))
         dGSoutputRA = float(refXMLtree.findtext('dGSoutputRA'))
         dGSoutputDEC = float(refXMLtree.findtext('dGSoutputDEC'))
+        outputCatalog = refXMLtree.findtext('outputCatalog')
+        inputCatalog = refXMLtree.findtext('inputCatalog')
 
 
     # Use GS coordinate as reference point
@@ -451,7 +453,8 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
     new_coordinate = (dGSoutputRA, dGSoutputDEC)
 
     deltas = {'ra': delta_ra, 'dec': delta_dec, 'roll': delta_roll, 'scale': delta_scale,
-              'old_coordinate': old_coordinate, 'new_coordinate': new_coordinate}
+              'old_coordinate': old_coordinate, 'new_coordinate': new_coordinate,
+              'output_catalog': outputCatalog, 'input_catalog': inputCatalog}
     return deltas
 
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -393,9 +393,9 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
 
     NOTES
     ------
-    The default transform is GSC2-GAIA. The options were primarily for transforming 
-    individual objects from the catalogs and that is not specified in the limited 
-    documentation. The ipppssoot input is a special case where it pulls the gsids, 
+    The default transform is GSC2-GAIA. The options were primarily for transforming
+    individual objects from the catalogs and that is not specified in the limited
+    documentation. The ipppssoot input is a special case where it pulls the gsids,
     epoch and refframe from the dms databases and overrides the transform using this logic.
         REFFRAME=GSC1 sets GSC1-GAIA
         REFFRAME=ICRS and EPOCH < 2017.75 sets GSC2-GAIA
@@ -422,8 +422,10 @@ def find_gsc_offset(image, input_catalog='GSC1', output_catalog='GAIA'):
 
     # Define what service needs to be used to get the offsets
     serviceType = "GSCConvert/GSCconvert.aspx"
-    spec_str = "TRANSFORM={}-{}&IPPPSSOOT={}"
-    spec = spec_str.format(input_catalog, output_catalog, ippssoot)
+    # spec_str = "TRANSFORM={}-{}&IPPPSSOOT={}"
+    # spec = spec_str.format(input_catalog, output_catalog, ippssoot)
+    spec_str = "REFFRAME=ICRS&IPPPSSOOT={}"
+    spec = spec_str.format(ippssoot)
     serviceUrl = "{}/{}?{}".format(SERVICELOCATION, serviceType, spec)
     rawcat = requests.get(serviceUrl)
     if not rawcat.ok:

--- a/drizzlepac/updatehdr.py
+++ b/drizzlepac/updatehdr.py
@@ -204,7 +204,7 @@ def updatewcs_with_shift(image, reference, wcsname='TWEAK', reusename=False,
     if isinstance(image, fits.HDUList):
         open_image = False
         filename = image.filename()
-        if image.fileinfo(0)['filemode'] == 'update':
+        if image.fileinfo(0)['filemode'] is 'update':
             image_update = True
         else:
             image_update = False
@@ -397,7 +397,7 @@ def update_refchip_with_shift(chip_wcs, wcslin, fitgeom='rscale',
 
 
 ###
-### Header keyword prefix related archive functions
+#   Header keyword prefix related archive functions
 ###
 def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=False):
     """

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         'stsci.imagestats',
         'stsci.skypac>=1.0',
         'stsci.stimage',
-        'stwcs>=1.5.3',
+        'stwcs>=1.6.2',
         'tweakwcs>=0.6.3',
         'stregion',
         'requests',


### PR DESCRIPTION
This addresses #909 by recognizing when no solution returned by the astrometric WCS database was based on the IDCTAB specified in the image header.  In that situation, these changes compute a new 'apriori' WCS based on the offsets stored in the guide star database and applies that as the new Primary WCS.  

This newly created apriori WCS also gets saved as a stand-alone headerlet so that the astrometric database can ingest the new solution for subsequent reprocessing efforts using the same distortion model. 