### PR TITLE
Fix hap apriori pytest

### DIFF
--- a/drizzlepac/haputils/testutils.py
+++ b/drizzlepac/haputils/testutils.py
@@ -124,7 +124,8 @@ def compare_wcs_alignment(dataset, force=False):
                                               catalog_list=['GAIADR2', 'GAIADR1'],
                                               num_sources=250,
                                               clobber=False,
-                                              debug=True)
+                                              debug=True,
+                                              product_type='pipeline')
             results = align_table.filtered_table
             alignment[wcs] = extract_results(results)
 


### PR DESCRIPTION
Fix how the compare_wcs function works so that the hap/test_apriori tests will run correctly.