### PR TITLE
Minimize memory usage of SkyFootprint

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -874,7 +874,7 @@ class ProjectionCell(object):
         for xi in range(mosaic_xr[0], mosaic_xr[1]):
             for yi in range(mosaic_yr[0], mosaic_yr[1]):
                 skycell = SkyCell(x=xi, y=yi, projection_cell=self)
-                skycell.build_mask()
+                # skycell.build_mask()
 
                 sc_overlap = self.compute_overlap(skycell, mosaic_ra, mosaic_dec)
 

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -357,10 +357,15 @@ class SkyFootprint(object):
                     scaled_blank = blank * scale_val
                     self.scaled_mask[scell_slice] += scaled_blank
 
-            self.total_mask += self.exp_masks[exposure]['mask']
+                self.total_mask[scell_slice] += blank
+                del blank
 
-            # Compute the bounded WCS for this mask of exposed pixels
-            self.find_bounded_wcs()
+            # Only add members which contributed to this footprint
+            if exposure not in self.members:
+                self.members.append(exposure)
+
+        # Compute the bounded WCS for this mask of exposed pixels
+        self.find_bounded_wcs()
 
 
     def find_bounded_wcs(self):


### PR DESCRIPTION
One of the primary limitations for processing MVM datasets has been the memory requirements for the SkyFootprint class.  These changes reduce the memory use for that class to a single np.int16 array for the total_mask and, when requested, a single np.float32 array for the exposure time scaled total_mask.  These arrays are the size of the final output frame, which for MVM processing is the full size of a SkyCell or 21418 x 21418 pixels.  This memory usage does not go up noticeably with the number of input exposures, unlike the original implementation.  

One of the major benefits of this PR is that the **runtime was also dramatically sped up** now taking only about 1second per input image, **about 10X faster**, give or take.

The **'get_sky_cells' function was also fixed** to work correctly with these changes, while also minimizing it's memory usage and while speeding up its operation as well (by orders of magnitude).  

**_In addition,_** a logic problem was fixed in the GridDefs class for defining the ProjectionCell at the south pole.  