### PR TITLE
Add build-backend to pyproject.toml, to force PEP517 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = ["setuptools>=30.3.0", "wheel", "oldest-supported-numpy", "astropy"]
 
 [tool.stsci-bot]


### PR DESCRIPTION
The build is currently failing because `setup.py` imports `numpy`, meaning that `numpy` must be installed and available before setuptools is run. `pyproject.toml`, and [PEP517](https://www.python.org/dev/peps/pep-0517/)/[PEP518](https://www.python.org/dev/peps/pep-0518/) more generally, is intended to allow users to specify build requirements such as these, when they're necessary to run `setup.py`. However, at the moment we are not using the PEP517 build process, due to [logic in the spacetelescope/action-publish_to_pypi](https://github.com/spacetelescope/action-publish_to_pypi/blob/master/entrypoint.sh#L67-L78) GitHub Action we're using. The end result is that the build dependencies specified in the `requires` key of the `pyproject.toml` are not installed automatically, including `numpy`.

This pull request fixes the build by adding the `build-backend` key to the `pyproject.toml` (and specifying the `setuptools.build_meta` backend), thus forcing our `action-publish_to_pypi` GitHub Action to use the PEP517 build process, which will automatically install the dependencies already specified in the `requires` key of the `pyproject.toml`, including `numpy`. I've [tested this in my fork](https://github.com/zanecodes/drizzlepac/runs/3559183326?check_suite_focus=true) so it should work equally well here.