### PR TITLE
Fix the construction of the manifest filename for MVM processing

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -221,11 +221,11 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
                                                                          layer_method='all')
 
         # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
-        # to use only one of the Total Products to generate the manifest name as the name is not
-        # dependent on the detector.
-        # Example: instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
+        # to use only one of the SkyCellProducts to generate the manifest name as the name
+        # is only dependent on the sky cell.
+        # Example: hst_skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., hst_skycell-p0797x12y05_manifest.txt)
         manifest_name = total_obj_list[0].manifest_name
-        log.info("\nGenerate the manifest name for this multi-visit.")
+        log.info("\nGenerate the manifest name for this multi-visit: {}.".format(manifest_name))
         log.info("The manifest will contain the names of all the output products.")
 
         # The product_list is a list of all the output products which will be put into the manifest file

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -923,7 +923,6 @@ class SkyCellProduct(HAPProduct):
         layer_scale = layer[1]
 
         self.info = '_'.join(['hst', skycell_name, instrument, detector, filter_str, layer_str])
-        self.manifest_info = '_'.join(['hst', skycell_name, instrument, detector, filter_str])
         self.exposure_name = skycell_name
         self.product_basename = self.info
 
@@ -937,11 +936,11 @@ class SkyCellProduct(HAPProduct):
         self.drizzle_filename = '_'.join([self.product_basename, self.filetype]) + ".fits"
         self.refname = self.product_basename + "_ref_cat.ecsv"
 
-        # Generate the name for the manifest file which is for the entire visit.  It is fine
-        # to create it as an attribute of a TotalProduct as it is independent of
-        # the detector in use.
-        # instrument_programID_obsetID_manifest.txt (e.g.,wfc3_b46_06_manifest.txt)
-        self.manifest_name = '_'.join([self.manifest_info, "manifest.txt"])
+        # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
+        # to use only one of the SkyCellProducts to generate the manifest name as the name
+        # is only dependent on the sky cell.
+        # Example: hst_skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., hst_skycell-p0797x12y05_manifest.txt)
+        self.manifest_name = '_'.join(['hst', skycell_name, 'manifest.txt'])
 
         # Define HAPLEVEL value for this product
         self.haplevel = 3


### PR DESCRIPTION
Fixed the construction of the manifest filename for MVM processing.  The manifest name is now of the form hst_skycell-p<PPPP>x<XX>y<YY>_manifest.txt.   The name is solely dependent upon the skycell name which should make it predictable for the operations software.