### PR TITLE
Add logic to avoid relative fit with singletons

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -154,6 +154,9 @@ class HAPProduct:
 
         # Fitting methods
         mosaic_method_list = alignment_pars['run_align']['mosaic_fit_list']
+        if len(self.edp_list) == 1:
+            # Remove 'match_relative_fit' (first entry) since there is only 1 image to align
+            del mosaic_method_list[0]
         num_method = len(mosaic_method_list)
 
         # Fit geometry methods


### PR DESCRIPTION
This restores the logic to avoid trying to perform a relative fit when there is only 1 exposure to align, as some visits only contain a single exposure (ibe809 and idcm13 for example).  