### PR TITLE
Allow local files in poller files

### DIFF
--- a/drizzlepac/haputils/make_poller_files.py
+++ b/drizzlepac/haputils/make_poller_files.py
@@ -106,6 +106,10 @@ def locate_fitspath_from_rootname(rootname):
     fullfilepath : str
         full path + image name of specified rootname.
     """
+    import glob
+    files = sorted(glob.glob('{}*fl?.fits'.format(rootname[:4])))
+    if rootname in files:
+        return rootname
     if not os.getenv("DATA_PATH"):
         sys.exit("ERROR: Undefined online cache data root path. Please set environment variable 'DATA_PATH'")
     filenamestub = "{}/{}/{}/{}".format(os.getenv("DATA_PATH"), rootname[:4], rootname, rootname)


### PR DESCRIPTION
This additional logic allows the creation of MVM poller files when the input files are already in the current working directory without having to specify an external environment variable. 

This change is NOT critical to any pipeline functionality, but rather allows poller files to be generated for local use; primarily, for testing.