### PR TITLE
Fix svm qa logic

### DIFF
--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1175,6 +1175,10 @@ def compare_photometry(drizzle_list, json_timestamp=None, json_time_since_epoch=
     # The "product" in this context is a filter name.
     # The filename is all lower-case by design.
     for drizzle_file in drizzle_list:
+        if not os.path.exists(drizzle_file):
+            log.warning("[compare_photometry] Input {} not found. Skipping comparison.".format(drizzle_file))
+            continue
+
         tokens = drizzle_file.split('_')
         detector = tokens[4]
         filter_name = tokens[5]

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1177,7 +1177,7 @@ def compare_photometry(drizzle_list, json_timestamp=None, json_time_since_epoch=
     for drizzle_file in drizzle_list:
         if not os.path.exists(drizzle_file):
             log.warning("[compare_photometry] Input {} not found. Skipping comparison.".format(drizzle_file))
-            continue
+            return  # So calling routine can continue to next test
 
         tokens = drizzle_file.split('_')
         detector = tokens[4]
@@ -1210,7 +1210,7 @@ def compare_photometry(drizzle_list, json_timestamp=None, json_time_since_epoch=
                             "for comparison.".format(catalog))
                 log.warning("Program skipping comparison of catalogs associated "
                             "with {}.\n".format(drizzle_file))
-                continue
+                return  # So calling routine can continue to next test
 
         # If the catalogs were actually produced, then get the data.
         tab_point_measurements = ascii.read(cat_names[0])


### PR DESCRIPTION
The dataset `ibtq25` results in some products not being generated during processing, and the SVM QA checks did not recognize the missing products when they tried to run.  These changes add logic to guard against missing inputs for the comparisons, and was tested on `ibtq25`.
