### PR TITLE
Skip inconsistent fits during relative alignment

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -743,6 +743,8 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     #       allows all the input images to be aligned in
     #       a relative way using the first input image as the reference.
     # 1: Perform relative alignment
+    # Setting 'minobj' to None allows 'tweakwcs' to use its own built-in
+    # limits.
     match_relcat = tweakwcs.align_wcs(imglist, None,
                                       match=match,
                                       minobj=None,  # common_pars['minobj'][fitgeom],

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -785,7 +785,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
         # 2: Perform absolute alignment
         matched_cat = tweakwcs.align_wcs(imglist, reference_catalog,
                                          match=match,
-                                         minobj=common_pars['MIN_FIT_MATCHES'],
+                                         minobj=common_pars['minobj'][fitgeom],
                                          fitgeom=fitgeom)
     else:
         # Insure the expanded reference catalog has all the information needed
@@ -851,7 +851,7 @@ def match_default_fit(imglist, reference_catalog, **fit_pars):
     # Align images and correct WCS
     matched_cat = tweakwcs.align_wcs(imglist, reference_catalog,
                                      match=match,
-                                     minobj=common_pars['MIN_FIT_MATCHES'],
+                                     minobj=common_pars['minobj'][fitgeom],
                                      expand_refcat=False,
                                      fitgeom=fitgeom)
 
@@ -912,7 +912,7 @@ def match_2dhist_fit(imglist, reference_catalog, **fit_pars):
     # Align images and correct WCS
     matched_cat = tweakwcs.align_wcs(imglist, reference_catalog,
                                      match=match,
-                                     minobj=common_pars['MIN_FIT_MATCHES'],
+                                     minobj=common_pars['minobj'][fitgeom],
                                      expand_refcat=False,
                                      fitgeom=fitgeom)
 

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -747,7 +747,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     # limits.
     match_relcat = tweakwcs.align_wcs(imglist, None,
                                       match=match,
-                                      minobj=None,  # common_pars['minobj'][fitgeom],
+                                      minobj=common_pars['minobj'][fitgeom],
                                       expand_refcat=True,
                                       fitgeom=fitgeom)
     # Implement a consistency check even before trying absolute alignment

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -1853,7 +1853,7 @@ def check_mag_corr(imglist, threshold=0.5):
     for image in imglist:
         input_mags = image.meta['fit_info']['input_mag']
         ref_mags = image.meta['fit_info']['ref_mag']
-        if input_mags is not None and len(input_mags) > 0:
+        if input_mags is not None and len(input_mags) > 1:
             mag_corr, mag_corr_std = pearsonr(input_mags, ref_mags)
             log.info("{} Magnitude correlation: {}".format(image.meta['name'], mag_corr))
             cross_match_check = True if abs(mag_corr) > threshold else False

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -266,6 +266,10 @@ class HAPProduct:
                                 alignment_pars['determine_fit_quality']['min_xmatches'] = \
                                     alignment_pars['run_align']['mosaic_fitgeom_list'][mosaic_fitgeom]
 
+                                # turn off consistency check for SVM and MVM processing since filter-to-filter
+                                # or visit-to-visit offsets could be large relative to measurement RMS.
+                                alignment_pars['determine_fit_quality']['consistency_check'] = False
+
                                 # Evaluate the quality of the fit
                                 is_good_fit, _, _, _, _, _ = align.determine_fit_quality_mvm_interface(align_table.imglist,
                                                                                                        align_table.filtered_table,


### PR DESCRIPTION
These changes identify and flag as 'FAILED' any relative alignment solution (performed using `align_utils\match_relative_fit`) where any member exhibits a wildly different rotation.  This typically results from a nearly singular solution with very few (2 or 3) matches or from incorrect cross-matching. 

By setting the `meta["fit_info"]["status"}` to 'FAILED' for all members in the fit, that fit solution will be thrown out and the rest of the code will try the next possible solution.  This logic has only been added to the relative fit solution, since there is an expectation that any corrections will be relatively small in rotation at least.  

These changes were tested using 'ibvg03' under Windows which only uses float64 as long, instead of float128 used under Linux, resulting in a near singular solution for a couple of the 30 exposures being used to create the mosaic.   

In addition, these changes correctly pass in the 'minobj' values for each 'fitgeom' to 'tweakwcs'.