### PR TITLE
Remove unused variable `var`

### DIFF
--- a/src/arrdrizmodule.c
+++ b/src/arrdrizmodule.c
@@ -787,7 +787,6 @@ arrmoments(PyObject *obj, PyObject *args)
   long x,y;
   double moment = 0.0;
   integer_t i,j;
-  double val;
 
   if (!PyArg_ParseTuple(args,"Oll:arrmoments", &oimg, &p, &q)){
     return PyErr_Format(gl_Error, "cdriz.arrmoments: Invalid Parameters.");


### PR DESCRIPTION
Building a whl for drizzlepac produces the following warning:

> src/arrdrizmodule.c:790:10: warning: unused variable 'val' [-Wunused-variable]
  double val;
         ^
1 warning generated.

This PR removes the spurious variable and quiets the warning.