### PR TITLE
Reset parameters for shift alignment

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -734,7 +734,7 @@ def determine_fit_quality(imglist, filtered_table, catalogs_remaining, align_par
             if catalogs_remaining:
                 log.warning(
                     "Not enough cross matches found between astrometric"
-                    "catalog and sources found in {}".format(image_name))
+                    " catalog and sources found in {}".format(image_name))
                 overall_valid = False
                 continue
 

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -733,6 +733,8 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
     common_pars = fit_pars['pars']
     del fit_pars['pars']
 
+    nclip = None if fitgeom == 'shift' else 3
+
     # 0: Specify matching algorithm to use
     match = tweakwcs.TPMatch(**fit_pars)
     # match = tweakwcs.TPMatch(searchrad=250, separation=0.1,
@@ -749,7 +751,8 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
                                       match=match,
                                       minobj=common_pars['minobj'][fitgeom],
                                       expand_refcat=True,
-                                      fitgeom=fitgeom)
+                                      fitgeom=fitgeom,
+                                      nclip=nclip)
     # Implement a consistency check even before trying absolute alignment
     # If relative alignment in question, no use in aligning to GAIA
     if not check_consistency(imglist):
@@ -786,18 +789,18 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
         matched_cat = tweakwcs.align_wcs(imglist, reference_catalog,
                                          match=match,
                                          minobj=common_pars['minobj'][fitgeom],
-                                         fitgeom=fitgeom)
-    else:
+                                         fitgeom=fitgeom,
+                                         nclip=nclip)
         # Insure the expanded reference catalog has all the information needed
         # to complete processing.
         # TODO: Work out how to get the 'mag' column from input source catalog
         #       into this extended reference catalog...
-        reference_catalog = match_relcat
-        reference_catalog['mag'] = np.array([-999.9] * len(reference_catalog),
-                                            np.float32)
-        reference_catalog.meta['catalog'] = 'relative'
+        # reference_catalog = match_relcat
+        # reference_catalog['mag'] = np.array([-999.9] * len(reference_catalog),
+        #                                    np.float32)
+        # reference_catalog.meta['catalog'] = 'relative'
 
-    # 3: Interpret RMS values from tweakwcs
+        # 3: Interpret RMS values from tweakwcs
     interpret_fit_rms(imglist, reference_catalog)
 
     del match_relcat
@@ -842,6 +845,7 @@ def match_default_fit(imglist, reference_catalog, **fit_pars):
     common_pars = fit_pars['pars']
     del fit_pars['pars']
 
+    nclip = None if fitgeom == 'shift' else 3
 
     log.info("{} (match_default_fit) Cross matching and fitting "
              "{}".format("-" * 20, "-" * 27))
@@ -853,7 +857,8 @@ def match_default_fit(imglist, reference_catalog, **fit_pars):
                                      match=match,
                                      minobj=common_pars['minobj'][fitgeom],
                                      expand_refcat=False,
-                                     fitgeom=fitgeom)
+                                     fitgeom=fitgeom,
+                                     nclip=nclip)
 
     # Interpret RMS values from tweakwcs
     interpret_fit_rms(imglist, reference_catalog)
@@ -904,6 +909,7 @@ def match_2dhist_fit(imglist, reference_catalog, **fit_pars):
     common_pars = fit_pars['pars']
     del fit_pars['pars']
 
+    nclip = None if fitgeom == 'shift' else 3
 
     log.info("{} (match_2dhist_fit) Cross matching and fitting "
              "{}".format("-" * 20, "-" * 28))
@@ -914,7 +920,8 @@ def match_2dhist_fit(imglist, reference_catalog, **fit_pars):
                                      match=match,
                                      minobj=common_pars['minobj'][fitgeom],
                                      expand_refcat=False,
-                                     fitgeom=fitgeom)
+                                     fitgeom=fitgeom,
+                                     nclip=nclip)
 
     # Interpret RMS values from tweakwcs
     interpret_fit_rms(imglist, reference_catalog)

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -16,7 +16,7 @@
       "MAX_FIT_LIMIT": 150,
       "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
       "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-      "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
+      "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
     },
   "generate_source_catalogs":
     {

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -16,7 +16,7 @@
       "MAX_FIT_LIMIT": 150,
       "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
       "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-      "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
+      "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
     },
   "generate_source_catalogs":
     {

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -16,7 +16,7 @@
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-        "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
       },
     "generate_source_catalogs":
       {

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -16,7 +16,7 @@
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-        "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
       },
     "generate_source_catalogs":
       {

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -16,7 +16,7 @@
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-        "mosaic_fitgeom_list": {"shift": 2, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
       },
     "generate_source_catalogs":
       {


### PR DESCRIPTION
These changes allow some single source images to be aligned to GAIA, if the single source cross-matches with GAIA.   The primary revisions are:

- reset minimum number of cross-matches for 'shift' alignment, and ONLY 'shift' alignment, to 1 from 2
- turn off clipping in 'tweakwcs' for 'shift' mode since we are already working with so few sources

These changes allowed the images taken for 'jdzn04' of a photometric calibration source to be aligned to GAIA with 1 cross-match.  This will still not help images where the sources are completely saturated.  