### PR TITLE
Corrected manner of checking for a return type of None

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -914,7 +914,7 @@ class HAPPointCatalog(HAPCatalogBase):
                                                              box_size=self.param_dict['region_size'],
                                                              nsigma=self.param_dict['nsigma'],
                                                              mask=self.image.footprint_mask)
-                    if len(user_peaks) == 0:
+                    if not user_peaks:
                         user_peaks = None
 
                     log.info("UserStarFinder identified {} sources".format(len(user_peaks)))


### PR DESCRIPTION
Simple fix to check for a return type having no values.  Replace the check for a length of zero which causes an exception to "if not variable_name".