### PR TITLE
Make corner detection more robust

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -388,7 +388,9 @@ class SkyFootprint(object):
 
             # Use Harris corner detection to identify corners in the
             # total footprint
-            mask_corners = corner_peaks(corner_harris(self.footprint),
+            # insure footprint has enough signal to deterct corners
+            fp = self.footprint.astype(np.int32) * (10000./self.footprint.max())
+            mask_corners = corner_peaks(corner_harris(fp),
                                    min_distance=1,
                                    threshold_rel=0.5)
             xy_corners = mask_corners * 0.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         'astroquery>=0.4',
         'bokeh',
         'pandas',
-        'photutils>=0.7',
+        'photutils<1.1.0',
         'lxml',
         'PyPDF2',
         'tables',


### PR DESCRIPTION
These changes update how corners are detected for the footprints of datasets when defining the S_REGION keyword value.  It turned out that for some datasets where only 1 image contributed to the footprint, that the corners could not be identified by the 'corner_harris' algorithm due to (basically) too low S/N.  This simple change insures that the maximum S/N is roughly 100.  This was tested on datasets `ibeveo` to show that it correctly identified all the corners for all the products, despite the some of the IR footprints only having 1 exposure. 

Addresses HLA-514.