### PR TITLE
Create Drizzled MVM FLC files

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -117,6 +117,11 @@ def create_drizzle_products(total_obj_list):
         # Add individual single input images with updated WCS headers to manifest
         for exposure_obj in filt_obj.edp_list:
             product_list.append(exposure_obj.full_filename)
+            # Create Drizzled images for each input on SkyCell pixels
+            exposure_obj.wcs_drizzle_product(meta_wcs)
+            # Add drizzled FLC images to manifest
+            product_list.append(exposure_obj.drizzle_filename)
+
 
     # Ensure that all drizzled products have headers that are to specification
     try:

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -247,6 +247,12 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
                                                                 input_custom_pars_file=input_custom_pars_file,
                                                                 output_custom_pars_file=output_custom_pars_file)
 
+            for edp in filter_item.edp_list:
+                edp.configobj_pars = config_utils.HapConfig(edp,
+                                                                log_level=log_level,
+                                                                use_defaults=use_defaults_configs,
+                                                                input_custom_pars_file=input_custom_pars_file,
+                                                                output_custom_pars_file=output_custom_pars_file)
         log.info("The configuration parameters have been read and applied to the drizzle objects.")
 
         reference_catalog = run_align_to_gaia(total_obj_list, log_level=log_level, diagnostic_mode=diagnostic_mode)

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -121,6 +121,7 @@ def create_drizzle_products(total_obj_list):
             exposure_obj.wcs_drizzle_product(meta_wcs)
             # Add drizzled FLC images to manifest
             product_list.append(exposure_obj.drizzle_filename)
+            product_list.append(exposure_obj.trl_filename)
 
 
     # Ensure that all drizzled products have headers that are to specification


### PR DESCRIPTION
These changes should result in drizzled versions of the MVM input FLC files to be produced as output products of MVM processing.