### PR TITLE
Update HAPLEVEL for MVM products

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -961,7 +961,7 @@ class SkyCellProduct(HAPProduct):
         self.manifest_name = '_'.join(['hst', skycell_name, 'manifest.txt'])
 
         # Define HAPLEVEL value for this product
-        self.haplevel = 3
+        self.haplevel = 4
 
         # These attributes will be populated during processing
         self.edp_list = []


### PR DESCRIPTION
Simple change to update the value of the HAPLEVEL keyword for MVM products (not exposure level MVM products) to a value of 4, from 3.  