### PR TITLE
Keep using stsci.tools.bitmask for compatibility with numpy 1.21

### DIFF
--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -35,7 +35,7 @@ Functions to build mask files for PyDrizzle.
 import os
 
 from stsci.tools import fileutil, readgeis
-from astropy.nddata.bitmask import bitfield_to_boolean_mask
+from stsci.tools.bitmask import bitfield_to_boolean_mask
 
 from astropy.io import fits
 import numpy as np

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -13,7 +13,7 @@ from scipy import ndimage
 import astropy
 from astropy.io import fits
 from astropy.table import Table
-from astropy.nddata.bitmask import bitfield_to_boolean_mask
+from stsci.tools.bitmask import bitfield_to_boolean_mask
 from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -39,7 +39,6 @@ from astropy.io import fits as fits
 from astropy.io import ascii
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm, sigma_clipped_stats
-from astropy.nddata.bitmask import bitfield_to_boolean_mask
 from astropy.visualization import SqrtStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.modeling.fitting import LevMarLSQFitter
@@ -63,6 +62,7 @@ from stsci.tools import fileutil as fu
 from stsci.tools import parseinput
 from stsci.tools import logutil
 from stsci.tools.fileutil import countExtn
+from stsci.tools.bitmask import bitfield_to_boolean_mask
 
 from ..tweakutils import build_xy_zeropoint, ndfind
 

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -13,13 +13,12 @@ import copy
 import numpy as np
 
 from astropy import wcs as pywcs
-from astropy.nddata import interpret_bit_flags
-import stwcs
 from astropy.io import fits
 from spherical_geometry.polygon import SphericalPolygon
 from stsci.skypac.parseat import FileExtMaskInfo, parse_cs_line
 from stsci.skypac import utils as spu
 
+import stwcs
 from stwcs.distortion import utils
 from stwcs.wcsutil import wcscorr
 from stwcs.wcsutil import headerlet
@@ -27,6 +26,7 @@ from stwcs.wcsutil import altwcs
 from stsci.tools import fileutil as fu
 from stsci.stimage import xyxymatch
 from stsci.tools import logutil, textutil
+from stsci.tools.bitmask import interpret_bit_flags
 
 
 from . import catalogs

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -37,7 +37,7 @@ import sys
 import numpy as np
 import astropy
 from astropy.io import fits
-from astropy.nddata import interpret_bit_flags
+from stsci.tools.bitmask import interpret_bit_flags
 
 from stwcs import updatewcs as uw
 from stwcs.wcsutil import altwcs, wcscorr

--- a/drizzlepac/resetbits.py
+++ b/drizzlepac/resetbits.py
@@ -64,10 +64,10 @@ EXAMPLES
 """
 import os
 import numpy as np
-from astropy.nddata import interpret_bit_flags
 
 from stsci.tools import stpyfits as fits
 from stsci.tools import parseinput, logutil
+from stsci.tools.bitmask import interpret_bit_flags
 
 from . import util
 

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -12,9 +12,9 @@ input image while recording the subtracted value in the image header.
 import os, sys
 
 import numpy as np
-from astropy.nddata import interpret_bit_flags
 
 from stsci.tools import fileutil, teal, logutil
+from stsci.tools.bitmask import interpret_bit_flags
 import stsci.imagestats as imagestats
 
 from stsci.skypac.skymatch import skymatch

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'stsci.tools>=3.6',
         'stsci.image>=2.3.0',
         'stsci.imagestats',
-        'stsci.skypac>=1.0',
+        'stsci.skypac>=1.0.7',
         'stsci.stimage',
         'stwcs>=1.5.3',
         'tweakwcs>=0.7.2',


### PR DESCRIPTION
This PR effectively undoes https://github.com/spacetelescope/drizzlepac/pull/1098 in light of https://github.com/spacetelescope/stsci.tools/pull/135#issuecomment-896792533: `numpy 1.21` compatibility can be improved in `stsci.tools.bitmask` before next `astropy` release.