### PR TITLE
Fix fitgeom use in log msg

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -971,7 +971,8 @@ def check_consistency(imglist, rot_tolerance=0.1, shift_tolerance=1.0):
             img.meta['fit_info']['process_msg'] = msg
 
         log.info('Relative fit solution is NOT consistent!')
-        log.debug('DELTAS for "{}" fit:'.format(finfo['fitgeom']))
+        fitgeom = finfo['fitgeom'] if 'fitgeom' in finfo else 'Unknown'
+        log.debug('DELTAS for "{}" fit:'.format(fitgeom))
         log.debug('  max rot={:.4f}\n '.format(delta_rots.max()))
         is_consistent = False
 


### PR DESCRIPTION
This fixes the problem where a log message was trying to be written out using a field that 'tweakwcs' did not create for an image (reference image?).  

Found using dataset 'ibcd61'.