### PR TITLE
Fix support of astrometric catalog names

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -359,7 +359,8 @@ class FilterProduct(HAPProduct):
                     ref_catalog = amutils.create_astrometric_catalog(align_table.process_list,
                                                                      catalog=catalog_item,
                                                                      output=self.refname,
-                                                                     full_catalog=True)
+                                                                     full_catalog=True,
+                                                                     log_level=self.log_level)
                     if ref_catalog.meta['converted'] and ref_catalog['RA_error'][0] != np.nan:
                         ref_weight = 1. / np.sqrt(ref_catalog['RA_error'] ** 2 + ref_catalog['DEC_error'] ** 2)
                         ref_weight = np.nan_to_num(ref_weight, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
@@ -917,7 +918,8 @@ class SkyCellProduct(HAPProduct):
                 ref_catalog = amutils.create_astrometric_catalog(align_table.process_list,
                                                                  catalog=catalog_name,
                                                                  output=self.refname,
-                                                                 gaia_only=False)
+                                                                 gaia_only=False,
+                                                                 log_level=self.log_level)
 
                 log.debug("Abbreviated reference catalog displayed below\n{}".format(ref_catalog))
                 align_table.reference_catalogs[self.refname] = ref_catalog


### PR DESCRIPTION
Astrometric catalog names will no longer be treated as case-sensitive with these changes.  This makes it more robust when users specify what they think is the catalog name (GAIAedr3, for example) when the the list of "SUPPORTED_CATALOGS" for translation may have it differently (GAIAeDR3, for example) causing the translation to fail and the rest of the code to throw an Exception and not align to that catalog even though it is the right catalog.  

In addition, logging is cleaned up a bit with logging levels explicitly set when calling some user-callable functions from 'haputils/astrometric_utils'.  This should only result in a little more information being included in the log file, primarily when run in 'debug' mode. Additional changes can be done in separate PRs to insure that those log messages show up when running 'runastrodriz' as well.  

These changes were tested by successfully processing dataset 'ic8o82'.