### PR TITLE
Insure HDRNAME is always valid

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -1321,7 +1321,7 @@ def _verify_sci_hdrname(filename):
     for ext in range(1, numext + 1):
         sciext = ('sci', ext)
         scihdr = fhdu[sciext].header
-        if 'hdrname' not in scihdr or scihdr['hdrname'] == '':
+        if 'hdrname' not in scihdr or scihdr['hdrname'].rstrip() == '':
             # We need to create a valid value for the keyword
             # Define new HDRNAME value in case it is needed.
             # Same value for all SCI extensions, so just precompute it and be ready.

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -346,3 +346,24 @@ def make_section_str(str="", width=60, symbol='-'):
     side_dash = symbol * (dash_len // 2)
     section_str = "{}{}{}".format(side_dash, str, side_dash)
     return section_str
+
+
+def _find_open_files():
+    """Useful utility function to identify any open file handles during processing."""
+    import psutil
+
+    cwd = os.getcwd()
+    log.info("Checking for open files in {}".format(cwd))
+
+    open_files = []
+    for proc in psutil.process_iter():
+        try:
+            for pfile, pid in proc.open_files():
+                if os.path.dirname(pfile) == cwd:
+                    open_files.append(pfile)
+        except psutil.AccessDenied:
+            continue
+        except FileNotFoundError:
+            continue
+
+    return open_files


### PR DESCRIPTION
A new function has been added to `hapsequencer` to insure that all SCI extensions of all science images have valid, non-empty HDRNAME keyword values.  Invalid values can cause problems with using the headerlet functions in STWCS.  

A couple of small Flake8 fixes were also added.