### PR TITLE
Clean up manifest file and disk as necessary

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -703,16 +703,20 @@ def run_align_to_gaia(tot_obj, log_level=logutil.logging.INFO, diagnostic_mode=F
     log.info("\n{}: Finished aligning gaia_obj to GAIA".format(str(datetime.datetime.now())))
     log.info("ALIGNED WCS: \n{}".format(tot_obj.meta_wcs))
 
-    # Return the name of the alignment catalog
+    # Clean up if the align_table does not exist - the metawcs file
+    # may already be deleted, but make sure here.
     if align_table is None:
         gaia_obj.refname = None
         headerlet_filenames = []
+        try:
+            os.remove(gaia_obj.refname)
+        except OSError:
+            pass
     else:
         # Get names of all headerlet files written out to file
         headerlet_filenames = [f for f in align_table.filtered_table['headerletFile'] if f != "None"]
 
-    return [gaia_obj.refname] + headerlet_filenames
-
+    return headerlet_filenames
 # ----------------------------------------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Fix to ensure the literal 'None' and the name of the 'metawcs all ref catalog' strings are not in the manifest.  In addition the
'metawcs fall ref catalog' file should be deleted from disk.  The disk clean up may have already happened, but this is to ensure it is done and is encapsulated in a try/except.