### PR TITLE
Fix MVM poller

### DIFF
--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -283,9 +283,9 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
         obset_table = copy.deepcopy(user_table)
 
     # Add INSTRUMENT column
-    instr = INSTRUMENT_DICT[obset_table['filename'][0][0]]
+    instr = [INSTRUMENT_DICT[fname[0]] for fname in obset_table['filename']]
     # convert input to an Astropy Table for parsing
-    obset_table.add_column(Column([instr] * len(obset_table)), name='instrument')
+    obset_table.add_column(Column(instr, name='instrument'))
 
     # Add Date column
     # Uncomment this if we want to control the observation date in the same way as the exposure times.
@@ -301,7 +301,6 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
     obset_table = sort_poller_table(obset_table)
 
     define_exp_layers(obset_table, method=layer_method, exp_limit=exp_limit)
-
     # parse Table into a tree-like dict
     log.debug("Build the multi-visit layers tree.")
     obset_tree = build_mvm_tree(obset_table)
@@ -471,7 +470,6 @@ def parse_mvm_tree(det_tree, all_mvm_exposures, log_level):
                 #
                 # mvm prod_info = 'skycell_p1234_x01y01 wfc3 uvis f200lp all 2009 1 drz'
                 #
-
                 prod_list = prod_info.split(" ")
                 pscale = 'fine' if prod_list[2].upper() != 'IR' else 'coarse'
                 prod_info += " {:s}".format(pscale)

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -934,10 +934,9 @@ class SkyCellProduct(HAPProduct):
         # e.g.: [f160w, coarse, all, all]
         #
         if layer[1] == 'coarse':
-            layer_vals = [layer[1], layer[2], self.exposure_name]
+            layer_str = '-'.join([layer[1], layer[2]])
         else:
-            layer_vals = ['all', self.exposure_name]
-        layer_str = '-'.join(layer_vals)
+            layer_str = 'all'
 
         layer_scale = layer[1]
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -789,7 +789,16 @@ class SkyCellExposure(HAPProduct):
         super().__init__(prop_id, obset_id, instrument, detector, filename, filetype, log_level)
 
         filter_str = layer[0]
-        layer_str = '-'.join(layer[1:])
+
+        # parse layer information into filename layer_str
+        # layer: [filter_str, pscale_str, exptime_str, epoch_str]
+        # e.g.: [f160w, coarse, all, all]
+        #
+        if layer[1] == 'coarse':
+            layer_vals = [layer[1], layer[2], self.exposure_name]
+        else:
+            layer_vals = ['all', self.exposure_name]
+        layer_str = '-'.join(layer_vals)
 
         cell_id = "p{}{}".format(prop_id, obset_id)
         self.basename = "hst_skycell-" + "_".join(map(str, [cell_id, instrument, detector])) + "_"
@@ -803,7 +812,7 @@ class SkyCellExposure(HAPProduct):
         self.exptime = hdu_list[0].header['EXPTIME']
         hdu_list.close()
 
-        self.product_basename = self.basename + "_".join(map(str, [filter_str, layer_str, self.exposure_name]))
+        self.product_basename = self.basename + "_".join(map(str, [filter_str, layer_str]))
         self.drizzle_filename = self.product_basename + "_" + self.filetype + ".fits"
         self.headerlet_filename = self.product_basename + "_hlet.fits"
         self.trl_logname = self.product_basename + "_trl.log"
@@ -919,7 +928,17 @@ class SkyCellProduct(HAPProduct):
         # May need to exclude 'filter' component from layer_str
         filter_str = layer[0]
         self.filters = filter_str
-        layer_str = '-'.join(layer[1:])
+
+        # parse layer information into filename layer_str
+        # layer: [filter_str, pscale_str, exptime_str, epoch_str]
+        # e.g.: [f160w, coarse, all, all]
+        #
+        if layer[1] == 'coarse':
+            layer_vals = [layer[1], layer[2], self.exposure_name]
+        else:
+            layer_vals = ['all', self.exposure_name]
+        layer_str = '-'.join(layer_vals)
+
         layer_scale = layer[1]
 
         self.info = '_'.join(['hst', skycell_name, instrument, detector, filter_str, layer_str])


### PR DESCRIPTION
The interpretation of the MVM poller file would not work when exposures from multiple instruments were included.  The poller file now correctly associates the right instrument with each exposure when reading the MVM poller file.  In addition, the information from the poller files have been interpreted to generate the latest convention for the MVM exposure files, by eliminating extra 'all' terms and the 'fine' pscale term from the layer string.

These changes were tested using the 24 exposures that overlap hst_skycell_p1637x16y01.  