### PR TITLE
Define bounded WCS for SkyCell footprint

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -210,6 +210,7 @@ class SkyFootprint(object):
         self.meta_wcs = meta_wcs
         # bounded_wcs corresponds to WCS of bounding box of footprint
         self.bounded_wcs = None
+        self.bounding_box = None
 
         # the exp_masks dict records the individual footprints of each exposure
         self.exp_masks = {}
@@ -316,6 +317,7 @@ class SkyFootprint(object):
 
         # make a copy of the full WCS to be revised
         self.bounded_wcs = self.meta_wcs.copy()
+        self.bounding_box = [slice(ymin, ymax), slice(xmin, xmax)]
 
         # Use this box to compute new CRPIX position
         self.bounded_wcs.wcs.crpix -= [xmin, ymin]

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -303,12 +303,12 @@ class SkyFootprint(object):
 
             self.total_mask += self.exp_masks[exposure]['mask']
 
-            # Compute the bounded WCS for this footprint
+            # Compute the bounded WCS for this mask of exposed pixels
             self.find_bounded_wcs()
 
 
     def find_bounded_wcs(self):
-        """Compute the WCS based on the bounding box of footprint """
+        """Compute the WCS based on the bounding box of exposed pixels(mask) """
         if self.total_mask is None:
             print("Please add exposures before computing bounding box WCS...")
 

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -321,7 +321,8 @@ class SkyFootprint(object):
 
         # Use this box to compute new CRPIX position
         self.bounded_wcs.wcs.crpix -= [xmin, ymin]
-        self.bounded_wcs.wcs.naxis = [xmax - xmin + 1, ymax - ymin + 1]
+        self.bounded_wcs.naxis1 = xmax - xmin + 1
+        self.bounded_wcs.naxis2 = ymax - ymin + 1
 
 
     # Methods with 'find' compute values


### PR DESCRIPTION
This PR adds a new attribute to the SkyFootprint class, bounded_wcs, which represents the WCS of just the section of the SkyCell where the footprint has HST data.  This attribute gets automatically computed upon completion of the '.build()' method, although the method could be called again separately if needed. 

In addition, during testing, it was discovered that the similarity computations have been broken for a few months.  This PR includes a fix for this long-standing bug as well so that that similarity check now gets performed as designed.  