### PR TITLE
Insure IDCSCALE always exists

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1211,9 +1211,9 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
                                 cd21 = fhdu[('sci', sciext + 1)].header['CD2_1']
                                 fhdu_idscale = round(np.sqrt(np.power(cd11, 2) + np.power(cd21, 2)) * 3600., 3)
                             # Set the value of the IDCSCALE keyword
-                            for sciext in range(num_sci):
-                                msg +=  'Adding IDCSCALE {} to {}[sci,{}]'.format(fhdu_idscale, fhdu.filename(), sciext + 1)
-                                fhdu[('sci', sciext + 1)].header['idcscale'] = fhdu_idscale
+                            for extn in range(num_sci):
+                                msg +=  'Adding IDCSCALE {} to {}[sci,{}]'.format(fhdu_idscale, fhdu.filename(), extn + 1)
+                                fhdu[('sci', extn + 1)].header['idcscale'] = fhdu_idscale
     return msg
 
 def restore_pipeline_default(files):

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1193,7 +1193,26 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
                                                          force=True,
                                                          hdrname=most_recent_wcs[1],
                                                          archive=False)
-
+                        # insure IDCSCALE is still present
+                        if 'idcscale' not in fhdu[('sci', 1)].header:
+                            # get IDCTAB name
+                            itabroot = fhdu[0].header['idctab'].split('$')[1].split('_')[0]
+                            fhdu_idscale = None
+                            # pull a value from one of the other headerlet extensions
+                            for extn in extvers:
+                                if itabroot in fhdu[('HDRLET', extn)].header['wcsname']:
+                                    _hdrlet = fhdu[('HDRLET', extn)].headerlet
+                                    if 'idcscale' in _hdrlet[('SIPWCS', 1)].header:
+                                        fhdu_idscale = _hdrlet[('SIPWCS', 1)].header['idcscale']
+                                        break
+                            if fhdu_idscale is None:
+                                cd11 = fhdu[('sci', sciext + 1)].header['CD1_1']
+                                cd21 = fhdu[('sci', sciext + 1)].header['CD2_1']
+                                fhdu_idscale = round(np.sqrt(np.power(cd11, 2) + np.power(cd21, 2)) * 3600., 3)
+                            # Set the value of the IDCSCALE keyword
+                            for sciext in range(num_sci):
+                                print('Adding IDCSCALE {} to {}'.format(fhdu_idscale, fhdu.filename()))
+                                fhdu[('sci', sciext + 1)].header['idcscale'] = fhdu_idscale
     return msg
 
 def restore_pipeline_default(files):

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1195,6 +1195,7 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
                                                          archive=False)
                         # insure IDCSCALE is still present
                         if 'idcscale' not in fhdu[('sci', 1)].header:
+                            msg += "Headerlet {} was missing IDCSCALE keyword".format(most_recent_wcs[1])
                             # get IDCTAB name
                             itabroot = fhdu[0].header['idctab'].split('$')[1].split('_')[0]
                             fhdu_idscale = None
@@ -1211,7 +1212,7 @@ def verify_gaia_wcsnames(filenames, catalog_name='GSC240', catalog_date=gsc240_d
                                 fhdu_idscale = round(np.sqrt(np.power(cd11, 2) + np.power(cd21, 2)) * 3600., 3)
                             # Set the value of the IDCSCALE keyword
                             for sciext in range(num_sci):
-                                print('Adding IDCSCALE {} to {}'.format(fhdu_idscale, fhdu.filename()))
+                                msg +=  'Adding IDCSCALE {} to {}[sci,{}]'.format(fhdu_idscale, fhdu.filename(), sciext + 1)
                                 fhdu[('sci', sciext + 1)].header['idcscale'] = fhdu_idscale
     return msg
 


### PR DESCRIPTION
Some headerlets from the astrometry database are not entirely complete, lacking at least the IDCSCALE keyword.  These changes look for that keyword when applying an `a priori` WCS solution from the database, and when it is missing, it gets added to the SCI header.  

Association j900a5010 headerlet with hdrname = 'j900a5agq_flt_IDC_0461802ej' does not contain the 'IDCSCALE' keyword and triggered an Exception during standard processing.  This PR resolves the problems and allows this dataset, jdgq05020, and others like it to process successfully. 