### PR TITLE
Only apply DRIZPARS when returned by tweakwcs

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -765,7 +765,8 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
 
             # Edit trailer file name since 'runastrodriz' copies what astrodrizzle used
             # to another file...
-            fits.setval(drz_product, 'DRIZPARS', value=trlfile)
+            if os.path.exists(drz_product):
+                fits.setval(drz_product, 'DRIZPARS', value=trlfile)
 
             util.end_logging(drizlog)
 


### PR DESCRIPTION
This corrects the problem with trying to update the DRIZPARS keyword in an empty DRZ file or one for which AstroDrizzle did not create a DRZ product at all.  

The problem was identified with dataset 'ib8c5k'.