### PR TITLE
Fix EXTNAME/EXTVER in simple FITS files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ of the list).
 3.2.1 (unreleased)
 ==================
 
+- Changed to insure that EXTNAME and EXTVER are always removed from
+  simple FITS drizzle product headers. [#954]
+
+- Changed to insure that all the distortion keywords (e.g., TDD*, D2IM*,...)
+  are removed from from the output drizzle product headers [#954].
+
 - Fix a bug in ``tweakback`` that may cause incorrect "updated" WCS to be
   picked up from the drizzled image. [#913]
 

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -7,7 +7,7 @@ This module manages the creation of the output image FITS file.
 
 """
 from astropy.io import fits
-from stsci.tools import fileutil, readgeis, logutil
+from stsci.tools import fileutil, logutil
 
 from . import wcs_functions
 from . import version
@@ -18,7 +18,7 @@ from fitsblender import blendheaders
 yes = True
 no = False
 
-RESERVED_KEYS = ['NAXIS', 'BITPIX', 'DATE', 'IRAF-TLM', 'XTENSION', 'EXTNAME',' EXTVER']
+RESERVED_KEYS = ['NAXIS', 'BITPIX', 'DATE', 'IRAF-TLM', 'XTENSION', 'EXTNAME', ' EXTVER']
 
 EXTLIST = ('SCI', 'WHT', 'CTX')
 
@@ -32,21 +32,21 @@ PYFITS_COMPRESSION = hasattr(fits, 'CompImageHDU')
 # Set up dictionary of default keywords to be written out to the header
 # of the output drizzle image using writeDrizKeywords()
 DRIZ_KEYWORDS = {
-                'VER':{'value':"",'comment':'Drizzle, task version'},
-                'GEOM':{'value':"wcs",'comment':'Drizzle, source of geometric information'},
-                'DATA':{'value':"",'comment':'Drizzle, input data image'},
-                'DEXP':{'value':"",'comment':'Drizzle, input image exposure time (s)'},
-                'OUDA':{'value':"",'comment':'Drizzle, output data image'},
-                'OUWE':{'value':"",'comment':'Drizzle, output weighting image'},
-                'OUCO':{'value':"",'comment':'Drizzle, output context image'},
-                'MASK':{'value':"",'comment':'Drizzle, input weighting image'},
-                'WTSC':{'value':"",'comment':'Drizzle, weighting factor for input image'},
-                'KERN':{'value':"",'comment':'Drizzle, form of weight distribution kernel'},
-                'PIXF':{'value':"1.0",'comment':'Drizzle, linear size of drop'},
-                'COEF':{'value':"SIP",'comment':'Drizzle, source of coefficients'},
-                'OUUN':{'value':"cps",'comment':'Drizzle, units of output image - counts or cps'},
-                'FVAL':{'value':"INDEF",'comment':'Drizzle, fill value for zero weight output pix'},
-                'WKEY':{'value':"",'comment':'Input image WCS Version used'}
+                'VER': {'value': "", 'comment': 'Drizzle, task version'},
+                'GEOM': {'value': "wcs", 'comment': 'Drizzle, source of geometric information'},
+                'DATA': {'value': "", 'comment': 'Drizzle, input data image'},
+                'DEXP': {'value': "", 'comment': 'Drizzle, input image exposure time (s)'},
+                'OUDA': {'value': "", 'comment': 'Drizzle, output data image'},
+                'OUWE': {'value': "", 'comment': 'Drizzle, output weighting image'},
+                'OUCO': {'value': "", 'comment': 'Drizzle, output context image'},
+                'MASK': {'value': "", 'comment': 'Drizzle, input weighting image'},
+                'WTSC': {'value': "", 'comment': 'Drizzle, weighting factor for input image'},
+                'KERN': {'value': "", 'comment': 'Drizzle, form of weight distribution kernel'},
+                'PIXF': {'value': "1.0", 'comment': 'Drizzle, linear size of drop'},
+                'COEF': {'value': "SIP", 'comment': 'Drizzle, source of coefficients'},
+                'OUUN': {'value': "cps", 'comment': 'Drizzle, units of output image - counts or cps'},
+                'FVAL': {'value': "INDEF", 'comment': 'Drizzle, fill value for zero weight output pix'},
+                'WKEY': {'value': "", 'comment': 'Input image WCS Version used'}
                 }
 
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
@@ -105,7 +105,7 @@ class OutputImage:
         self.blot = blot
 
         if PYFITS_COMPRESSION and 'compress' in input_pars:
-            self.compress = input_pars['compress'] # Control creation of compressed FITS files
+            self.compress = input_pars['compress']  # Control creation of compressed FITS files
         else:
             self.compress = False
 
@@ -115,10 +115,10 @@ class OutputImage:
 
         if not blot:
             self.output = plist[0]['output']
-            self.shape = (plist[0]['outny'],plist[0]['outnx'])
+            self.shape = (plist[0]['outny'], plist[0]['outnx'])
         else:
             self.output = plist[0]['blotImage']
-            self.shape = (plist[0]['blotny'],plist[0]['blotnx'])
+            self.shape = (plist[0]['blotny'], plist[0]['blotnx'])
 
         # Keep track of desired output WCS computed by PyDrizzle
         self.wcs = wcs
@@ -145,7 +145,7 @@ class OutputImage:
             # Report values appropriate for entire combined product
             self.texptime = plist[0]['texptime']
             self.expstart = plist[0]['texpstart']
-            self.expend = plist[_nimgs-1]['texpend']
+            self.expend = plist[_nimgs - 1]['texpend']
 
 
         if blot:
@@ -159,13 +159,13 @@ class OutputImage:
         self.outweight = _outweight
         self.outcontext = _outcontext
 
-    def set_bunit(self,bunit):
+    def set_bunit(self, bunit):
         """
         Method used to update the value of the bunit attribute.
         """
         self.bunit = bunit
 
-    def set_units(self,units):
+    def set_units(self, units):
         """
         Method used to record what units were specified by the user for the output product.
         """
@@ -234,19 +234,18 @@ class OutputImage:
         # If only writing out single drizzle product, blending needs to be
         # forced off as there is only 1 input to report, no blending needed
         if self.single:
-            blend=False
+            blend = False
 
         # If input data is not in MEF FITS format, it will return 'None'
         # and those headers will have to be generated from drizzle output
         # file FITS headers.
         # NOTE: These are HEADER objects, not HDUs
-        #prihdr,scihdr,errhdr,dqhdr = getTemplates(template)
         self.fullhdrs, intab = getTemplates(template, blend=False,
                                             rules_file=rules_file)
 
-        newhdrs, newtab = getTemplates(template,blend=blend,
+        newhdrs, newtab = getTemplates(template, blend=blend,
                                         rules_file=rules_file)
-        if newtab is not None: nextend += 1 # account for new table extn
+        if newtab is not None: nextend += 1  # account for new table extn
 
         prihdr = newhdrs[0]
         scihdr = newhdrs[1]
@@ -281,7 +280,7 @@ class OutputImage:
             prihdu.header['EXPSTART'] = self.expstart
             prihdu.header['EXPEND'] = self.expend
 
-        #Update ASN_MTYPE to reflect the fact that this is a product
+        # Update ASN_MTYPE to reflect the fact that this is a product
         # Currently hard-wired to always output 'PROD-DTH' as MTYPE
         prihdu.header['ASN_MTYP'] = 'PROD-DTH'
 
@@ -292,14 +291,14 @@ class OutputImage:
         if 'DITHCORR' in prihdu.header:
             prihdu.header['DITHCORR'] = 'COMPLETE'
 
-        prihdu.header['NDRIZIM'] =(len(self.parlist),
+        prihdu.header['NDRIZIM'] = (len(self.parlist),
                                    'Drizzle, No. images drizzled onto output')
 
         # Only a subset of these keywords makes sense for the new WCS based
         # transformations. They need to be reviewed to decide what to keep
         # and what to leave out.
         if not self.blot:
-            self.addDrizKeywords(prihdu.header,versions)
+            self.addDrizKeywords(prihdu.header, versions)
 
         if scihdr:
             try:
@@ -312,7 +311,7 @@ class OutputImage:
                 scihdr['NCOMBINE'] = self.parlist[0]['nimages']
 
             # If BUNIT keyword was found and reset, then
-            bunit_last_kw = self.find_kwupdate_location(scihdr,'bunit')
+            bunit_last_kw = self.find_kwupdate_location(scihdr, 'bunit')
             if self.bunit is not None:
                 comment_str = "Units of science product"
                 if self.bunit.lower()[:5] == 'count':
@@ -330,17 +329,17 @@ class OutputImage:
 
             # Add WCS keywords to SCI header
             if self.wcs:
-                pre_wcs_kw = self.find_kwupdate_location(scihdr,'CD1_1')
-                addWCSKeywords(self.wcs,scihdr,blot=self.blot,
+                pre_wcs_kw = self.find_kwupdate_location(scihdr, 'CD1_1')
+                addWCSKeywords(self.wcs, scihdr, blot=self.blot,
                                 single=self.single, after=pre_wcs_kw)
                 # Recompute this after removing distortion kws
-                pre_wcs_kw = self.find_kwupdate_location(scihdr,'CD1_1')
+                pre_wcs_kw = self.find_kwupdate_location(scihdr, 'CD1_1')
 
         ##########
         # Now, build the output file
         ##########
         if self.build:
-            print('-Generating multi-extension output file: ',self.output)
+            print('-Generating multi-extension output file: ', self.output)
             fo = fits.HDUList()
 
             # Add primary header to output file...
@@ -350,7 +349,7 @@ class OutputImage:
                 hdu = fits.CompImageHDU(data=sciarr, header=scihdr, name=EXTLIST[0])
             else:
                 hdu = fits.ImageHDU(data=sciarr, header=scihdr, name=EXTLIST[0])
-            last_kw = self.find_kwupdate_location(scihdr,'EXTNAME')
+            last_kw = self.find_kwupdate_location(scihdr, 'EXTNAME')
             hdu.header.set('EXTNAME', value='SCI', after=last_kw)
             hdu.header.set('EXTVER', value=1, after='EXTNAME')
             fo.append(hdu)
@@ -363,14 +362,14 @@ class OutputImage:
                 hdu = fits.CompImageHDU(data=whtarr, header=errhdr, name=EXTLIST[1])
             else:
                 hdu = fits.ImageHDU(data=whtarr, header=errhdr, name=EXTLIST[1])
-            last_kw = self.find_kwupdate_location(errhdr,'EXTNAME')
+            last_kw = self.find_kwupdate_location(errhdr, 'EXTNAME')
             hdu.header.set('EXTNAME', value='WHT', after=last_kw)
             hdu.header.set('EXTVER', value=1, after='EXTNAME')
             if self.wcs:
-                pre_wcs_kw = self.find_kwupdate_location(hdu.header,'CD1_1')
+                pre_wcs_kw = self.find_kwupdate_location(hdu.header, 'CD1_1')
                 # Update WCS Keywords based on PyDrizzle product's value
                 # since 'drizzle' itself doesn't update that keyword.
-                addWCSKeywords(self.wcs,hdu.header,blot=self.blot,
+                addWCSKeywords(self.wcs, hdu.header, blot=self.blot,
                                single=self.single, after=pre_wcs_kw)
             fo.append(hdu)
 
@@ -388,34 +387,34 @@ class OutputImage:
                 hdu = fits.CompImageHDU(data=_ctxarr, header=dqhdr, name=EXTLIST[2])
             else:
                 hdu = fits.ImageHDU(data=_ctxarr, header=dqhdr, name=EXTLIST[2])
-            last_kw = self.find_kwupdate_location(dqhdr,'EXTNAME')
+            last_kw = self.find_kwupdate_location(dqhdr, 'EXTNAME')
             hdu.header.set('EXTNAME', value='CTX', after=last_kw)
             hdu.header.set('EXTVER', value=1, after='EXTNAME')
 
             if self.wcs:
-                pre_wcs_kw = self.find_kwupdate_location(hdu.header,'CD1_1')
+                pre_wcs_kw = self.find_kwupdate_location(hdu.header, 'CD1_1')
                 # Update WCS Keywords based on PyDrizzle product's value
                 # since 'drizzle' itself doesn't update that keyword.
-                addWCSKeywords(self.wcs,hdu.header,blot=self.blot,
+                addWCSKeywords(self.wcs, hdu.header, blot=self.blot,
                                single=self.single, after=pre_wcs_kw)
             fo.append(hdu)
 
             # remove all alternate WCS solutions from headers of this product
-            wcs_functions.removeAllAltWCS(fo,[1])
+            wcs_functions.removeAllAltWCS(fo, [1])
 
             # add table of combined header keyword values to FITS file
             if newtab is not None:
                 fo.append(newtab)
 
             if not virtual:
-                print('Writing out to disk:',self.output)
+                print('Writing out to disk:', self.output)
                 # write out file to disk
                 fo.writeto(self.output)
                 fo.close()
                 del fo, hdu
                 fo = None
             # End 'if not virtual'
-            outputFITS[self.output]= fo
+            outputFITS[self.output] = fo
 
         else:
             print('-Generating simple FITS output: %s' % self.outdata)
@@ -430,6 +429,7 @@ class OutputImage:
                 for _card in scihdr.cards:
                     if _card.keyword not in RESERVED_KEYS and _card.keyword not in hdu_header:
                         hdu_header.append(_card)
+
             for kw in ['PCOUNT', 'GCOUNT']:
                 try:
                     del kw
@@ -446,7 +446,10 @@ class OutputImage:
 
             # explicitly set EXTEND to FALSE for simple FITS files.
             dim = len(sciarr.shape)
-            hdu.header.set('extend', value=False, after='NAXIS%s'%dim)
+            hdu.header.set('extend', value=False, after='NAXIS%s' % dim)
+            # explicitly set EXTNAME, EXTVER to (sci,1)
+            hdu.header.set('EXTNAME', value='SCI', before='TELESCOP')
+            hdu.header.set('EXTVER', value=1, after='EXTNAME')
 
             # Add primary header to output file...
             fo.append(hdu)
@@ -454,7 +457,7 @@ class OutputImage:
             if not self.blot:
                 # remove all alternate WCS solutions from headers of this product
                 logutil.logging.disable(logutil.logging.INFO)
-                wcs_functions.removeAllAltWCS(fo,wcs_ext)
+                wcs_functions.removeAllAltWCS(fo, wcs_ext)
                 logutil.logging.disable(logutil.logging.NOTSET)
 
             # add table of combined header keyword values to FITS file
@@ -462,15 +465,15 @@ class OutputImage:
                 fo.append(newtab)
 
             if not virtual or "single_sci" in self.outdata:
-                print('Writing out image to disk:',self.outdata)
+                print('Writing out image to disk:', self.outdata)
                 # write out file to disk
-                fo.writeto(self.outdata)
+                fo.writeto(self.outdata, overwrite=True)
                 del hdu
                 if "single_sci" not in self.outdata:
                     del fo
                     fo = None
             # End 'if not virtual'
-            outputFITS[self.outdata]= fo
+            outputFITS[self.outdata] = fo
 
             if self.outweight and whtarr is not None:
                 # We need to build new PyFITS objects for each WHT array
@@ -491,25 +494,30 @@ class OutputImage:
                             hdu.header.append(_card)
                 hdu.header['filename'] = self.outweight
                 hdu.header['CCDCHIP'] = '-999'
+
                 if self.wcs:
-                    pre_wcs_kw = self.find_kwupdate_location(hdu.header,'CD1_1')
+                    pre_wcs_kw = self.find_kwupdate_location(hdu.header, 'CD1_1')
                     # Update WCS Keywords based on PyDrizzle product's value
                     # since 'drizzle' itself doesn't update that keyword.
-                    addWCSKeywords(self.wcs,hdu.header, blot=self.blot,
+                    addWCSKeywords(self.wcs, hdu.header, blot=self.blot,
                                    single=self.single, after=pre_wcs_kw)
+
+                # explicitly set EXTNAME, EXTVER to (sci,1)
+                hdu.header.set('EXTNAME', value='WHT', before='TELESCOP')
+                hdu.header.set('EXTVER', value=1, after='EXTNAME')
 
                 # Add primary header to output file...
                 fwht.append(hdu)
                 # remove all alternate WCS solutions from headers of this product
-                wcs_functions.removeAllAltWCS(fwht,wcs_ext)
+                wcs_functions.removeAllAltWCS(fwht, wcs_ext)
 
                 if not virtual:
-                    print('Writing out image to disk:',self.outweight)
-                    fwht.writeto(self.outweight)
-                    del fwht,hdu
+                    print('Writing out image to disk:', self.outweight)
+                    fwht.writeto(self.outweight, overwrite=True)
+                    del fwht, hdu
                     fwht = None
                 # End 'if not virtual'
-                outputFITS[self.outweight]= fwht
+                outputFITS[self.outweight] = fwht
 
             # If a context image was specified, build a PyFITS object
             # for it as well...
@@ -530,32 +538,37 @@ class OutputImage:
                 # header to Primary header...
                 if dqhdr:
                     for _card in dqhdr.cards:
-                        if ( (_card.keyword not in RESERVED_KEYS) and
+                        if ((_card.keyword not in RESERVED_KEYS) and
                              _card.keyword not in hdu.header):
                             hdu.header.append(_card)
                 hdu.header['filename'] = self.outcontext
+
                 if self.wcs:
-                    pre_wcs_kw = self.find_kwupdate_location(hdu.header,'CD1_1')
+                    pre_wcs_kw = self.find_kwupdate_location(hdu.header, 'CD1_1')
                     # Update WCS Keywords based on PyDrizzle product's value
                     # since 'drizzle' itself doesn't update that keyword.
-                    addWCSKeywords(self.wcs,hdu.header, blot=self.blot,
+                    addWCSKeywords(self.wcs, hdu.header, blot=self.blot,
                                    single=self.single, after=pre_wcs_kw)
+
+                # explicitly set EXTNAME, EXTVER to (sci,1)
+                hdu.header.set('EXTNAME', value='CTX', before='TELESCOP')
+                hdu.header.set('EXTVER', value=1, after='EXTNAME')
 
                 fctx.append(hdu)
                 # remove all alternate WCS solutions from headers of this product
-                wcs_functions.removeAllAltWCS(fctx,wcs_ext)
+                wcs_functions.removeAllAltWCS(fctx, wcs_ext)
                 if not virtual:
-                    print('Writing out image to disk:',self.outcontext)
-                    fctx.writeto(self.outcontext)
-                    del fctx,hdu
+                    print('Writing out image to disk:', self.outcontext)
+                    fctx.writeto(self.outcontext, overwrite=True)
+                    del fctx, hdu
                     fctx = None
                 # End 'if not virtual'
 
-                outputFITS[self.outcontext]= fctx
+                outputFITS[self.outcontext] = fctx
 
         return outputFITS
 
-    def find_kwupdate_location(self,hdr,keyword):
+    def find_kwupdate_location(self, hdr, keyword):
         """
         Find the last keyword in the output header that comes before the new
         keyword in the original, full input headers.
@@ -568,7 +581,6 @@ class OutputImage:
         last_kw = None
         for extn in self.fullhdrs:
             if keyword in extn:
-                #indx = extn.ascard.index_of(keyword)
                 indx = extn.index(keyword)
                 kw_list = list(extn.keys())[:indx]
                 break
@@ -590,7 +602,7 @@ class OutputImage:
         return last_kw
 
 
-    def addDrizKeywords(self,hdr,versions):
+    def addDrizKeywords(self, hdr, versions):
         """ Add drizzle parameter keywords to header. """
 
         # Extract some global information for the keywords
@@ -601,7 +613,7 @@ class OutputImage:
 
             # Start by building up the keyword prefix based
             # on the image number for the chip
-            #_keyprefix = 'D%03d'%_imgnum
+            # _keyprefix = 'D%03d'%_imgnum
             _imgnum += 1
 
             drizdict = DRIZ_KEYWORDS.copy()
@@ -627,7 +639,7 @@ class OutputImage:
                 _wtscl = pl['wt_scl_val']
             else:
                 if pl['wt_scl'] == 'exptime': _wtscl = pl['exptime']
-                elif pl['wt_scl'] == 'expsq': _wtscl = pl['exptime']*pl['exptime']
+                elif pl['wt_scl'] == 'expsq': _wtscl = pl['exptime'] * pl['exptime']
                 else: _wtscl = pl['wt_scl']
 
             drizdict['WTSC']['value'] = _wtscl
@@ -641,11 +653,11 @@ class OutputImage:
             drizdict['FVAL']['value'] = _fillval
             drizdict['WKEY']['value'] = pl['driz_wcskey']
 
-            drizdict['SCAL'] = {'value':pl['scale'],'comment':'Drizzle, pixel size (arcsec) of output image'}
-            drizdict['ISCL'] = {'value':pl['idcscale'],'comment':'Drizzle, default IDCTAB pixel size(arcsec)'}
+            drizdict['SCAL'] = {'value': pl['scale'], 'comment': 'Drizzle, pixel size (arcsec) of output image'}
+            drizdict['ISCL'] = {'value': pl['idcscale'], 'comment': 'Drizzle, default IDCTAB pixel size(arcsec)'}
 
             # Now update header with values
-            writeDrizKeywords(hdr,_imgnum,drizdict)
+            writeDrizKeywords(hdr, _imgnum, drizdict)
             del drizdict
 
         # Add version information as HISTORY cards to the header
@@ -653,11 +665,11 @@ class OutputImage:
             ver_str = "AstroDrizzle processing performed using: "
             hdr.add_history(ver_str)
             for k in versions.keys():
-                ver_str = '    '+str(k)+' Version '+str(versions[k])
+                ver_str = '    ' + str(k) + ' Version ' + str(versions[k])
                 hdr.add_history(ver_str)
 
 
-def cleanTemplates(scihdr,errhdr,dqhdr):
+def cleanTemplates(scihdr, errhdr, dqhdr):
 
     # Now, safeguard against having BSCALE and BZERO
     for kw in ['BSCALE', 'BZERO']:
@@ -683,7 +695,7 @@ def cleanTemplates(scihdr,errhdr,dqhdr):
                 if keyword not in errhdr:
                     errhdr[keyword] = scihdr[keyword]
                 if keyword not in dqhdr:
-                    dqhdr[keyword]= scihdr[keyword]
+                    dqhdr[keyword] = scihdr[keyword]
 
 def getTemplates(fnames, blend=True, rules_file=None):
     """ Process all headers to produce a set of combined headers
@@ -691,7 +703,7 @@ def getTemplates(fnames, blend=True, rules_file=None):
 
     """
     if not blend:
-        newhdrs =  blendheaders.getSingleTemplate(fnames[0])
+        newhdrs = blendheaders.getSingleTemplate(fnames[0])
         newtab = None
     else:
         # apply rules to create final version of headers, plus table
@@ -700,11 +712,11 @@ def getTemplates(fnames, blend=True, rules_file=None):
         newhdrs, newtab = blendheaders.get_blended_headers(inputs=fnames,
                                                             rules_file=rules_file)
 
-    cleanTemplates(newhdrs[1],newhdrs[2],newhdrs[3])
+    cleanTemplates(newhdrs[1], newhdrs[2], newhdrs[3])
 
     return newhdrs, newtab
 
-def addWCSKeywords(wcs,hdr,blot=False,single=False,after=None):
+def addWCSKeywords(wcs, hdr, blot=False, single=False, after=None):
     """ Update input header 'hdr' with WCS keywords.
     """
     wname = wcs.wcs.name
@@ -744,20 +756,20 @@ def deleteDistortionKeywords(hdr):
     """ Delete distortion related keywords from output drizzle science header
         since the drizzled image should have no remaining distortion.
     """
-    dist_kws = ['D2IMERR1','D2IMERR2','D2IMDIS1','D2IMDIS2','D2IM1.*','D2IM2.*',
+    dist_kws = ['D2IMERR1', 'D2IMERR2', 'D2IMDIS1', 'D2IMDIS2', 'D2IM1.*', 'D2IM2.*',
                 'D2IMEXT', 'DP1', 'DP2', 'CPDIS?', 'CPERR?']
     for kw in dist_kws:
         if kw in hdr:
             del hdr[kw]
 
 
-def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
+def writeSingleFITS(data, wcs, output, template, clobber=True, verbose=True,
                     rules_file=None):
     """ Write out a simple FITS file given a numpy array and the name of another
     FITS file to use as a template for the output image header.
     """
-    outname,outextn = fileutil.parseFilename(output)
-    outextname,outextver = fileutil.parseExtn(outextn)
+    outname, outextn = fileutil.parseFilename(output)
+    outextname, outextver = fileutil.parseExtn(outextn)
 
     if fileutil.findFile(outname):
         if clobber:
@@ -771,7 +783,7 @@ def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
             raise IOError
 
     # Now update WCS keywords with values from provided WCS
-    if hasattr(wcs.sip,'a_order'):
+    if hasattr(wcs.sip, 'a_order'):
         siphdr = True
     else:
         siphdr = False
@@ -781,16 +793,16 @@ def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
         # Get default headers from multi-extension FITS file
         # If input data is not in MEF FITS format, it will return 'None'
         # NOTE: These are HEADER objects, not HDUs
-        (prihdr,scihdr,errhdr,dqhdr),newtab = getTemplates(template,EXTLIST,
+        (prihdr, scihdr, errhdr, dqhdr), newtab = getTemplates(template, EXTLIST,
                                                            rules_file=rules_file)
 
         if scihdr is None:
             scihdr = fits.Header()
             indx = 0
             for c in prihdr.cards:
-                if c.keyword not in ['INHERIT','EXPNAME']: indx += 1
+                if c.keyword not in ['INHERIT', 'EXPNAME']: indx += 1
                 else: break
-            for i in range(indx,len(prihdr)):
+            for i in range(indx, len(prihdr)):
                 scihdr.append(prihdr.cards[i])
             for i in range(indx, len(prihdr)):
                 del prihdr[indx]
@@ -812,7 +824,7 @@ def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
     outhdu = fits.HDUList()
     # Setup primary header as an HDU ready for appending to output FITS file
     prihdu = fits.PrimaryHDU(header=prihdr)
-    scihdu = fits.ImageHDU(header=scihdr,data=data)
+    scihdu = fits.ImageHDU(header=scihdr, data=data)
 
     outhdu.append(prihdu)
     outhdu.append(scihdu)
@@ -821,18 +833,18 @@ def writeSingleFITS(data,wcs,output,template,clobber=True,verbose=True,
     if verbose:
         print('Created output image: %s' % outname)
 
-def writeDrizKeywords(hdr,imgnum,drizdict):
+def writeDrizKeywords(hdr, imgnum, drizdict):
     """ Write basic drizzle-related keywords out to image header as a record
         of the processing performed to create the image
 
         The dictionary 'drizdict' will contain the keywords and values to be
         written out to the header.
     """
-    _keyprefix = 'D%03d'%imgnum
+    _keyprefix = 'D%03d' % imgnum
 
     for key in drizdict:
         val = drizdict[key]['value']
         if val is None: val = ""
         comment = drizdict[key]['comment']
         if comment is None: comment = ""
-        hdr[_keyprefix+key] = (val, drizdict[key]['comment'])
+        hdr[_keyprefix + key] = (val, drizdict[key]['comment'])

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -453,7 +453,7 @@ class OutputImage:
                 if kw in hdu.header:
                     del hdu.header[kw]
 
-            hdu.header.set('filetype', 'SCI', before='TELESCOP')
+            hdu.header.set('filetype', 'SCI', before='TELESCOP', comment='Type of data in array')
 
             # Add primary header to output file...
             fo.append(hdu)
@@ -511,7 +511,7 @@ class OutputImage:
                     if kw in hdu.header:
                         del hdu.header[kw]
 
-                hdu.header.set('filetype', 'WHT', before='TELESCOP')
+                hdu.header.set('filetype', 'WHT', before='TELESCOP', comment='Type of data in array')
 
                 # Add primary header to output file...
                 fwht.append(hdu)
@@ -562,7 +562,7 @@ class OutputImage:
                     if kw in hdu.header:
                         del hdu.header[kw]
 
-                hdu.header.set('filetype', 'CTX', before='TELESCOP')
+                hdu.header.set('filetype', 'CTX', before='TELESCOP', comment='Type of data in array')
 
                 fctx.append(hdu)
                 # remove all alternate WCS solutions from headers of this product

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -18,15 +18,18 @@ from fitsblender import blendheaders
 yes = True
 no = False
 
-RESERVED_KEYS = ['NAXIS', 'BITPIX', 'DATE', 'IRAF-TLM', 'XTENSION', 'EXTNAME', ' EXTVER']
+RESERVED_KEYS = ['NAXIS', 'NAXIS1', 'NAXIS2', 'EXTEND',
+                 'BITPIX', 'DATE', 'IRAF-TLM',
+                 'XTENSION', 'EXTNAME', ' EXTVER']
 
 EXTLIST = ('SCI', 'WHT', 'CTX')
 
 WCS_KEYWORDS = ['CD1_1', 'CD1_2', 'CD2_1', 'CD2_2', 'CRPIX1',
 'CRPIX2', 'CRVAL1', 'CRVAL2', 'CTYPE1', 'CTYPE2', 'WCSNAME']
+
 DIST_KWS = ['D2IMERR1', 'D2IMERR2', 'D2IMDIS1', 'D2IMDIS2',
             'D2IMEXT', 'DP1', 'DP2', ]
-DIST_MULTI_KWS = ['D2IM1.*', 'D2IM2.*', 'CPDIS?', 'CPERR?', 'TDD*']
+DIST_MULTI_KWS = ['D2IM1.*', 'D2IM2.*', 'CPDIS?', 'CPERR?', 'TDD_C*']
 
 # fits.CompImageHDU() crashes with default arguments.
 # Instead check that fits module has *attribute* 'CompImageHDU':

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -20,7 +20,7 @@ no = False
 
 RESERVED_KEYS = ['NAXIS', 'NAXIS1', 'NAXIS2', 'EXTEND',
                  'BITPIX', 'DATE', 'IRAF-TLM',
-                 'XTENSION', 'EXTNAME', ' EXTVER']
+                 'XTENSION', 'EXTNAME', 'EXTVER']
 
 EXTLIST = ('SCI', 'WHT', 'CTX')
 

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -447,9 +447,13 @@ class OutputImage:
             # explicitly set EXTEND to FALSE for simple FITS files.
             dim = len(sciarr.shape)
             hdu.header.set('extend', value=False, after='NAXIS%s' % dim)
-            # explicitly set EXTNAME, EXTVER to (sci,1)
-            hdu.header.set('EXTNAME', value='SCI', before='TELESCOP')
-            hdu.header.set('EXTVER', value=1, after='EXTNAME')
+
+            # explicitly remove EXTNAME, EXTVER from header - they are not allowed
+            for kw in RESERVED_KEYS[-2:]:
+                if kw in hdu.header:
+                    del hdu.header[kw]
+
+            hdu.header.set('filetype', 'SCI', before='TELESCOP')
 
             # Add primary header to output file...
             fo.append(hdu)
@@ -502,9 +506,12 @@ class OutputImage:
                     addWCSKeywords(self.wcs, hdu.header, blot=self.blot,
                                    single=self.single, after=pre_wcs_kw)
 
-                # explicitly set EXTNAME, EXTVER to (sci,1)
-                hdu.header.set('EXTNAME', value='WHT', before='TELESCOP')
-                hdu.header.set('EXTVER', value=1, after='EXTNAME')
+                # explicitly remove EXTNAME, EXTVER from header - they are not allowed
+                for kw in RESERVED_KEYS[-2:]:
+                    if kw in hdu.header:
+                        del hdu.header[kw]
+
+                hdu.header.set('filetype', 'WHT', before='TELESCOP')
 
                 # Add primary header to output file...
                 fwht.append(hdu)
@@ -550,9 +557,12 @@ class OutputImage:
                     addWCSKeywords(self.wcs, hdu.header, blot=self.blot,
                                    single=self.single, after=pre_wcs_kw)
 
-                # explicitly set EXTNAME, EXTVER to (sci,1)
-                hdu.header.set('EXTNAME', value='CTX', before='TELESCOP')
-                hdu.header.set('EXTVER', value=1, after='EXTNAME')
+                # explicitly remove EXTNAME, EXTVER from header - they are not allowed
+                for kw in RESERVED_KEYS[-2:]:
+                    if kw in hdu.header:
+                        del hdu.header[kw]
+
+                hdu.header.set('filetype', 'CTX', before='TELESCOP')
 
                 fctx.append(hdu)
                 # remove all alternate WCS solutions from headers of this product
@@ -756,11 +766,16 @@ def deleteDistortionKeywords(hdr):
     """ Delete distortion related keywords from output drizzle science header
         since the drizzled image should have no remaining distortion.
     """
-    dist_kws = ['D2IMERR1', 'D2IMERR2', 'D2IMDIS1', 'D2IMDIS2', 'D2IM1.*', 'D2IM2.*',
-                'D2IMEXT', 'DP1', 'DP2', 'CPDIS?', 'CPERR?']
+    dist_kws = ['D2IMERR1', 'D2IMERR2', 'D2IMDIS1', 'D2IMDIS2',
+                'D2IMEXT', 'DP1', 'DP2', ]
+    dist_multi_kws = ['D2IM1.*', 'D2IM2.*', 'CPDIS?', 'CPERR?']
     for kw in dist_kws:
         if kw in hdr:
             del hdr[kw]
+    for multi_kw in dist_multi_kws:
+        for kw in hdr[multi_kw]:
+            if kw in hdr:
+                del hdr[kw]
 
 
 def writeSingleFITS(data, wcs, output, template, clobber=True, verbose=True,


### PR DESCRIPTION
These changes insure that all simple FITS files written out by astrodrizzle no longer have the `EXTNAME` and `EXTVER` keywords in the simple FITS drizzle product headers.  Instead, the `FILETYPE` keyword has been added to document the type of data in the file (SCI, WHT, CTX).  

This avoids the problems reported in #590 .  

In addition, 
  - all Flake8 errors in the 'outputimage.py' module have been resolved.
  - leftover WCS distortion keywords are finally cleaned up properly

Fixes https://github.com/spacetelescope/drizzlepac/issues/862, #590