### PR TITLE
Set a common active WCS for direct as well as corresponding Grism/Prism images

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -95,6 +95,7 @@ envvar_cat_str = "SVM_CATALOG_{}"
 
 # --------------------------------------------------------------------------------------------------------------
 
+
 def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, phot_mode='both',
                             catalog_switches=None):
     """This subroutine utilizes haputils/catalog_utils module to produce photometric sourcelists for the specified
@@ -469,6 +470,7 @@ def create_drizzle_products(total_obj_list):
 
 # ----------------------------------------------------------------------------------------------------------------------
 
+
 def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_file=None,
                        output_custom_pars_file=None, phot_mode="both", log_level=logutil.logging.INFO):
     """
@@ -700,6 +702,7 @@ def run_align_to_gaia(tot_obj, log_level=logutil.logging.INFO, diagnostic_mode=F
 
 # ----------------------------------------------------------------------------------------------------------------------
 
+
 def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_level, diagnostic_mode=False):
     """
     Super-basic and profoundly inelegant interface to hla_flag_filter.py.
@@ -825,18 +828,19 @@ def _get_envvar_switch(envvar_name, default=None):
 
 # ------------------------------------------------------------------------------
 
+
 def update_wcs_grism_in_visit(tdp):
     """Examine entries in the total data produce for Grism/Prism data
 
     This routine is only invoked if the total data product for a particular detector
-    for the visit is comprised of both an ExposureProduct list AND a 
+    for the visit is comprised of both an ExposureProduct list AND a
     GrismExposureProduct list which contain entries.
 
     *** If the visit contains Grism/Prism data, then either the 'a priori' WCS for
     the Grism/Prism data or the pipeline default WCS for the direct images will be
     set as the primary/active WCS for all the Grism/Prism and direct image data for
     that detector - whichever WCS is common to all the images.
-    
+
     Parameters
     ----------
     tdp : total data product (TotalProduct) object
@@ -908,7 +912,7 @@ def update_wcs_grism_in_visit(tdp):
             grism_wcsname = match_list[0]
             log.info("Proposed WCS for use after Grism/Prism examination: {}".format(grism_wcsname))
             break
-    
+
     if not grism_wcsname:
         log.error("None of the preferred WCS names are present in the common set of WCS names for the Grism/Prism images.")
         log.error("    There is a problem with this visit")
@@ -936,9 +940,9 @@ def update_wcs_grism_in_visit(tdp):
         # pre-existing class which could cause an issue
         drizcorr = hdu[0].header['DRIZCORR']
         if drizcorr == "OMIT":
-             updatewcs.updatewcs(filename, use_db=False, verbose=False)
+            updatewcs.updatewcs(filename, use_db=False, verbose=False)
         else:
-             updatewcs.updatewcs(filename, use_db=True, verbose=False)
+            updatewcs.updatewcs(filename, use_db=True, verbose=False)
 
         # Get all the WCS names which are common to all of the direct images
         dict_names = wcsutil.altwcs.wcsnames(filename, ext=1)
@@ -1013,6 +1017,7 @@ def update_wcs_grism_in_visit(tdp):
     return grism_product_list
 
 # ------------------------------------------------------------------------------
+
 
 def update_active_wcs(filename, wcsname):
     """

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -287,12 +287,19 @@ def analyze_data(input_file_list, log_level=logutil.logging.NOTSET):
             no_proc_key = CHINKEY
             no_proc_value = chinject
 
-        # Filter name which starts with "G" for Grism, "PR" for Prism, or
-        # "BLOCK" for internal calibration of SBC
+        # Filter name which starts with "BLOCK" for internal calibration of SBC
         # The sfilter variable may be the concatenation of two filters (F160_CLEAR)
-        split_sfilter = sfilter.split('_')
+        #
+        # Grism/Prism images are also IMAGING=SPECTROSCOPIC, suppress the "no processing"
+        # indicators to allow the Grism/Prism images to be minimally processed for
+        # keyword updates.  This was done as a retrofit to allow Grism/Prism images
+        # to have the same WCS solution as the direct images in the visit (same detector).
+        split_sfilter = sfilter.upper().split('_')
         for item in split_sfilter:
-            if item.startswith(('G', 'PR', 'BLOCK')):
+            if item.startswith(('G', 'PR')):
+                no_proc_key = None
+                no_proc_value = None
+            if item.startswith(('BLOCK')):
                 no_proc_key = FILKEY
                 no_proc_value = sfilter
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -710,6 +710,8 @@ def parse_obset_tree(det_tree, log_level):
             index_to_delete.append(index)
             tdp.grism_edp_list.clear()
             del tdp.grism_edp_list[:]
+    # Make sure to delete from the end of the list
+    index_to_delete.reverse()
     for item in index_to_delete:
         del tdp_list[item]
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -60,6 +60,7 @@ SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
+
 # -----------------------------------------------------------------------------
 # Single Visit Processing Functions
 #
@@ -150,6 +151,7 @@ def interpret_obset_input(results, log_level):
                 edp_obj.is_singleton = is_singleton
 
     return obset_dict, tdp_list
+
 
 # Translate the database query on an obset into actionable lists of filenames
 def build_obset_tree(obset_table):
@@ -305,7 +307,6 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
     #
     # obset_dict, tdp_list = merge_mvm_trees(obset_tree, layer_tree, log_level)
 
-
     # This little bit of code adds an attribute to single exposure objects that is True
     # if a given filter only contains one input (e.g. n_exp = 1)
     for filt_obj in tdp_list:
@@ -317,6 +318,7 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
             edp_obj.is_singleton = is_singleton
 
     return obset_dict, tdp_list
+
 
 # Translate the database query on an obset into actionable lists of filenames
 def build_mvm_tree(obset_table):
@@ -496,7 +498,7 @@ def parse_mvm_tree(det_tree, log_level):
                     # FilterProduct(prop_id, obset_id, instrument, detector,
                     #               filename, filters, filetype, log_level)
                     filt_obj = SkyCellProduct(str(0), str(0), prod_list[1], prod_list[2],
-                                             prod_list[0], layer, ftype, log_level)
+                                              prod_list[0], layer, ftype, log_level)
                 # Append exposure object to the list of exposure objects for this specific filter product object
                 filt_obj.add_member(sep_obj)
                 # Populate filter product dictionary with input filename
@@ -518,11 +520,10 @@ def parse_mvm_tree(det_tree, log_level):
                         # FilterProduct(prop_id, obset_id, instrument, detector,
                         #               filename, filters, filetype, log_level)
                         filt_obj_fine = SkyCellProduct(str(0), str(0), prod_list[1], prod_list[2],
-                                                 prod_list[0], layer_fine, ftype, log_level)
+                                                       prod_list[0], layer_fine, ftype, log_level)
 
                     obset_products[fprod_fine]['files'].append(filename[1])
                     filt_obj_fine.add_member(sep_obj)
-
 
             filt_indx += filt_indx_inc
 
@@ -534,8 +535,8 @@ def parse_mvm_tree(det_tree, log_level):
                 log1 = "Attach the sky cell layer object {}"
                 log2 = "to its associated total product object {}/{}."
                 log.debug(' '.join([log1, log2]).format(filt_obj.filters,
-                                           filt_obj.instrument,
-                                           filt_obj.detector))
+                                                        filt_obj.instrument,
+                                                        filt_obj.detector))
             # Add the total product object to the list of TotalProducts
             tdp_list.append(filt_obj)
             if pscale == 'coarse':
@@ -620,7 +621,7 @@ def parse_obset_tree(det_tree, log_level):
                 # Create a single exposure product object
                 #
                 # The prod_list[5] is the filter - use this information to distinguish between
-                # a direct exposure for drizzling (ExposureProduct) and an exposure 
+                # a direct exposure for drizzling (ExposureProduct) and an exposure
                 # (GrismExposureProduct) which is carried along (Grism/Prism) to make analysis
                 # easier for the user by having the same WCS in both the direct and
                 # Grism/Prism products.
@@ -694,6 +695,7 @@ def parse_obset_tree(det_tree, log_level):
     return obset_products, tdp_list
 
 # ------------------------------------------------------------------------------
+
 
 def define_exp_layers(obset_table, method='hard', exp_limit=None):
     """Determine what exposures will be grouped into the same layer of a sky cell"""
@@ -992,7 +994,6 @@ def build_poller_table(input, log_level, poller_type='svm'):
         poller_names = [colname for colname in cols]
         poller_table = Table(data=poller_data, names=poller_names,
                              dtype=poller_dtype)
-
 
     # The input was a poller file, so just keep the viable data rows for output
     else:

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -684,13 +684,34 @@ def parse_obset_tree(det_tree, log_level):
                         for e in filt_obj.edp_list:
                             e.crclean = True
 
+                    #tdp_obj.add_product(filt_obj)
+
                 elif is_grism:
                     tdp_obj.add_grism_member(grism_sep_obj)
 
-            tdp_obj.add_product(filt_obj)
+            if not is_grism:
+                tdp_obj.add_product(filt_obj)
 
         # Add the total product object to the list of TotalProducts
         tdp_list.append(tdp_obj)
+
+    # If the total product object has Grism members, it MUST have direct exposure
+    # members too, or the total product object is not valid.  In this case,
+    # the total product object, as well as its object contents must be deleted.
+    # Also, the SVM FLT/FLC files for the Grism/Prism images must be deleted.
+    index_to_delete = []
+    for index, tdp in enumerate(tdp_list):
+        if tdp.grism_edp_list and not tdp.edp_list:
+            for item in tdp.grism_edp_list:
+                try:
+                    os.remove(item.full_filename)
+                except OSError:
+                    pass
+            index_to_delete.append(index)
+            tdp.grism_edp_list.clear()
+            del tdp.grism_edp_list[:]
+    for item in index_to_delete:
+        del tdp_list[item]
 
     # Done... return dict and object product list
     return obset_products, tdp_list

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -563,6 +563,7 @@ def parse_obset_tree(det_tree, log_level):
       * total detection product per detector
       * filter products per detector
       * single exposure product
+      * grism/prism single exposure product [only if Grism/Prism exposures]
 
     Grism/Prism images were added to the "doProcess" list after most of this
     code was developed as they need to have the same Primary WCS as the direct
@@ -626,11 +627,10 @@ def parse_obset_tree(det_tree, log_level):
                 # easier for the user by having the same WCS in both the direct and
                 # Grism/Prism products.
                 #
-                # The GrismExposureProduct will only be an attibute of the TotalProduct. It
-                # object is NOT part of the FilterProduct or the obset_products.
+                # The GrismExposureProduct is only an attibutes of the TotalProduct.
                 prod_list = prod_info.split(" ")
 
-                # Determine if this image is a Grism/Prism
+                # Determine if this image is a Grism/Prism or a nominal direct exposure
                 is_grism = False
                 if prod_list[5].lower().startswith('g') or prod_list[5].lower().startswith('pr'):
                     is_grism = True
@@ -664,8 +664,8 @@ def parse_obset_tree(det_tree, log_level):
                     tdp_obj = TotalProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
                                            prod_list[4], prod_list[6], log_level)
 
-                # Append exposure object to the list of exposure objects for this specific total detection product
                 if not is_grism:
+                    # Append exposure object to the list of exposure objects for this specific total detection product
                     tdp_obj.add_member(sep_obj)
 
                     # Increment single exposure index
@@ -684,9 +684,10 @@ def parse_obset_tree(det_tree, log_level):
                         for e in filt_obj.edp_list:
                             e.crclean = True
 
-                    tdp_obj.add_product(filt_obj)
-                else:
+                elif is_grism:
                     tdp_obj.add_grism_member(grism_sep_obj)
+
+            tdp_obj.add_product(filt_obj)
 
         # Add the total product object to the list of TotalProducts
         tdp_list.append(tdp_obj)

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -42,6 +42,7 @@ MASK_KWS = {"NPIXFRAC": [None, "Fraction of pixels with data"],
             "MEDNEXP": [None, "Median number of exposures per pixel with data"],
             }
 
+
 class HAPProduct:
     """ HAPProduct is the base class for the various products generated during the
         astrometry update and mosaicing of image data.
@@ -176,7 +177,7 @@ class TotalProduct(HAPProduct):
         """ Add an ExposureProduct object to the list - composition.
         """
         self.edp_list.append(edp)
- 
+
     def add_grism_member(self, edp):
         """ Add an GrismExposureProduct object to the list - composition.
         """
@@ -226,6 +227,7 @@ class TotalProduct(HAPProduct):
         except PermissionError:
             pass
 
+
 class FilterProduct(HAPProduct):
     """ A Filter Detection Product is a mosaic comprised of images acquired
         during a single visit with one instrument, one detector, a single filter,
@@ -272,14 +274,14 @@ class FilterProduct(HAPProduct):
                 break
         return desired_member
 
-
     def add_member(self, edp):
+
         """ Add an ExposureProduct object to the list - composition.
         """
         self.edp_list.append(edp)
 
     def align_to_gaia(self, catalog_name='GAIADR2', headerlet_filenames=None, output=True,
-                        fit_label='EVM', align_table=None, fitgeom='rscale'):
+                      fit_label='EVM', align_table=None, fitgeom='rscale'):
         """Extract the flt/flc filenames from the exposure product list, as
            well as the corresponding headerlet filenames to use legacy alignment
            routine.
@@ -337,7 +339,7 @@ class FilterProduct(HAPProduct):
 
                     align_table.select_fit(catalog_name, method_name)
                     align_table.apply_fit(headerlet_filenames=headerlet_filenames,
-                                         fit_label=fit_label)
+                                          fit_label=fit_label)
                 else:
                     log.warning("Not enough reference sources for absolute alignment...")
                     raise ValueError
@@ -357,7 +359,6 @@ class FilterProduct(HAPProduct):
             # created for alignment of each filter product here.
             if self.refname and os.path.exists(self.refname):
                 os.remove(self.refname)
-
 
         # Return a table which contains data regarding the alignment, as well as the
         # list of the flt/flc exposures which were part of the alignment process
@@ -410,6 +411,7 @@ class FilterProduct(HAPProduct):
         except PermissionError:
             # TODO:  trailer filename should be saved for moving later...
             pass
+
 
 class ExposureProduct(HAPProduct):
     """ An Exposure Product is an individual exposure/image (flt/flc).
@@ -556,9 +558,9 @@ class GrismExposureProduct(HAPProduct):
 
         drizcorr = hdu_list[0].header['DRIZCORR']
         if drizcorr == "OMIT":
-             updatewcs.updatewcs(self.full_filename, use_db=False)
+            updatewcs.updatewcs(self.full_filename, use_db=False)
         else:
-             updatewcs.updatewcs(self.full_filename, use_db=True)
+            updatewcs.updatewcs(self.full_filename, use_db=True)
         hdu_list.close()
 
         self.product_basename = self.basename + "_".join(map(str, [filters, self.exposure_name]))
@@ -806,7 +808,7 @@ class SkyCellProduct(HAPProduct):
         return self.meta_wcs
 
     def align_to_gaia(self, catalog_name='GAIADR2', headerlet_filenames=None, output=True,
-                        fit_label='MVM', align_table=None, fitgeom='rscale'):
+                      fit_label='MVM', align_table=None, fitgeom='rscale'):
         """Extract the flt/flc filenames from the exposure product list, as
            well as the corresponding headerlet filenames to use legacy alignment
            routine.
@@ -842,10 +844,10 @@ class SkyCellProduct(HAPProduct):
                 align_table.reference_catalogs[self.refname] = ref_catalog
                 if len(ref_catalog) > align_utils.MIN_CATALOG_THRESHOLD:
                     align_table.perform_fit(method_name, catalog_name, ref_catalog,
-                                           fitgeom=fitgeom)
+                                            fitgeom=fitgeom)
                     align_table.select_fit(catalog_name, method_name)
                     align_table.apply_fit(headerlet_filenames=headerlet_filenames,
-                                         fit_label=fit_label)
+                                          fit_label=fit_label)
                 else:
                     log.warning("Not enough reference sources for absolute alignment...")
                     raise ValueError
@@ -865,7 +867,6 @@ class SkyCellProduct(HAPProduct):
             # created for alignment of each filter product here.
             if self.refname and os.path.exists(self.refname):
                 os.remove(self.refname)
-
 
         # Return a table which contains data regarding the alignment, as well as the
         # list of the flt/flc exposures which were part of the alignment process

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -107,8 +107,9 @@ class HAPProduct:
 
     def generate_metawcs(self):
         """ A method to build a unique WCS for each TotalProduct product which is
-            generated based upon the merging of all the ExposureProducts which comprise the
-            specific TotalProduct.  This is done on a per TotalProduct basis as the Single
+            generated based upon the merging of all the ExposureProducts
+            which comprise the specific TotalProduct.  This
+            is done on a per TotalProduct basis as the Single
             Visit Mosaics need to be represented in their native scale.
 
         """
@@ -180,6 +181,8 @@ class TotalProduct(HAPProduct):
 
     def add_grism_member(self, edp):
         """ Add an GrismExposureProduct object to the list - composition.
+
+            This routine adds Grism or Prism exposures to the exposure list.
         """
         self.grism_edp_list.append(edp)
 
@@ -263,7 +266,8 @@ class FilterProduct(HAPProduct):
         self.edp_list = []
         self.regions_dict = {}
 
-        log.debug("Filter object {}/{}/{} created.".format(self.instrument, self.detector, self.filters))
+        #log.debug("Filter object {}/{}/{} created.".format(self.instrument, self.detector, self.filters))
+        log.info("Filter object {}/{}/{} created.".format(self.instrument, self.detector, self.filters))
 
     def find_member(self, name):
         """ Return member instance with filename 'name' """
@@ -558,8 +562,6 @@ class GrismExposureProduct(HAPProduct):
 
         drizcorr = hdu_list[0].header['DRIZCORR']
         if drizcorr == "OMIT":
-            updatewcs.updatewcs(self.full_filename, use_db=False)
-        else:
             updatewcs.updatewcs(self.full_filename, use_db=True)
         hdu_list.close()
 


### PR DESCRIPTION
Accommodate processing Grism/Prism images in the form of the SVM hst*[flt/flc].fits) at least to the stage where the Grism/Prism SVM image and the direct SVM images have a common active WCS.