### PR TITLE
Turn off CTX creation for MVM products

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -868,6 +868,7 @@ class SkyCellExposure(HAPProduct):
         drizzle_pars["preserve"] = False
         drizzle_pars['rules_file'] = self.rules_file
         drizzle_pars['resetbits'] = "0"
+        drizzle_pars['context'] = False
 
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "
                   "have been updated for the drizzle step of the exposure drizzle product."
@@ -1032,6 +1033,8 @@ class SkyCellProduct(HAPProduct):
         # Setting "preserve" to false so the OrIg_files directory is deleted as the purpose
         # of this directory is now obsolete.
         drizzle_pars["preserve"] = False
+        # Turn off generation of CTX extension (not useful for these products)
+        drizzle_pars["context"] = False
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "
                   "have been updated for the drizzle step of the filter drizzle product."
                   .format(meta_wcs, self.trl_logname))

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -868,6 +868,8 @@ class SkyCellExposure(HAPProduct):
         drizzle_pars["preserve"] = False
         drizzle_pars['rules_file'] = self.rules_file
         drizzle_pars['resetbits'] = "0"
+        # Set 'context' to False in order to turn off creation of CTX extensions in MVM products
+        # to save on disk space and memory use during processing.
         drizzle_pars['context'] = False
 
         log.debug("The 'final_refimage' ({}) and 'runfile' ({}) configuration variables "


### PR DESCRIPTION
As requested by INS, this turns off the creation of CTX extensions for MVM products.