### PR TITLE
Replaced deprecated STWCS calls

### DIFF
--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1441,7 +1441,7 @@ def report_wcs(total_product_list, json_timestamp=None, json_time_since_epoch=No
                 # Activate an alternate WCS in order to gather its information.
                 # First copy the original primary WCS to an alternate (in case there was
                 # not already a duplicate). Use key 'Z'.  *** FIX MDD Should check for Z in use.
-                wcsutil.altwcs.archiveWCS(edp_object.full_filename, ext=extname_list, wcskey='Z')
+                wcsutil.altwcs.archive_wcs(edp_object.full_filename, ext=extname_list, wcskey='Z')
 
                 icnt = 0
                 # Restore an alternate to be the primary WCS
@@ -1532,7 +1532,7 @@ def report_wcs(total_product_list, json_timestamp=None, json_time_since_epoch=No
                         wcsutil.altwcs.deleteWCS(edp_object.full_filename, ext=extname_list, wcskey=alt_key)
 
                         # ... and archive the current primary with its original key
-                        wcsutil.altwcs.archiveWCS(edp_object.full_filename, ext=extname_list, wcskey=alt_key)
+                        wcsutil.altwcs.archive_wcs(edp_object.full_filename, ext=extname_list, wcskey=alt_key)
 
                         icnt += 1
 


### PR DESCRIPTION
This PR replaces all instances of the deprecated function 'stwcs.altwcs.archiveWCS' with the new version 'stwcs.altwcs.archive_wcs'.  The change corrects a problem with WCSNAMEs being set to blank when running 'svm_quality_analysis.report_wcs' leading to direct images in Grism/Prism datasets to having no WCSNAME.  

The original problem was reproduced using dataset 'ib3a03', which was then used to verify that this change corrected the problem.   