### PR TITLE
Insure correct versions get reported for WCS

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -1090,7 +1090,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
             before_kw = None
 
         hdulist[0].header.set('UPWCSVER', value=upwcsver,
-                        comment="Version of STWCS used to updated the WCS",
+                        comment="Version of STWCS used to update the WCS",
                         after=after_kw, before=before_kw)
         hdulist[0].header.set('PYWCSVER', value=pywcsver,
                         comment="Version of Astropy used to update the WCS",


### PR DESCRIPTION
 Applying a headerlet from an extension will cause these keywords to be overwritten with the values from the headerlet, which will most likely not be the current versions in use.  These simple changes insure that all a posteriori WCS headerlets created during pipeline processing, along with the FLT/FLC image primary header, get updated with the version of STWCS and Astropy actually used to create the new WCS.  Since this change affects code used by both pipeline processing and SVM/MVM processing, we are insuring all future processing will report the correct versions used to create the WCS in use. 