### PR TITLE
Add more error cases for FWHM use

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -669,7 +669,7 @@ class HAPImage:
                                                                  dao_threshold=self.bkg_rms_mean[chip],
                                                                  fwhm=self.kernel_fwhm,
                                                                  **extract_pars)
-            if crclean and crmap:
+            if crclean and crmap is not None:
                 i = self.imgname.replace('.fits', '')
                 if log.level < logutil.logging.INFO:
                     # apply crmap to input image

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -580,7 +580,6 @@ class HAPImage:
                     else:
                         bkg_rms_mean = 3. * threshold_flag
                         threshold = default_threshold
-
                     break
 
             # If Background2D does not work at all, define default scalar values for
@@ -670,7 +669,7 @@ class HAPImage:
                                                                  dao_threshold=self.bkg_rms_mean[chip],
                                                                  fwhm=self.kernel_fwhm,
                                                                  **extract_pars)
-            if crclean:
+            if crclean and crmap:
                 i = self.imgname.replace('.fits', '')
                 if log.level < logutil.logging.INFO:
                     # apply crmap to input image

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -929,6 +929,7 @@ class HAPPointCatalog(HAPCatalogBase):
                     try:
                         user_peaks, source_fwhm = decutils.find_point_sources(self.image.imgname,
                                                                  data=region,
+                                                                 def_fwhm=source_fwhm,
                                                                  box_size=self.param_dict['region_size'],
                                                                  mask=self.image.footprint_mask,
                                                                  block_size=self.param_dict['block_size'],
@@ -940,7 +941,7 @@ class HAPPointCatalog(HAPCatalogBase):
                         log.warning("Exception thrown when trying to use PSFs to find sources with UserStarFinder.")
                         user_peaks = None
 
-                    if user_peaks and len(user_peaks) > 0:
+                    if user_peaks is not None and len(user_peaks) > 0:
 
                         log.info("UserStarFinder identified {} sources".format(len(user_peaks)))
                         if self.diagnostic_mode:

--- a/drizzlepac/haputils/deconvolve_utils.py
+++ b/drizzlepac/haputils/deconvolve_utils.py
@@ -926,7 +926,7 @@ def find_point_sources(drzname, data=None, mask=None,
     # try to measure just the core of the PSF
     # This will be a lot less likely to result in invalid/impossible FWHM values
     yc, xc = np.where(drzpsf == drzpsf.max())[0]
-    psf_core = drzpsf[yc - box_size: yc + box_size, xc - box_size: yc - box_size]
+    psf_core = drzpsf[yc - box_size: yc + box_size, xc - box_size: xc + box_size]
     psf_fwhm = amutils.find_fwhm(psf_core, def_fwhm)
 
     # check value

--- a/drizzlepac/haputils/deconvolve_utils.py
+++ b/drizzlepac/haputils/deconvolve_utils.py
@@ -829,6 +829,7 @@ class UserStarFinder(findstars.StarFinderBase):
 #
 # -----------------------------------------------------------------------------
 def find_point_sources(drzname, data=None, mask=None,
+                       def_fwhm=2.0,
                        box_size=11, block_size=(1024, 1024),
                        diagnostic_mode=False):
     """ Identify point sources most similar to TinyTim PSFs
@@ -858,6 +859,10 @@ def find_point_sources(drzname, data=None, mask=None,
         If provided, this mask will be used to eliminate regions in the
         input array from being searched for point sources.  Pixels with
         a value of 0 in the mask indicate what pixels should be ignored.
+
+    def_fwhm : `float`, optional
+        Default FWHM to use in case the model PSF can not be accurately
+        measured by `photutils`.
 
     box_size : `int`, optional
         Size of the box used to recognize each point source.
@@ -918,7 +923,10 @@ def find_point_sources(drzname, data=None, mask=None,
                                      pixfrac=0.8,
                                      clean_psfs=clean_psfs)
     drzpsf = fits.getdata(drzpsfname)
-    psf_fwhm = amutils.find_fwhm(drzpsf, 2.0)
+    psf_fwhm = amutils.find_fwhm(drzpsf, def_fwhm)
+    if psf_fwhm < 0 or psf_fwhm > 2.0 * def_fwhm:
+        log.debug("FWHM computed as {}.  Reverting to using default FWHM of {}".format(psf_fwhm, def_fwhm))
+        psf_fwhm = def_fwhm
 
     # deconvolve the image with the PSF
     decdrz = fft_deconv_img(drz, drzpsf,
@@ -935,11 +943,6 @@ def find_point_sources(drzname, data=None, mask=None,
         fits.PrimaryHDU(data=decmask.astype(np.uint16)).writeto(drzname.replace('.fits', '_deconv_mask.fits'),
                                                                 overwrite=True)
     # find sources in deconvolved image
-    """
-    s = sigma_clipped_stats(decdrz, maxiters=1)
-    peaks = find_peaks(decdrz, threshold=s[1] + nsigma * s[2],
-                       mask=invmask, box_size=5)
-    """
     dec_peaks = find_peaks(decdrz, threshold=0.0,
                        mask=invmask, box_size=box_size)
 
@@ -958,7 +961,9 @@ def find_point_sources(drzname, data=None, mask=None,
 
     # Use this new mask to find the actual peaks in the original input
     # but only to integer pixel precision.
-    peaks = find_peaks(drz, threshold=0., box_size=5)
+    peaks = find_peaks(drz, threshold=0., box_size=box_size // 2)
+    if len(peaks) == 0:
+        peaks = None
 
     # Remove PSF used, unless running in diagnostic_mode
     if not diagnostic_mode:


### PR DESCRIPTION
The use of the FWHM determination by the library PSF use for point-catalog generation now includes proper catches for invalid values returned by photutils.  In addition, other error cases where the code did not correctly catch empty lists for point-catalogs based on the library PSF were also addressed by the changes in the PR.  

The additional check for CR map used during alignment also needed to be added for cases where no updates are returned when alignment sources are identified.  Should be tested against dataset j8dnd5.

These changes were tested against datasets ib1319, ibbso1, ia1s70 and jcol11.  