### PR TITLE
Compute mvm sregion

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -381,14 +381,14 @@ class SkyFootprint(object):
         arr = fits.getdata(filename, ext=sciext)
         # If working with drizzled data which has NaN as non-exposed pixel values
         if np.isnan(arr.min()):
-            self.total_mask = (np.isnan(arr) == 0).astype(np.int16)
+            total_mask = (np.isnan(arr) == 0).astype(np.int16)
         else:
             total_mask = (arr != 0).astype(np.int16)
-            # Remove 'small' holes in the image due to noise to avoid
-            # creating extraneous 'regions' from the image when it is really
-            # all one region/chip.
-            total_mask = ndimage.binary_fill_holes(total_mask)
-            self.total_mask = total_mask
+        # Remove 'small' holes in the image due to noise to avoid
+        # creating extraneous 'regions' from the image when it is really
+        # all one region/chip.
+        total_mask = ndimage.binary_fill_holes(total_mask)
+        self.total_mask = total_mask
 
         # clean up as quickly as possible
         del arr

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -580,7 +580,6 @@ class SkyFootprint(object):
                 ordered_xyc = xy_corners[radial_order].tolist()
                 ordered_xyc.append(ordered_xyc[0])  # close polygon
                 ordered_xy.append(np.array(ordered_xyc, dtype=np.float64))
-                import pickle; pickle.dump({'ordered_xyc':ordered_xyc, 'radial_order':radial_order, 'cordist': cordist, 'ordered_indices':ordered_indices}, open('radial_results{}.pkl'.format(label), 'wb'))
                 sky_corners.append(self.meta_wcs.all_pix2world(ordered_xyc, 0))
 
                 ordered_edges.append(edge_pixels)

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -214,15 +214,17 @@ def compute_sregion(image, extname='SCI'):
             #  the array corners directly
             extwcs = wcsutil.HSTWCS(hdu, ext=sciext)
             footprint = extwcs.calc_footprint(center=True)
-
+            for corner in footprint:
+                sregion_str += '{} {} '.format(corner[0], corner[1])
         else:
             # Working with a drizzled image, so we need to
             # get all the corners from each of the input files
             footprint = find_footprint(hdu, extname=extname)
 
-        for chip in footprint:
-            for corner in chip:
-                sregion_str += '{} {} '.format(corner[0], corner[1])
+            for chip in footprint.corners:
+                for corner in chip:
+                    sregion_str += '{} {} '.format(corner[0], corner[1])
+
         hdu[sciext].header['s_region'] = sregion_str
 
     # close file if opened by this functions
@@ -268,7 +270,7 @@ def find_footprint(hdu, extname='SCI'):
     # Now, find the corners from this mask
     footprint.find_corners()
 
-    return footprint.corners
+    return footprint
 
 
 def interpret_sregion(image, extname='SCI'):

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -220,9 +220,12 @@ def compute_sregion(image, extname='SCI'):
             # Working with a drizzled image, so we need to
             # get all the corners from each of the input files
             footprint = find_footprint(hdu, extname=extname)
-
-            for chip in footprint.corners:
-                for corner in chip:
+            sregion_str = ''
+            for region in footprint.corners:
+                # S_REGION string should contain a separate POLYGON
+                # for each region or chip in the SCI array
+                sregion_str += 'POLYGON ICRS '
+                for corner in region:
                     sregion_str += '{} {} '.format(corner[0], corner[1])
 
         hdu[sciext].header['s_region'] = sregion_str

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -471,6 +471,8 @@ class TotalProduct(HAPProduct):
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
                 hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
+        # Compute S_REGION keyword and add it to the header of this product
+        putils.compute_sregion(self.drizzle_filename)
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Total combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
@@ -572,6 +574,8 @@ class FilterProduct(HAPProduct):
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
                 hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
+        # Compute S_REGION keyword and add it to the header of this product
+        putils.compute_sregion(self.drizzle_filename)
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Filter combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
@@ -662,6 +666,9 @@ class ExposureProduct(HAPProduct):
         astrodrizzle.AstroDrizzle(input=self.full_filename,
                                   output=self.drizzle_filename,
                                   **drizzle_pars)
+
+        # Compute S_REGION keyword and add it to the header of this product
+        putils.compute_sregion(self.drizzle_filename)
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Exposure image {}".format(self.drizzle_filename))

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -471,8 +471,6 @@ class TotalProduct(HAPProduct):
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
                 hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
-        # Compute S_REGION keyword and add it to the header of this product
-        putils.compute_sregion(self.drizzle_filename)
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Total combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
@@ -574,8 +572,6 @@ class FilterProduct(HAPProduct):
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
                 hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
-        # Compute S_REGION keyword and add it to the header of this product
-        putils.compute_sregion(self.drizzle_filename)
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Filter combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
@@ -666,9 +662,6 @@ class ExposureProduct(HAPProduct):
         astrodrizzle.AstroDrizzle(input=self.full_filename,
                                   output=self.drizzle_filename,
                                   **drizzle_pars)
-
-        # Compute S_REGION keyword and add it to the header of this product
-        putils.compute_sregion(self.drizzle_filename)
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Exposure image {}".format(self.drizzle_filename))
@@ -889,6 +882,7 @@ class SkyCellExposure(HAPProduct):
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Exposure image {}".format(self.drizzle_filename))
+
         try:
             shutil.move(self.trl_logname, self.trl_filename)
         except PermissionError:


### PR DESCRIPTION
The S_REGION keyword computation has been simplified and generalized to not only work for pipeline and SVM products, but also for MVM products.  

The simplification comes from correctly implementing use of the Harris corner detection algorithm (from skimage) to detect the corners in the mask of SCI array while removing the computation based on each input to the output product.  This allows the code to work on images where chips extend beyond the bounds of the output image, as is the case with MVM products.  

The output value of the S_REGION keyword also now separates each region with it's own POLYGON ICRS tag, leading to multiple POLYGON sets of coordinates in the keyword value.  

In addition, a new method was added to the SkyFootprint class to enable creation of a footprint mask directly from the SCI extension of an exposure without having to read in any other images (like all the input exposures for an SVM or MVM product).   

This computation of the S_REGION keyword was used to successfully determine the corners for a variety of exposures, namely:

- **hst_skycell-p0212x04y03_acs_wfc_f658n_all** : MVM product with 5 separate regions where ACS exposures partially land in the output image
- **j8mbnl** : single pointing ACS/WFC SVM product with 2 separate regions (1 for each chip)
- **ib3m53**:  WFC3/IR mosaic with complex pointing creating 1 large irregularly shaped footprint/region
- **ibvg03** : WFC3/IR mosaic with  complex pointing creating 1 large irregularly shaped footprint/region
- **ib1f85** : WFC3/IR single pointing product complete with hole
In each SVM case, the number of corners was comparable to or less than the number of corners previously computed. 

**NOTE:**
This PR should not be merged until we get confirmation from ASB that this form of the S_REGION keyword value can be correctly interpreted by the archive's portal.