### PR TITLE
Adjust threshold for point-catalog generation

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -935,6 +935,10 @@ class HAPPointCatalog(HAPCatalogBase):
                     # Perform manual detection of sources using theoretical PSFs
                     # Initial test data: ictj65
                     try:
+                        # Subtract the detection threshold image so that detection is anything > 0
+                        region -= - (reg_rms * self.param_dict['nsigma'])
+                        # insure no negative values for deconvolution
+                        region = np.clip(region, 0., region.max())
                         user_peaks, source_fwhm = decutils.find_point_sources(self.image.imgname,
                                                                  data=region,
                                                                  def_fwhm=source_fwhm,

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -936,7 +936,7 @@ class HAPPointCatalog(HAPCatalogBase):
                     # Initial test data: ictj65
                     try:
                         # Subtract the detection threshold image so that detection is anything > 0
-                        region -= - (reg_rms * self.param_dict['nsigma'])
+                        region -= (reg_rms * self.param_dict['nsigma'])
                         # insure no negative values for deconvolution
                         region = np.clip(region, 0., region.max())
                         user_peaks, source_fwhm = decutils.find_point_sources(self.image.imgname,


### PR DESCRIPTION
The background used for point-source detection based on PSFs has been revised to use the full detection threshold (bkg + nsigma*rms) instead of just the background by itself.  This will resolve the most egregious cases where peaks in the background get picked up as 'real' sources as noted by INS for 'id7h42' and 'ica9t3'.  