### PR TITLE
Support general input poller file name

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -130,7 +130,7 @@ def rename_output_products(filter_obj, output_file_prefix=None):
             new_name = orig_name.replace(text_to_replace, output_file_prefix)
             log.debug("exposure object attr {}: {} -> {}".format(attr_name, orig_name, new_name))
             setattr(filter_obj.edp_list[j], attr_name, new_name)
-            if attr_name is "full_filename":
+            if attr_name == "full_filename":
                 os.rename(orig_name, new_name)
                 log.debug("Renamed file {} -> {}".format(orig_name, new_name))
 
@@ -298,10 +298,7 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
     return_value = 0
     log.setLevel(log_level)
     # Define trailer file (log file) that will contain the log entries for all processing
-    if isinstance(input_filename, str):  # input file is a poller file -- easy case
-        logname = input_filename.replace('.out', '.log')
-    else:
-        logname = 'mvm_process.log'
+    logname = proc_utils.build_logname(input_filename, process_type='mvm')
 
     # Initialize total trailer filename as temp logname
     logging.basicConfig(filename=logname, format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -534,10 +534,8 @@ def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_
     return_value = 0
     log.setLevel(log_level)
     # Define trailer file (log file) that will contain the log entries for all processing
-    if isinstance(input_filename, str):  # input file is a poller file -- easy case
-        logname = input_filename.replace('.out', '.log')
-    else:
-        logname = 'svm_process.log'
+    logname = proc_utils.build_logname(input_filename)
+
     # Initialize total trailer filename as temp logname
     logging.basicConfig(filename=logname, format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
     # start processing

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -42,6 +42,19 @@ def get_rules_file(product):
 
     return new_rules_name
 
+
+def build_logname(input_filename, process_type='svm'):
+    """Build the log filename based on the input filename"""
+
+    suffix = '.{}'.format(input_filename.split('.')[-1])
+    if isinstance(input_filename, str):  # input file is a poller file -- easy case
+        logname = input_filename.replace(suffix, '.log')
+    else:
+        logname = '{}_process.log'.format(process_type)
+
+    return logname
+
+
 def refine_product_headers(product, total_obj_list):
     """Refines output product headers to include values not available to AstroDrizzle.
 


### PR DESCRIPTION
Update SVM and MVM processing code to support input filenames with any extension, as opposed to throwing an Exception if the filename did not end in '.out'.  