### PR TITLE
Initialize the SkyFootprint attribute, self.footprint_member

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -253,6 +253,7 @@ class SkyFootprint(object):
         self.total_mask = np.zeros(meta_wcs.array_shape, dtype=np.int16)
         self.scaled_mask = None
         self.footprint = None
+        self.footprint_member = None
 
         self.edges = None
         self.edges_ra = None


### PR DESCRIPTION
The SkyFootprint class attribute, self.footprint_member, needed to be initialized in the constructor in order to avoid errors being raised elsewhere in the code when checking for its value.  This bug was noticed during testing, and also seen when generating the fix which became PR#1057.    This PR was generated in order to avoid code smuggling.

This fix is short, sweet, and oh so petite.