### PR TITLE
Fix HAPEXPNAME in HDRTAB for EXP HAP Products

### DIFF
--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -153,16 +153,12 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
 
         for expname in input_exposures:
             if rootname in expname:
-                if level == 1:
-                    # Intrepret inputs as exposures (FLT/FLC) filename not HAP names
-                    name_col.append(expname)
-                else:
-                    # Convert input exposure names into HAP names
-                    for tot_obj in total_obj_list:
-                        for exposure in tot_obj.edp_list:
-                            if rootname in exposure.full_filename:
-                                name_col.append(exposure.product_basename)
-                                break
+                # Convert input exposure names into HAP names
+                for tot_obj in total_obj_list:
+                    for exposure in tot_obj.edp_list:
+                        if rootname in exposure.full_filename:
+                            name_col.append(exposure.product_basename)
+                            break
 
     # define new column with HAP expname
     max_len = min(max([len(name) for name in name_col]), 51)


### PR DESCRIPTION
This makes the logic consistent for all HAP Drizzle products when updating the HDRTAB extension so that the HAPEXPNAME column contains the product_basename, not full filename, as the value. 

These changes were tested by processing visit 'hst_11603_06' (ib2t06).  

This addresses HLA-483 and the related issue #925 .