### PR TITLE
Fix multiprocessing incompatibility with Python >= 3.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ of the list).
 - Fix a memory corruption issue in ``interpolate_bilinear()`` in
   ``cdrizzleblot.c`` which could result in segfault. [#1048]
 
+- Fixed multiprocessing incompatibility with ``Python >= 3.8``. [#1101]
+
 In addition to a couple dozen bug fixes for the new SVM processing code
 to expand the number of visits which can be aligned to GAIA, the
 following significant changes to the code or some of the APIs have also

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -20,6 +20,7 @@ from . import quickDeriv
 from . import util
 from . import processInput
 from . version import __version__, __version_date__
+
 if util.can_parallel:
     import multiprocessing
 
@@ -76,11 +77,12 @@ def rundrizCR(imgObjList, configObj, procSteps=None):
     subprocs = []
     if pool_size > 1:
         log.info('Executing {:d} parallel workers'.format(pool_size))
+        mp_ctx = multiprocessing.get_context('fork')
         for image in imgObjList:
-            manager = multiprocessing.Manager()
+            manager = mp_ctx.Manager()
             mgr = manager.dict({})
 
-            p = multiprocessing.Process(
+            p = mp_ctx.Process(
                 target=_driz_cr,
                 name='drizCR._driz_cr()',  # for err msgs
                 args=(image, mgr, paramDict.dict())

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -260,8 +260,7 @@ def reportResourceUsage(imageObjectList, outwcs, num_cores,
         numchips += img._nmembers # account for group parameter set by user
 
     # if we have the cpus and s/w, ok, but still allow user to set pool size
-    pool_size = util.get_pool_size(num_cores, None)
-    pool_size = pool_size if (numchips >= pool_size) else numchips
+    pool_size = util.get_pool_size(num_cores, numchips)
 
     inimg = 0
     chip_mem = 0
@@ -600,10 +599,14 @@ def _process_input_wcs(infiles, wcskey, updatewcs):
     if pool_size > 1:
         log.info('Executing %d parallel workers' % pool_size)
         subprocs = []
+        mp_ctx = multiprocessing.get_context('fork')
+
         for fname in outfiles:
-            p = multiprocessing.Process(target=_process_input_wcs_single,
+            p = mp_ctx.Process(
+                target=_process_input_wcs_single,
                 name='processInput._process_input_wcs()', # for err msgs
-                args=(fname, wcskey, updatewcs) )
+                args=(fname, wcskey, updatewcs)
+            )
             subprocs.append(p)
         mputil.launch_and_wait(subprocs, pool_size) # blocks till all done
     else:


### PR DESCRIPTION
This PR fixes compatibility issues in `Python >= 3.8` when running `astrodrizzle` in parallel mode.

From [Python 3.8 Documentation](https://docs.python.org/3.8/library/multiprocessing.html#contexts-and-start-methods):

> Changed in version 3.8: On macOS, the spawn start method is now the default. The fork start method should be considered unsafe as it can lead to crashes of the subprocess. See bpo-33725.

In order to pass open `HDULists` (or other complicated objects) to subprocesses, we have to continue using `'fork'` for now.

In the future, it may be worth exploring switching to `'spawn'` or `'forkserver'` which may improve security and possibly add support for multiprocessing when running on Windows.

Fixes #1068
