### PR TITLE
Correct computation of CR threshold factor

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -352,7 +352,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
             # rate of cosmic-ray contamination for the total detection product
             reject_catalogs = total_product_catalogs.verify_crthresh(n1_exposure_time)
 
-            if not reject_catalogs or diagnostic_mode:
+            if not reject_catalogs:
                 for filter_product_obj in total_product_obj.fdp_list:
                     filter_product_catalogs = filter_catalogs[filter_product_obj.drizzle_filename]
 


### PR DESCRIPTION
Computation of the CR threshold used to decide whether the catalogs are valid based on expected numbers of cosmic-rays turned out to have been provided the incorrect exposure time of N=1 exposures.  These changes correct the logic for computing the correct exposure time to be used in the threshold.  