### PR TITLE
Fixed bug to access the dataset filenames properly AND remove zero exposure images from processing

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -973,12 +973,16 @@ def update_wcs_in_visit(tdp):
             break
 
     if not grism_wcsname:
+        log.error("")
         log.error("None of the preferred WCS names are present in the common set of WCS names for the Grism/Prism images.")
-        log.error("    There is a problem with this visit.  Deleting all SVM Grism/Prism FLT/FLC files.")
+        log.error("There is a problem with this visit.  Deleting all SVM Grism/Prism FLT/FLC files.")
+        log.error("")
         try:
-            for image_file in tdp.grism_edp_list.full_filename:
-                os.remove(image_file)
-                log.warning("Deleted Grism/Prism image {}.".format(image_file))
+            for image_file in tdp.grism_edp_list:
+               os.remove(image_file.full_filename)
+               log.warning("Deleted Grism/Prism image {}.".format(image_file.full_filename))
+            tdp.grims_edp_list = []
+            return grism_product_list
         except OSError:
             pass
         sys.exit(1)

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -981,7 +981,7 @@ def update_wcs_in_visit(tdp):
             for image_file in tdp.grism_edp_list:
                os.remove(image_file.full_filename)
                log.warning("Deleted Grism/Prism image {}.".format(image_file.full_filename))
-            tdp.grims_edp_list = []
+            tdp.grism_edp_list = []
             return grism_product_list
         except OSError:
             pass


### PR DESCRIPTION
Fixed the bug to access the dataset filenames properly if all Grism/Prism
datasets need to be deleted from the processing.  Also, fixed an unreported
algorithmic bug causing the ibbr01 to not produce output.  Two of the
Grism/Prism data files actually had an exposure time of zero.  The
Grism/Prism data is minimally processed in order to have the same
WCS as the corresponding direct images. STWCS found the images had
zero exposure time, so the images had only an OPUS WCS. This
caused the processing to fail as there was no preferred 'a priori'
WCS available for all the images to use.