### PR TITLE
WIP: Address unreasonable deblending times for segments 

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1493,6 +1493,14 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                 self.param_dict['bkg_filter_size'],
                                                 self.param_dict['dao']['TWEAK_FWHMPSF'])
 
+                        # Reset the local version of the Custom/Gaussian kernel and the RickerWavelet
+                        # kernel when the background type changes
+                        g2d_kernel = self.image.kernel
+
+                        rw2d_kernel = RickerWavelet2DKernel(self.image.kernel_fwhm,
+                                                            x_size=self._rw2d_size,
+                                                            y_size=self._rw2d_size)
+                        rw2d_kernel.normalize()
 
                         sigma_for_threshold = self._nsigma
                         rw2d_sigma_for_threshold = self._rw2d_nsigma
@@ -1552,10 +1560,10 @@ class HAPSegmentCatalog(HAPCatalogBase):
                         # The segmentation image is problematic and the big island/source fraction limits are exceeded,
                         # so deblending could take days, and the results would not be viable in any case.
                         else:
-                            log.info("")
-                            log.info("The second round of segmentation images still contain big islands or a\n"
+                            log.warning("")
+                            log.warning("The second round of segmentation images still contain big islands or a\n"
                                      "large source fraction of segments.")
-                            log.info("The segmentation algorithm is unable to continue.")
+                            log.warning("The segmentation algorithm is unable to continue and no segmentation catalog will be produced.")
                             del g_segm_img
                             del rw_segm_img
                             return
@@ -1682,6 +1690,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # a final message and return.
             if segm_img is None:
                 log.warning("End processing for the segmentation catalog due to no sources detected with the current kernel.")
+                log.warning("No segmentation catalog will be produced.")
                 return
 
             # Determine if the segmentation image is filled with big sources/islands (bs) or is crowded with a large

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -395,6 +395,7 @@ class TotalProduct(HAPProduct):
         self.fdp_list = []
         self.regions_dict = {}
         self.grism_edp_list = []
+        self.bkg_used = ""
 
         log.debug("Total detection object {}/{} created.".format(self.instrument, self.detector))
 

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -40,6 +40,7 @@
         "rw2d_biggest_source": 0.045,
         "rw2d_source_fraction": 0.15,
         "biggest_source_deblend_limit": 0.15,
-        "source_fraction_deblend_limit": 0.20
+        "source_fraction_deblend_limit": 0.20,
+        "ratio_bigsource_limit": 2
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -36,8 +36,10 @@
         "contrast": 0.005,
         "border": 10,
         "rw2d_size": 15,
-        "rw2d_nsigma": 1.5,
+        "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.045,
-        "rw2d_source_fraction": 0.15
+        "rw2d_source_fraction": 0.15,
+        "biggest_source_deblend_limit": 0.15,
+        "source_fraction_deblend_limit": 0.20
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -40,6 +40,7 @@
         "rw2d_biggest_source": 0.045,
         "rw2d_source_fraction": 0.15,
         "biggest_source_deblend_limit": 0.15,
-        "source_fraction_deblend_limit": 0.20
+        "source_fraction_deblend_limit": 0.20,
+        "ratio_bigsource_limit": 2
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -36,8 +36,10 @@
         "contrast": 0.005,
         "border": 10,
         "rw2d_size": 15,
-        "rw2d_nsigma": 1.5,
+        "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.045,
-        "rw2d_source_fraction": 0.15
+        "rw2d_source_fraction": 0.15,
+        "biggest_source_deblend_limit": 0.15,
+        "source_fraction_deblend_limit": 0.20
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -17,7 +17,7 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_percent": 20.0,
+    "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
@@ -38,6 +38,8 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.015,
-        "rw2d_source_fraction": 0.075
+        "rw2d_source_fraction": 0.075,
+        "biggest_source_deblend_limit": 0.15,
+        "source_fraction_deblend_limit": 0.20
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -17,7 +17,7 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_percent": 15.0,
+    "negative_percent": 20.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
@@ -36,7 +36,7 @@
         "contrast": 0.005,
         "border": 10,
         "rw2d_size": 15,
-        "rw2d_nsigma": 1.5,
+        "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.015,
         "rw2d_source_fraction": 0.075
     }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -40,6 +40,8 @@
         "rw2d_biggest_source": 0.015,
         "rw2d_source_fraction": 0.075,
         "biggest_source_deblend_limit": 0.15,
-        "source_fraction_deblend_limit": 0.20
+        "source_fraction_deblend_limit": 0.20,
+        "ratio_bigsource_limit": 2
+       
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -40,6 +40,7 @@
         "rw2d_biggest_source": 0.045,
         "rw2d_source_fraction": 0.15,
         "biggest_source_deblend_limit": 0.15,
-        "source_fraction_deblend_limit": 0.20
+        "source_fraction_deblend_limit": 0.20,
+        "ratio_bigsource_limit": 2
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -17,7 +17,7 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_percent": 15.0,
+    "negative_percent": 20.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
@@ -36,7 +36,7 @@
         "contrast": 0.001,
         "border": 10,
         "rw2d_size": 11,
-        "rw2d_nsigma": 1.5,
+        "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.045,
         "rw2d_source_fraction": 0.15
     }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -17,7 +17,7 @@
     "flag_trim_value": 5,
     "simple_bkg": false,
     "zero_percent": 25.0,
-    "negative_percent": 20.0,
+    "negative_percent": 15.0,
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
@@ -38,6 +38,8 @@
         "rw2d_size": 11,
         "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.045,
-        "rw2d_source_fraction": 0.15
+        "rw2d_source_fraction": 0.15,
+        "biggest_source_deblend_limit": 0.15,
+        "source_fraction_deblend_limit": 0.20
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -40,6 +40,7 @@
         "rw2d_biggest_source": 0.015,
         "rw2d_source_fraction": 0.075,
         "biggest_source_deblend_limit": 0.15,
-        "source_fraction_deblend_limit": 0.20
+        "source_fraction_deblend_limit": 0.20,
+        "ratio_bigsource_limit": 2
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -36,7 +36,7 @@
         "contrast": 0.005,
         "border": 10,
         "rw2d_size": 15,
-        "rw2d_nsigma": 1.5,
+        "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.015,
         "rw2d_source_fraction": 0.075
     }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -38,6 +38,8 @@
         "rw2d_size": 15,
         "rw2d_nsigma": 3.0,
         "rw2d_biggest_source": 0.015,
-        "rw2d_source_fraction": 0.075
+        "rw2d_source_fraction": 0.075,
+        "biggest_source_deblend_limit": 0.15,
+        "source_fraction_deblend_limit": 0.20
     }
 }


### PR DESCRIPTION
Restructured code to allow for modest recomputation with regard to identifying
segments with the custom/Gaussian or RickerWavelet kernel.  If the segmentation
image is found to have big islands or a large source fraction after both
kernels have been tried, the algorithm allows for a recomputation of the background
image (sigma-clipped to Background2D) or raising the threshold for detection if the
Background2D is already in use.  Pending: last ditch thresholds on big islands and/or
source fraction which allow segmentation processing to continue as the deblending
should statistically not take days and days (based upon test results).  I still
need to analyze the stats to determine these thresholds.

Reset some configuration variables, keep track of the background determination
type (zero_background, sigma_clipped_background, twod_background), reset class
attribute to a local variable, switch order of catalog computation (segmentation is
now done first), ensure use of the "custom kernel" for the segmentation detection.
Currently an incomplete update of all configuration files.