### PR TITLE
Update defaults for pipeline catalog use

### DIFF
--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -8,7 +8,7 @@
   "run_align":
     {
       "update_hdr_wcs": true,
-      "catalog_list": ["GAIAedr3", "GAIADR2", "GAIADR1"],
+      "catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
       "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
       "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
       "MIN_CATALOG_THRESHOLD": 3,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -8,7 +8,7 @@
   "run_align":
     {
       "update_hdr_wcs": true,
-      "catalog_list": ["GAIAedr3", "GAIADR2", "GAIADR1"],
+      "catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
       "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
       "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
       "MIN_CATALOG_THRESHOLD": 3,

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -8,7 +8,7 @@
     "run_align":
       {
         "update_hdr_wcs": true,
-        "catalog_list": ["GAIAedr3", "GAIADR2", "GAIADR1"],
+        "catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
         "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
         "MIN_CATALOG_THRESHOLD": 3,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -8,7 +8,7 @@
     "run_align":
       {
         "update_hdr_wcs": true,
-        "catalog_list": ["GAIAedr3", "GAIADR2", "GAIADR1"],
+        "catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
         "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
         "MIN_CATALOG_THRESHOLD": 3,

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -8,7 +8,7 @@
     "run_align":
       {
         "update_hdr_wcs": true,
-        "catalog_list": ["GAIAedr3", "GAIADR2", "GAIADR1"],
+        "catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "fit_algorithm_list_ngt1": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
         "fit_algorithm_list_n1": ["match_2dhist_fit", "match_default_fit"],
         "MIN_CATALOG_THRESHOLD": 3,


### PR DESCRIPTION
After updating the SVM processing with a new set of catalogs, this updates the options for alignment in standard pipeline processing of ASNs and singletons to be consistent.  