### PR TITLE
Update default fit pars

### DIFF
--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -15,7 +15,7 @@
       "MIN_OBSERVABLE_THRESHOLD": 10,
       "MAX_FIT_LIMIT": 150,
       "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
-      "mosaic_fit_list": ["match_relative_fit", "match_default_fit"],
+      "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
       "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
     },
   "generate_source_catalogs":
@@ -50,13 +50,13 @@
       "fitgeom": "rscale",
       "searchrad": 250,
       "separation": 0.1,
-      "tolerance": 100,
+      "tolerance": 10,
       "use2dhist": false
     },
   "match_2dhist_fit":
     {
       "fitgeom": "rscale",
-      "searchrad": 75,
+      "searchrad": 100,
       "separation": 0.1,
       "tolerance": 2,
       "use2dhist": true

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -56,8 +56,8 @@
   "match_2dhist_fit":
     {
       "fitgeom": "rscale",
-      "searchrad": 100,
-      "separation": 0.1,
+      "searchrad": 250,
+      "separation": 4.0,
       "tolerance": 2,
       "use2dhist": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -15,7 +15,7 @@
       "MIN_OBSERVABLE_THRESHOLD": 10,
       "MAX_FIT_LIMIT": 150,
       "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
-      "mosaic_fit_list": ["match_relative_fit", "match_default_fit"],
+      "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
       "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
     },
   "generate_source_catalogs":
@@ -50,13 +50,13 @@
       "fitgeom": "rscale",
       "searchrad": 250,
       "separation": 0.1,
-      "tolerance": 100,
+      "tolerance": 10,
       "use2dhist": false
     },
   "match_2dhist_fit":
     {
       "fitgeom": "rscale",
-      "searchrad": 75,
+      "searchrad": 100,
       "separation": 0.1,
       "tolerance": 2,
       "use2dhist": true

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -56,8 +56,8 @@
   "match_2dhist_fit":
     {
       "fitgeom": "rscale",
-      "searchrad": 100,
-      "separation": 0.1,
+      "searchrad": 250,
+      "separation": 4.0,
       "tolerance": 2,
       "use2dhist": true
     },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -56,8 +56,8 @@
     "match_2dhist_fit":
       {
         "fitgeom": "rscale",
-        "searchrad": 100,
-        "separation": 0.1,
+        "searchrad": 400,
+        "separation": 4.0,
         "tolerance": 2,
         "use2dhist": true
       },

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -15,7 +15,7 @@
         "MIN_OBSERVABLE_THRESHOLD": 10,
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
-        "mosaic_fit_list": ["match_relative_fit", "match_default_fit"],
+        "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
         "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
       },
     "generate_source_catalogs":
@@ -50,13 +50,13 @@
         "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
-        "tolerance": 100,
+        "tolerance": 10,
         "use2dhist": false
       },
     "match_2dhist_fit":
       {
         "fitgeom": "rscale",
-        "searchrad": 75,
+        "searchrad": 100,
         "separation": 0.1,
         "tolerance": 2,
         "use2dhist": true

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -56,8 +56,8 @@
     "match_2dhist_fit":
       {
         "fitgeom": "rscale",
-        "searchrad": 100,
-        "separation": 0.1,
+        "searchrad": 250,
+        "separation": 4.0,
         "tolerance": 2,
         "use2dhist": true
       },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -15,7 +15,7 @@
         "MIN_OBSERVABLE_THRESHOLD": 10,
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
-        "mosaic_fit_list": ["match_relative_fit", "match_default_fit"],
+        "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
         "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
       },
     "generate_source_catalogs":
@@ -50,13 +50,13 @@
         "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
-        "tolerance": 100,
+        "tolerance": 10,
         "use2dhist": false
       },
     "match_2dhist_fit":
       {
         "fitgeom": "rscale",
-        "searchrad": 75,
+        "searchrad": 100,
         "separation": 0.1,
         "tolerance": 2,
         "use2dhist": true

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -56,8 +56,8 @@
     "match_2dhist_fit":
       {
         "fitgeom": "rscale",
-        "searchrad": 100,
-        "separation": 0.1,
+        "searchrad": 400,
+        "separation": 4.0,
         "tolerance": 2,
         "use2dhist": true
       },

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -3,7 +3,7 @@
       {
         "MIN_FIT_MATCHES": 6,
         "MAX_FIT_RMS": 10,
-        "MAX_SOURCES_PER_CHIP": 500
+        "MAX_SOURCES_PER_CHIP": 250
       },
     "run_align":
       {
@@ -15,7 +15,7 @@
         "MIN_OBSERVABLE_THRESHOLD": 10,
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
-        "mosaic_fit_list": ["match_relative_fit", "match_default_fit"],
+        "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
         "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
       },
     "generate_source_catalogs":
@@ -50,13 +50,13 @@
         "fitgeom": "rscale",
         "searchrad": 250,
         "separation": 0.1,
-        "tolerance": 100,
+        "tolerance": 10,
         "use2dhist": false
       },
     "match_2dhist_fit":
       {
         "fitgeom": "rscale",
-        "searchrad": 75,
+        "searchrad": 100,
         "separation": 0.1,
         "tolerance": 2,
         "use2dhist": true


### PR DESCRIPTION
These adjustments to the parameters used for alignment allow data which was previously unable to be aligned or aligned correctly to actually get aligned to GAIA.  These changes were demonstrated to work for 'ibe809' which ended up having an offset of (236, -347) pixels or 16.6 arcseconds.  In addition, the 2dhist fitting option was restored for mosaic_fitting use since it relies on a very different algorithm from the default fitting for cross-matching and determination of the offset providing complimentary techniques for trying to align single exposures to GAIA.  In fact, the 2dhist option was the only way to align 'ibe809'.
