### PR TITLE
Iterate over SkyMatch options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,12 +10,17 @@ The version of DrizzlePac can be identified using ::
 >>> import drizzlepac
 >>> drizzlepac.__version__
 
+
 The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
 3.2.1 (unreleased)
 ==================
+
+- Sky Subtraction step will automatically downgrade from 'match' to 'localmin',
+  and from 'globalmin+match' to 'globalmin' when sky matching runs into an
+  Exception. [# 1007]
 
 - Changed to insure that EXTNAME and EXTVER are always removed from
   simple FITS drizzle product headers. [#954]

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -349,11 +349,15 @@ def _skymatch(imageList, paramDict, in_memory, clean, logfile):
                  flog        = MultiFileLog(console = True, enableBold = False),
                  _taskname4history = 'AstroDrizzle')
     except AssertionError:
-        if paramDict['skymethod'] != 'localmin':
+        if 'match' in paramDict['skymethod']:  # This catches 'match' and 'globalmin+match'
+            if 'globalmin' in paramDict['skymethod']:
+                new_method = 'globalmin'
+            else:
+                new_method = 'localmin'
             # revert to simpler sky computation algorithm
             log.warning('Reverting sky computation to "localmin" from "{}'.format(paramDict['skymethod']))
             skymatch(new_fi,
-                     skymethod='localmin',
+                     skymethod=new_method,
                      skystat=paramDict['skystat'],
                      lower=paramDict['skylower'],
                      upper=paramDict['skyupper'],

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -212,7 +212,7 @@ def _skymatch(imageList, paramDict, in_memory, clean, logfile):
 
     nimg = len(imageList)
     if nimg == 0:
-        log.info("Skymatch needs at least one images to perform{0} \
+        log.info("Skymatch needs at least one image to perform{0} \
                     sky matching. Nothing to be done.",os.linesep)
         return
 

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -212,8 +212,8 @@ def _skymatch(imageList, paramDict, in_memory, clean, logfile):
 
     nimg = len(imageList)
     if nimg == 0:
-        ml.logentry("Skymatch needs at least one images to perform{0}" \
-                    "sky matching. Nothing to be done.",os.linesep)
+        log.info("Skymatch needs at least one images to perform{0} \
+                    sky matching. Nothing to be done.",os.linesep)
         return
 
     # create a list of input file names as provided by the user:
@@ -823,7 +823,7 @@ def getreferencesky(image,keyval):
     _refplatescale=image.header["REFPLTSCL"]
     _platescale=image.header["PLATESCL"]
 
-    return (_subtractedsky * (_refplatescale / _platescale)**2 )
+    return (_subtractedSky * (_refplatescale / _platescale)**2 )
 
 
 def help(file=None):

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -350,10 +350,8 @@ def _skymatch(imageList, paramDict, in_memory, clean, logfile):
                  _taskname4history = 'AstroDrizzle')
     except AssertionError:
         if 'match' in paramDict['skymethod']:  # This catches 'match' and 'globalmin+match'
-            if 'globalmin' in paramDict['skymethod']:
-                new_method = 'globalmin'
-            else:
-                new_method = 'localmin'
+            new_method = 'globalmin' if 'globalmin' in paramDict['skymethod'] else 'localmin'
+
             # revert to simpler sky computation algorithm
             log.warning('Reverting sky computation to "localmin" from "{}'.format(paramDict['skymethod']))
             skymatch(new_fi,

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -327,26 +327,52 @@ def _skymatch(imageList, paramDict, in_memory, clean, logfile):
 
         new_fi.append(fi)
 
-    # Run skymatch algorithm:
-    skymatch(new_fi,
-             skymethod   = paramDict['skymethod'],
-             skystat     = paramDict['skystat'],
-             lower       = paramDict['skylower'],
-             upper       = paramDict['skyupper'],
-             nclip       = paramDict['skyclip'],
-             lsigma      = paramDict['skylsigma'],
-             usigma      = paramDict['skyusigma'],
-             binwidth    = paramDict['skywidth'],
-             skyuser_kwd = skyKW,
-             units_kwd   = 'BUNIT',
-             readonly    = not paramDict['skysub'],
-             dq_bits     = None,
-             optimize    = 'inmemory' if in_memory else 'balanced',
-             clobber     = True,
-             clean       = clean,
-             verbose     = True,
-             flog        = MultiFileLog(console = True, enableBold = False),
-             _taskname4history = 'AstroDrizzle')
+    try:
+        # Run skymatch algorithm:
+        skymatch(new_fi,
+                 skymethod   = paramDict['skymethod'],
+                 skystat     = paramDict['skystat'],
+                 lower       = paramDict['skylower'],
+                 upper       = paramDict['skyupper'],
+                 nclip       = paramDict['skyclip'],
+                 lsigma      = paramDict['skylsigma'],
+                 usigma      = paramDict['skyusigma'],
+                 binwidth    = paramDict['skywidth'],
+                 skyuser_kwd = skyKW,
+                 units_kwd   = 'BUNIT',
+                 readonly    = not paramDict['skysub'],
+                 dq_bits     = None,
+                 optimize    = 'inmemory' if in_memory else 'balanced',
+                 clobber     = True,
+                 clean       = clean,
+                 verbose     = True,
+                 flog        = MultiFileLog(console = True, enableBold = False),
+                 _taskname4history = 'AstroDrizzle')
+    except AssertionError:
+        if paramDict['skymethod'] != 'localmin':
+            # revert to simpler sky computation algorithm
+            log.warning('Reverting sky computation to "localmin" from "{}'.format(paramDict['skymethod']))
+            skymatch(new_fi,
+                     skymethod='localmin',
+                     skystat=paramDict['skystat'],
+                     lower=paramDict['skylower'],
+                     upper=paramDict['skyupper'],
+                     nclip=paramDict['skyclip'],
+                     lsigma=paramDict['skylsigma'],
+                     usigma=paramDict['skyusigma'],
+                     binwidth=paramDict['skywidth'],
+                     skyuser_kwd=skyKW,
+                     units_kwd='BUNIT',
+                     readonly=not paramDict['skysub'],
+                     dq_bits=None,
+                     optimize='inmemory' if in_memory else 'balanced',
+                     clobber=True,
+                     clean=clean,
+                     verbose=True,
+                     flog=MultiFileLog(console=True, enableBold=False),
+                     _taskname4history='AstroDrizzle')
+        else:
+            raise
 
     # Populate 'subtractedSky' and 'computedSky' of input image objects:
     for i in range(nimg):


### PR DESCRIPTION
Some datasets triggered Exceptions during sky subtraction when using the 'match' option due to exactly overlapping input images and problems with the spherical geometry package.  This simple update adds a check for problems with the sky computation and if an AssertionError is raised (as happens when the spherical geometry error is triggered), it will simply try again with a simpler SkyMatch option that does not rely on spherical geometry to work.  

A verifiable test case still needs to be identified for testing of this change before it can be merged. 