### PR TITLE
Fix all photutils imports

### DIFF
--- a/drizzlepac/devutils/sourcelist_generation.py
+++ b/drizzlepac/devutils/sourcelist_generation.py
@@ -9,7 +9,8 @@ import sys
 from astropy.io import fits
 from astropy.stats import mad_std
 import numpy as np
-from photutils import aperture_photometry, CircularAperture, DAOStarFinder
+from photutils.aperture import aperture_photometry, CircularAperture
+from photutils.detection import DAOStarFinder
 from stsci.tools import logutil
 
 from drizzlepac import util
@@ -34,7 +35,7 @@ def create_dao_like_coordlists(fitsfile,sourcelist_filename,make_region_file=Fal
         Name of optionally generated ds9-compatible region file
 
     dao_fwhm : float
-        (photutils.DAOstarfinder param 'fwhm') The full-width half-maximum (FWHM) of the major axis of the
+        (`~photutils.detection.DAOstarfinder` param 'fwhm') The full-width half-maximum (FWHM) of the major axis of the
         Gaussian kernel in units of pixels. Default value = 3.5.
 
     make_region_file : Boolean

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -16,7 +16,7 @@ from astropy.nddata.bitmask import bitfield_to_boolean_mask
 from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 
-import photutils
+from photutils import background
 from photutils.background import Background2D
 from photutils.utils import NoDetectionsWarning
 
@@ -1190,6 +1190,5 @@ def update_headerlet_phdu(tweakwcs_item, headerlet):
 def register_photutils_function(name):
     """Convert photutils name as a string into a pointer to the actual photutils function"""
 
-    if name in dir(photutils):
-        func = eval("photutils.{}".format(name))
+    func = getattr(background, name)  # raises AttributeError if not found
     return func

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -17,7 +17,7 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 
 import photutils
-from photutils import Background2D
+from photutils.background import Background2D
 from photutils.utils import NoDetectionsWarning
 
 from stwcs.wcsutil import HSTWCS

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -18,6 +18,7 @@ from astropy import units as u
 
 import photutils
 from photutils import Background2D
+from photutils.utils import NoDetectionsWarning
 
 from stwcs.wcsutil import HSTWCS
 from stwcs.wcsutil import headerlet
@@ -44,9 +45,6 @@ SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
 
-NoDetectionsWarning = photutils.findstars.NoDetectionsWarning if \
-                        hasattr(photutils.findstars, 'NoDetectionsWarning') else \
-                        photutils.utils.NoDetectionsWarning
 
 class AlignmentTable:
     """ This class handles alignment operations for HST data.

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -14,11 +14,14 @@ from astropy.coordinates import SkyCoord
 import numpy as np
 from scipy import ndimage, stats
 
-from photutils import CircularAperture, CircularAnnulus, DAOStarFinder, IRAFStarFinder
-from photutils import Background2D, SExtractorBackground, StdBackgroundRMS
-from photutils import detect_sources, source_properties, deblend_sources
-from photutils import make_source_mask
+from photutils.aperture import CircularAperture, CircularAnnulus
+from photutils.background import (Background2D, SExtractorBackground,
+                                  StdBackgroundRMS)
+from photutils.detection import DAOStarFinder, IRAFStarFinder
+from photutils.segmentation import (detect_sources, source_properties,
+                                    deblend_sources, make_source_mask)
 from photutils.utils import calc_total_error
+
 from stsci.tools import logutil
 from stwcs.wcsutil import HSTWCS
 
@@ -1638,7 +1641,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
            Returns
            -------
-           segm_img : photutils.SegmentationImage or None
+           segm_img : `~photutils.segmentation.SegmentationImage` or None
 
         """
 
@@ -1674,7 +1677,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
            Parameters
            ----------
-           segm_img : photutils.SegmentationImage
+           segm_img : `~photutils.segmentation.SegmentationImage`
                Segmentation image created by detect_segments() based on the total detection image
 
            imgarr :
@@ -1693,7 +1696,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
            Updates
            -------
-           segm_img : photutils.SegmentationImage
+           segm_img : `~photutils.segmentation.SegmentationImage`
                Deblended segmentation image
         """
 
@@ -2245,7 +2248,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
         Regardless of the setting for reject_catalogs, the regions file will be written
         solely based upon the setting of diagnostic_mode.
-        
+
         Parameters
         ----------
         reject_catalogs : bool

--- a/drizzlepac/haputils/deconvolve_utils.py
+++ b/drizzlepac/haputils/deconvolve_utils.py
@@ -5,14 +5,22 @@ import os
 import sys
 import shutil
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 
 import skimage
 from astropy.io import fits as fits
-from photutils.detection import (StarFinderBase, find_peaks,
-                                 _DAOFindProperties, _StarCutout,
-                                 _StarFinderKernel, _find_stars)
+
+import photutils
+if LooseVersion(photutils.__version__) < '1.1.0':
+    from photutils.detection.findstars import (_DAOFindProperties, _StarCutout,
+                                               _StarFinderKernel, _find_stars)
+else:
+    from photutils.detection._utils import (_StarCutout, _StarFinderKernel,
+                                            _find_stars)
+    from photutils.detection.daofinder import _DAOFindProperties
+from photutils.detection import StarFinderBase, find_peaks
 from photutils.utils import NoDetectionsWarning
 
 from stsci.tools import fileutil as fu

--- a/drizzlepac/haputils/photometry_tools.py
+++ b/drizzlepac/haputils/photometry_tools.py
@@ -61,7 +61,7 @@ Classes and Functions
 import numpy as np
 from astropy.table import Table
 from drizzlepac.haputils.background_median import aperture_stats_tbl
-from photutils import aperture_photometry
+from photutils.aperture import aperture_photometry
 
 
 def iraf_style_photometry(phot_apertures, bg_apertures, data, photflam, photplam, error_array=None,

--- a/drizzlepac/haputils/se_source_generation.py
+++ b/drizzlepac/haputils/se_source_generation.py
@@ -28,9 +28,6 @@ from astropy.io import fits as fits
 from astropy.table import Column, Table
 from astropy.convolution import Gaussian2DKernel, MexicanHat2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
-# import photutils
-# from photutils import detect_sources, source_properties, deblend_sources
-# from photutils import Background2D, MedianBackground, SExtractorBackground, StdBackgroundRMS
 from stwcs.wcsutil import HSTWCS
 from stsci.tools import logutil
 

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -49,7 +49,7 @@ from bokeh.models import ColumnDataSource, Label
 from bokeh.models.tools import HoverTool
 from itertools import chain
 import numpy as np
-from photutils import DAOStarFinder
+from photutils.detection import DAOStarFinder
 from scipy import ndimage
 from scipy.spatial import KDTree
 


### PR DESCRIPTION
I expanded this PR beyond fixing only the `NoDetectionsWarning` import to all `photutils` imports and references in docstrings.  These changes work for all drizzlepac-supported versions (>=0.7) of `photutils`.  I will put in a separate PR of updates specifically for `photutils 1.1.0` enhancements.

I noticed that several private functions from the `photutils.detection` subpackage are being imported here. The private functions are not intended to be used outside of `photutils` and of course are subject to change (e.g., API changes) or removed completely due to refactoring.  I don't plan to change those functions in the near-term, but I do want to refactor `photutils.detection` at some point.  If API stability is critical, then you may want to package those current functions with `drizzlepac`.