### PR TITLE
Remove reference to source_properties

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -1082,7 +1082,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
 
                     # Revert to segmentation photometry for sat. source posns
                     if OLD_PHOTUTILS:
-                        segment_properties = source_properties(detection_img, segment.data)
+                        segment_properties = SourceCatalog(detection_img, segment.data)
                     else:
                         segimg = SegmentationImage(segment.data)
                         segment_properties = SourceCatalog(detection_img, segimg)


### PR DESCRIPTION
Replace reference to 'source_properties' with name used on import; namely, SourceCatalog.  This will avoid throwing an Exception when using photutils < 1.1.0 while keeping the 1.1.0 syntax backwards-compatible. 