### PR TITLE
Use intrinsic int, bool, and float types instead of numpy

### DIFF
--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -414,14 +414,14 @@ def mergeDQarray(maskname, dqarr):
             # working with file on disk (default case)
             if os.path.exists(maskname):
                 mask = fileutil.openImage(maskname, memmap=False)
-                maskarr = mask[0].data.astype(np.bool)
+                maskarr = mask[0].data.astype(bool)
                 mask.close()
         else:
             if isinstance(maskname, fits.HDUList):
                 # working with a virtual input file
-                maskarr = maskname[0].data.astype(np.bool)
+                maskarr = maskname[0].data.astype(bool)
             else:
-                maskarr = maskname.data.astype(np.bool)
+                maskarr = maskname.data.astype(bool)
 
         if maskarr is not None:
             # merge array with dqarr now

--- a/drizzlepac/catalogs.py
+++ b/drizzlepac/catalogs.py
@@ -475,7 +475,7 @@ class ImageCatalog(Catalog):
             for ext in extlist:
                 usermask = hdulist[ext].data
                 if usermask.shape == (img_ny, img_nx):
-                    regmask = usermask.astype(np.bool)
+                    regmask = usermask.astype(bool)
                     break
             hdulist.close()
             if regmask is None:
@@ -523,7 +523,7 @@ class ImageCatalog(Catalog):
             # create a mask from regions:
             regmask = np.asarray(
                 reglist.get_mask(shape=(img_ny, img_nx)),
-                dtype=np.bool
+                dtype=bool
             )
 
         if mask is not None and regmask is not None:

--- a/drizzlepac/devutils/alignment_viewer.py
+++ b/drizzlepac/devutils/alignment_viewer.py
@@ -286,5 +286,6 @@ def create_product_page(prodname, zoom_size=128, wcsname="",
 
 def get_col_val(hdrtab, keyword, default=None):
     val = hdrtab[0][keyword.upper()] if keyword.upper() in hdrtab.columns.names else default
-    if isinstance(val, bool) or isinstance(val, np.bool_): val = str(val)
+    if isinstance(val, (bool, np.bool_)):
+        val = str(val)
     return val

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -1583,13 +1583,13 @@ def within_footprint(img, wcsobj, x, y):
     yint = y[wcsmask].astype(np.int32)
 
     fprint = ~np.isnan(img)
-    xymask = np.zeros(img.shape, dtype=np.bool)
+    xymask = np.zeros(img.shape, dtype=bool)
     xymask[yint, xint] = True
 
     skymask = np.bitwise_and(fprint, xymask)
 
     mask = [True if skymask[yx]==True else False for yx in zip(yint, xint)]
-    mask = np.array(mask).astype(np.bool)
+    mask = np.array(mask).astype(bool)
 
     # NOTE: There is probably a way to use list comprehension to do this,
     # but for now, this works as intended.

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1428,7 +1428,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             g_segm_img, g_is_big_crowded, g_bs, g_sf = self.detect_and_eval_segments(imgarr,
                                                                                      g2d_kernel,
                                                                                      ncount,
-                                                                                     self._size_source_box, 
+                                                                                     self._size_source_box,
                                                                                      self._nsigma,
                                                                                      self.image.bkg_background_ra,
                                                                                      self.image.bkg_rms_ra,
@@ -1455,7 +1455,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 rw_segm_img, rw_is_big_crowded, rw_bs, rw_sf = self.detect_and_eval_segments(imgarr,
                                                                                              rw2d_kernel,
                                                                                              ncount,
-                                                                                             self._size_source_box, 
+                                                                                             self._size_source_box,
                                                                                              self._rw2d_nsigma,
                                                                                              self.image.bkg_background_ra,
                                                                                              self.image.bkg_rms_ra,
@@ -1477,7 +1477,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                     log.info("")
                     log.info("RickerWavelet computed segmentation image still contains big sources/islands.")
                     log.info("Recomputing the threshold or background image for improved segmentation detection.")
-                
+
                     # Make sure to be working with the unmodified image data
                     imgarr = copy.deepcopy(self.image.data)
 
@@ -1530,7 +1530,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                     g_segm_img, g_is_big_crowded, g_bs, g_sf = self.detect_and_eval_segments(imgarr,
                                                                                              g2d_kernel,
                                                                                              ncount,
-                                                                                             self._size_source_box, 
+                                                                                             self._size_source_box,
                                                                                              sigma_for_threshold,
                                                                                              self.image.bkg_background_ra,
                                                                                              self.image.bkg_rms_ra,
@@ -1552,7 +1552,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                         rw_segm_img, rw_is_big_crowded, rw_bs, rw_sf = self.detect_and_eval_segments(imgarr,
                                                                                                      rw2d_kernel,
                                                                                                      ncount,
-                                                                                                     self._size_source_box, 
+                                                                                                     self._size_source_box,
                                                                                                      rw2d_sigma_for_threshold,
                                                                                                      self.image.bkg_background_ra,
                                                                                                      self.image.bkg_rms_ra,
@@ -2489,7 +2489,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
 def make_inv_mask(mask):
 
-    invmask = ~(mask.astype(np.bool))
+    invmask = ~(mask.astype(bool))
     invmask = invmask.astype(np.uint8)
 
     return invmask

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -1449,7 +1449,7 @@ def update_grid_defs(pc_size=5.0, output=None, grid_file=None):
         c1_pixels = [np.abs(pcell.wcs.world_to_pixel_values(e.ra, e.dec)) for e in c1_edges]
 
         # Compute overall size of cell in pixels
-        naxis1, naxis2 = (np.array(c1_pixels).sum(axis=0) + 1).astype(np.int)
+        naxis1, naxis2 = (np.array(c1_pixels).sum(axis=0) + 1).astype(int)
         # apply new definition to cell WCS
         pcell.wcs.wcs.crpix = [naxis1 / 2. + 0.5, naxis2 / 2. + 0.5]
         pcell.wcs.naxis1 = naxis1

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -515,7 +515,7 @@ def hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, p
     all_detections = catalog_data
 
     nrows = len(all_detections)
-    full_coord_list = numpy.empty((nrows, 2), dtype=numpy.float)
+    full_coord_list = numpy.empty((nrows, 2), dtype=float)
     for row_count, detection in enumerate(all_detections):
         full_coord_list[row_count, 0] = float(detection[column_titles["x_coltitle"]])
         full_coord_list[row_count, 1] = float(detection[column_titles["y_coltitle"]])
@@ -712,7 +712,7 @@ def hla_swarm_flags(drizzled_image, catalog_name, catalog_data, exptime, plate_s
 
     nrows = len(catalog_data)
 
-    complete_src_list = numpy.empty((nrows, 6), dtype=numpy.float)
+    complete_src_list = numpy.empty((nrows, 6), dtype=float)
 
     for row_num, row in enumerate(catalog_data[0:]):
         x_val = float(row[column_titles["x_coltitle"]])
@@ -1080,7 +1080,7 @@ def hla_swarm_flags(drizzled_image, catalog_name, catalog_data, exptime, plate_s
 
             # select just the lowest value of refepp/swarm threshold for each source
             # create array with extra columns
-            ring_source_list = numpy.empty((len(ring_index_list), 9), dtype=numpy.float)
+            ring_source_list = numpy.empty((len(ring_index_list), 9), dtype=float)
             ring_source_list[:, 0:6] = swarm_list_b[ring_index_list, :]
             ring_source_list[:, 6] = numpy.concatenate(ring_refepp_list)
             ring_source_list[:, 7] = numpy.repeat(ring_thresh_list, ring_count)

--- a/drizzlepac/haputils/hla_flag_filter_HLAClassic.py
+++ b/drizzlepac/haputils/hla_flag_filter_HLAClassic.py
@@ -81,7 +81,7 @@ y_limit = 2051.
 def run_source_list_flaging(all_drizzled_filelist, filter_sorted_flt_dict,param_dict, exp_dictionary_scis,
                             dict_newTAB_matched2drz, phot_table_matched2drz, proc_type, drz_root_dir, debug=True):
     """Simple calling subroutine that executes the other flagging subroutines.
-    
+
     Parameters
     ----------
     all_drizzled_filelist : list
@@ -89,7 +89,7 @@ def run_source_list_flaging(all_drizzled_filelist, filter_sorted_flt_dict,param_
 
     filter_sorted_flt_dict : dictionary
         dictionary containing lists of calibrated images sorted (also keyed) by filter name.
-    
+
     param_dict : dictionary
         Dictionary of instrument/detector - specific drizzle, source finding and photometric parameters
 
@@ -110,7 +110,7 @@ def run_source_list_flaging(all_drizzled_filelist, filter_sorted_flt_dict,param_
 
     debug : bool
         write intermediate files?
-    
+
     Returns
     -------
     catalog_data : astropy.Table object
@@ -473,7 +473,7 @@ def HLASaturationFlags(drizzled_image, flt_list, catalog_name, catalog_data, pro
     all_detections = catalog_data
 
     nrows = len(all_detections)
-    full_coordList = numpy.empty((nrows, 2), dtype=numpy.float)
+    full_coordList = numpy.empty((nrows, 2), dtype=float)
     for row_count, detection in enumerate(all_detections):
         full_coordList[row_count, 0] = float(detection[0])
         full_coordList[row_count, 1] = float(detection[1])
@@ -569,7 +569,7 @@ def HLASwarmFlags(drizzled_image, catalog_name, catalog_data, exptime, proc_type
     ----------
     drizzled_image : string
         Name of drizzled image to process
-    
+
     catalog_name : string
         drizzled filter product catalog filename to process
 
@@ -587,7 +587,7 @@ def HLASwarmFlags(drizzled_image, catalog_name, catalog_data, exptime, proc_type
 
     debug : bool
         write intermediate files?
-    
+
     Returns
     -------
     catalog_data : astropy.Table object
@@ -650,7 +650,7 @@ def HLASwarmFlags(drizzled_image, catalog_name, catalog_data, exptime, proc_type
 
     nrows = len(catalog_data)
 
-    complete_src_list = numpy.empty((nrows,6), dtype=numpy.float)
+    complete_src_list = numpy.empty((nrows,6), dtype=float)
 
     for row_num,row in enumerate(catalog_data[0:]):
         x_val = float(row[0])
@@ -1012,7 +1012,7 @@ def HLASwarmFlags(drizzled_image, catalog_name, catalog_data, exptime, proc_type
 
             # select just the lowest value of refepp/swarm threshold for each source
             # create array with extra columns
-            ring_source_list = numpy.empty((len(ring_index_list),9), dtype=numpy.float)
+            ring_source_list = numpy.empty((len(ring_index_list),9), dtype=float)
             ring_source_list[:,0:6] = swarm_listB[ring_index_list,:]
             ring_source_list[:,6] = numpy.concatenate(ring_refepp_list)
             ring_source_list[:,7] = numpy.repeat(ring_thresh_list,ring_count)
@@ -1159,7 +1159,7 @@ def HLASwarmFlags(drizzled_image, catalog_name, catalog_data, exptime, proc_type
 
 def HLANexpFlags(drizzled_image, flt_list, param_dict, catalog_name, catalog_data, drz_root_dir, debug):
     """flags out sources from regions where there are a low (or a null) number of contributing exposures
-   
+
     drizzled_image : string
         Name of drizzled image to process
 
@@ -1185,7 +1185,7 @@ def HLANexpFlags(drizzled_image, flt_list, param_dict, catalog_name, catalog_dat
     -------
     catalog_data : astropy.Table object
         drizzled filter product catalog data with updated flag values
-    
+
     """
     # ------------------
     # CREATE NEXP IMAGE
@@ -1728,7 +1728,7 @@ def HLASaturationFlags_OLD(all_drizzled_filelist, working_hla_red, filter_sorted
         inputfile.close()
 
         nrows = len(all_detections)-1
-        full_coordList = numpy.empty((nrows,2), dtype=numpy.float)
+        full_coordList = numpy.empty((nrows,2), dtype=float)
         for row_count,detection in enumerate(all_detections[1:]):
             ss = detection.split(',')
             full_coordList[row_count,0] = float(ss[0])
@@ -1957,7 +1957,7 @@ def HLASwarmFlags_OLD(all_drizzled_filelist, dict_newTAB_matched2drz, working_hl
 
         nrows = len(phot_table_rows) - 1
 
-        complete_src_list = numpy.empty((nrows, 6), dtype=numpy.float)
+        complete_src_list = numpy.empty((nrows, 6), dtype=float)
 
         for row_num, row in enumerate(phot_table_rows[1:]):
 
@@ -2349,7 +2349,7 @@ def HLASwarmFlags_OLD(all_drizzled_filelist, dict_newTAB_matched2drz, working_hl
 
                 # select just the lowest value of refepp/swarm threshold for each source
                 # create array with extra columns
-                ring_source_list = numpy.empty((len(ring_index_list), 9), dtype=numpy.float)
+                ring_source_list = numpy.empty((len(ring_index_list), 9), dtype=float)
                 ring_source_list[:, 0:6] = swarm_listB[ring_index_list, :]
                 ring_source_list[:, 6] = numpy.concatenate(ring_refepp_list)
                 ring_source_list[:, 7] = numpy.repeat(ring_thresh_list, ring_count)
@@ -2891,24 +2891,24 @@ def xymatch(cat1, cat2, sep, multiple=False, stack=True, verbose=True):
 
     Marcel Haas, 2012-06-29, after IDL routine xymatch.pro by Rick White
     With some tweaks by Rick White
-    
+
     Parameters
     ----------
     cat1 : numpy.ndarray
         list of x,y source coords to match.
-    
+
     cat2 : numpy.ndarray
         list of x,y source coords to match.
-    
+
     sep : float
         maximum separation (in pixels) allowed for source matching.
-    
+
     multiple : Boolean
         If multiple is true, returns a tuple (p1,p2) such that cat1[p1] and cat2[p2] are within sep.  p1 and p2 may include multiple pointers to the same objects in cat1 or cat2.  In this case objects that don't match are simply omitted from the lists. Default value is 'False'.
-    
+
     stack : Boolean
         If stack is true, the returned matching pointers are stacked into a single big array, so both p1 and p2 are 1-D arrays of length nmatches. Default value is 'True'.
-    
+
     verbose : Boolean
         print verbose output? Default value is 'True'.
 
@@ -3004,7 +3004,7 @@ def sorted_median(a):
     ----------
     a : numpy.ndarray
         list of values what will be processed.
-     
+
     Returns
     -------
     med : numpy.float32
@@ -3022,7 +3022,7 @@ def sorted_median(a):
 
 def get_median_sky(drizzled_image):
     """Read drizzled image from FITS file and compute sky
-    
+
     Parameters
     ----------
     drizzled_image : string
@@ -3031,7 +3031,7 @@ def get_median_sky(drizzled_image):
     Returns
     -------
     median_sky : float
-        median sky value for image specified by 'drizzled_image'. 
+        median sky value for image specified by 'drizzled_image'.
     """
 
     driz_img_data = getdata(drizzled_image,1).ravel()
@@ -3069,13 +3069,13 @@ def rdtoxy(rd_coord_array, image, image_ext):
 
     rd_coord_array : numpy.ndarray
         array containing RA and dec values to convert.
-    
+
     image : string
-        drizzled image whose WCS info will be used in the coordinate conversion. 
-    
+        drizzled image whose WCS info will be used in the coordinate conversion.
+
     image_ext : string
         fits image extension to be used in the conversion.
-    
+
     Returns
     xy_arr: array
         array of converted x,y coordinate value pairs
@@ -3122,9 +3122,9 @@ def xytord(xy_coord_array, image, image_ext):
 # ========================================================================================================
 def extract_name(stringWpath):
     """This task will extract just the name of  specific filename that includes the path in the name: 'stringWpath'.
-    
+
     Tested.
-    
+
     stringWpath : string
         input path to be processed
 
@@ -3181,7 +3181,7 @@ def arrayfy_ctx(ctx, maxindex):
 
     ctxarray = numpy.zeros ( (nx, ny, n3), dtype="bool" )
     comparison = numpy.zeros ( (nx, ny), dtype="int32")
-    
+
     for i in range(n3):
         ilayer = int(i/32)
         ibit = i - 32*ilayer

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -1334,7 +1334,7 @@ class RefImage:
         print("Adding {} new sources to the reference catalog "
               "for a total of {} sources."
               .format(adding_nsources, old_ref_nsources + adding_nsources))
-        not_matched_mask = np.ones(image.outxy.shape[0], dtype=np.bool)
+        not_matched_mask = np.ones(image.outxy.shape[0], dtype=bool)
         not_matched_mask[matched_idx] = False
         not_matched_outxy = image.outxy[not_matched_mask]
 

--- a/drizzlepac/minmed.py
+++ b/drizzlepac/minmed.py
@@ -424,10 +424,10 @@ def min_med(images, weight_images, readnoise_list, exptime_list,
     if weight_masks == [] or weight_masks is None:
         weight_masks = None
         mask_sum = np.zeros(images.shape[1:], dtype=np.int16)
-        all_bad_idx = np.array([], dtype=np.int)
-        all_bad_idy = np.array([], dtype=np.int)
+        all_bad_idx = np.array([], dtype=int)
+        all_bad_idy = np.array([], dtype=int)
     else:
-        weight_masks = np.asarray(weight_masks, dtype=np.bool)
+        weight_masks = np.asarray(weight_masks, dtype=bool)
         mask_sum = np.sum(weight_masks, axis=0, dtype=np.int16)
         all_bad_idx, all_bad_idy = np.where(mask_sum == nimages)
 

--- a/drizzlepac/stisData.py
+++ b/drizzlepac/stisData.py
@@ -424,7 +424,7 @@ def expand_image(image, shape):
     oy = (sy - 1.0) / (2.0 * sy)
 
     # generate output coordinates:
-    y, x = np.indices(shape, dtype=np.float)
+    y, x = np.indices(shape, dtype=float)
     x = x / sx - ox
     y = y / sy - oy
 
@@ -444,8 +444,8 @@ def bilinear_interp(data, x, y):
     x = x.ravel()
     y = y.ravel()
 
-    x0 = np.empty(out_size, dtype=np.int)
-    y0 = np.empty(out_size, dtype=np.int)
+    x0 = np.empty(out_size, dtype=int)
+    y0 = np.empty(out_size, dtype=int)
     np.clip(x, 0, data.shape[1] - 2, out=x0)
     np.clip(y, 0, data.shape[0] - 2, out=y0)
     x1 = x0 + 1

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -688,7 +688,7 @@ def run(configobj):
 
 def _overlap_matrix(images):
     nimg = len(images)
-    m = np.zeros((nimg,nimg), dtype=np.float)
+    m = np.zeros((nimg,nimg), dtype=float)
     for i in range(nimg):
         for j in range(i+1,nimg):
             p = images[i].skyline.intersection(images[j].skyline)
@@ -750,7 +750,7 @@ def _max_overlap_image(refimage, images, expand_refcat, enforce_user_order):
         # revert to old tweakreg behavior
         return images.pop(0)
 
-    area = np.zeros(nimg, dtype=np.float)
+    area = np.zeros(nimg, dtype=float)
     for i in range(nimg):
         area[i] = np.fabs(
             refimage.skyline.intersection(images[i].skyline).area()

--- a/drizzlepac/tweakutils.py
+++ b/drizzlepac/tweakutils.py
@@ -148,7 +148,7 @@ def ndfind(array, hmin, fwhm, skymode,
         return tuple([[] for i in range(7 if use_sharp_round else 4)])
 
     star_list = list(np.array(star_list).T)
-    fluxes = np.array(fluxes, np.float)
+    fluxes = np.array(fluxes, float)
 
     if nbright is not None:
         idx = np.argsort(fluxes)[::-1]


### PR DESCRIPTION
This replaces the deprecated `numpy` global types

```python
np.float
np.bool
np.int
```

with the Python types

```python
float
bool
int
```
 
to avoid (reduce) deprecation warnings.