### PR TITLE
Ensure the PHOT keywords can be found in the SVM product header

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -472,7 +472,6 @@ class CatalogImage:
         keyword_dict["aperture_dec"] = self.imghdu[1].header["DEC_APER"]
         keyword_dict["photflam"] = proc_utils.find_flt_keyword(self.imghdu, "PHOTFLAM")
         keyword_dict["photplam"] = proc_utils.find_flt_keyword(self.imghdu, "PHOTPLAM")
-        keyword_dict["photplam"] = proc_utils.find_flt_keyword(self.imghdu, "BLEE")
 
         return keyword_dict
 

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -25,6 +25,7 @@ from stwcs.wcsutil import HSTWCS
 from . import astrometric_utils
 from . import photometry_tools
 from . import deconvolve_utils as decutils
+from . import processing_utils as proc_utils
 
 try:
     from matplotlib import pyplot as plt
@@ -469,10 +470,11 @@ class CatalogImage:
         keyword_dict["orientation"] = self.imghdu[1].header["ORIENTAT"]
         keyword_dict["aperture_ra"] = self.imghdu[1].header["RA_APER"]
         keyword_dict["aperture_dec"] = self.imghdu[1].header["DEC_APER"]
-        keyword_dict["photflam"] = self.imghdu[1].header["PHOTFLAM"]
-        keyword_dict["photplam"] = self.imghdu[1].header["PHOTPLAM"]
+        keyword_dict["photflam"] = proc_utils.find_flt_keyword(self.imghdu, "PHOTFLAM")
+        keyword_dict["photplam"] = proc_utils.find_flt_keyword(self.imghdu, "PHOTPLAM")
 
         return keyword_dict
+
 
     def _get_max_key_value(self, header, root_of_keyword):
         """Read FITS keywords with the same prefix from primary header and return the maximum value

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -472,6 +472,7 @@ class CatalogImage:
         keyword_dict["aperture_dec"] = self.imghdu[1].header["DEC_APER"]
         keyword_dict["photflam"] = proc_utils.find_flt_keyword(self.imghdu, "PHOTFLAM")
         keyword_dict["photplam"] = proc_utils.find_flt_keyword(self.imghdu, "PHOTPLAM")
+        keyword_dict["photplam"] = proc_utils.find_flt_keyword(self.imghdu, "BLEE")
 
         return keyword_dict
 

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -346,3 +346,54 @@ def make_section_str(str="", width=60, symbol='-'):
     side_dash = symbol * (dash_len // 2)
     section_str = "{}{}{}".format(side_dash, str, side_dash)
     return section_str
+
+def find_flt_keyword (hdu, keyword, extname="SCI", extver=1):
+    """Look for the FITS keyword in the Primary and specified extension header
+
+    This routine deliberately does not use astropy.io.fits getval() as it
+    should not be used in application code due to its self-documented inefficiency.
+
+    Parameters
+    ----------
+    hdu : HDUList
+    List of Header Data Unit objects
+
+    keyword : str
+    Keyword of interest
+
+    extname : str
+    Named extension to check in case the keyword is not found in the Primary
+    e.g., (extname, extver) ("SCI", 2)
+
+    extver : int
+    Specified extver of an extname to check in case the keyword is not found in the Primary
+    e.g., (extname, extver) ("SCI", 2)
+
+    Returns
+    -------
+    value : float
+    """
+
+    # Look for the keyword in the Primary header
+    try:
+        value = hdu[0].header[keyword]
+        log.info("Read keyword {} from the Primary header.".format(keyword))
+    # Oops.  Look for the keyword in the extension
+    except KeyError:
+        try:
+            sciext = (extname, extver)
+            value = hdu[sciext].header[keyword]
+            log.info("Read keyword from the {} header.".format(sciext))
+        except KeyError as err:
+            log.error("Keyword {} does not exist in the Primary or {} extension.".format(keyword, sciext))
+            raise err
+
+    # Now ensure the returned variable is of the proper type
+    try:
+        value = float(value)
+        log.info("Keyword {}: {}.".format(keyword, value))
+    except (ValueError, TypeError) as err:
+            log.error("The value of keyword, {}, cannot be cast as a floating point value.".format(keyword))
+            raise err
+
+    return value

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -352,6 +352,9 @@ def find_flt_keyword (hdu, keyword, extname="SCI", extver=1):
 
     This routine deliberately does not use astropy.io.fits getval() as it
     should not be used in application code due to its self-documented inefficiency.
+    This routine is only a STOPGAP to be used as a backstop to handle the
+    issue when refine_product_headers() does not successfully update the drizzle
+    product headers.
 
     Parameters
     ----------
@@ -386,7 +389,7 @@ def find_flt_keyword (hdu, keyword, extname="SCI", extver=1):
             log.info("Read keyword from the {} header.".format(sciext))
         except KeyError as err:
             log.error("Keyword {} does not exist in the Primary or {} extension.".format(keyword, sciext))
-            raise err
+            raise
 
     # Now ensure the returned variable is of the proper type
     try:
@@ -394,6 +397,6 @@ def find_flt_keyword (hdu, keyword, extname="SCI", extver=1):
         log.info("Keyword {}: {}.".format(keyword, value))
     except (ValueError, TypeError) as err:
             log.error("The value of keyword, {}, cannot be cast as a floating point value.".format(keyword))
-            raise err
+            raise
 
     return value


### PR DESCRIPTION
When the update to the drizzle products for CAOM compatibility fails, the FITS headers of the files may not be modified to contain all the proper information in the proper header for successful processing.  In particular the PHOT keywords for the WFC3/IR are found in the Primary and must be copied to the SCI extensions which is where these keywords are found for all of the other instruments.  

Added a stopgap routine which will search the Primary header, as well as one other specified header (extname, extver) to search for a floating-point keyword.  This is only a stopgap as generic template should be created to handle multiple datatypes.