### PR TITLE
Generate empty source catalogs

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -356,30 +356,33 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
             # rate of cosmic-ray contamination for the total detection product
             reject_catalogs = total_product_catalogs.verify_crthresh(n1_exposure_time)
 
-            if not reject_catalogs or diagnostic_mode:
-                for filter_product_obj in total_product_obj.fdp_list:
-                    filter_product_catalogs = filter_catalogs[filter_product_obj.drizzle_filename]
+            if diagnostic_mode:
+                # If diagnostic mode, we want to inspect the original full source catalogs
+                reject_catalogs = False
 
-                    # Now write the catalogs out for this filter product
-                    log.info("Writing out filter product catalog")
-                    # Write out photometric (filter) catalog(s)
-                    filter_product_catalogs.write(reject_catalogs)
+            for filter_product_obj in total_product_obj.fdp_list:
+                filter_product_catalogs = filter_catalogs[filter_product_obj.drizzle_filename]
 
-                    # append filter product catalogs to list
-                    if phot_mode in ['aperture', 'both']:
-                        product_list.append(filter_product_obj.point_cat_filename)
-                    if phot_mode in ['segment', 'both']:
-                        product_list.append(filter_product_obj.segment_cat_filename)
+                # Now write the catalogs out for this filter product
+                log.info("Writing out filter product catalog")
+                # Write out photometric (filter) catalog(s)
+                filter_product_catalogs.write(reject_catalogs)
 
-                log.info("Writing out total product catalog")
-                # write out list(s) of identified sources
-                total_product_catalogs.write(reject_catalogs)
-
-                # append total product catalogs to manifest list
+                # append filter product catalogs to list
                 if phot_mode in ['aperture', 'both']:
-                    product_list.append(total_product_obj.point_cat_filename)
+                    product_list.append(filter_product_obj.point_cat_filename)
                 if phot_mode in ['segment', 'both']:
-                    product_list.append(total_product_obj.segment_cat_filename)
+                    product_list.append(filter_product_obj.segment_cat_filename)
+
+            log.info("Writing out total product catalog")
+            # write out list(s) of identified sources
+            total_product_catalogs.write(reject_catalogs)
+
+            # append total product catalogs to manifest list
+            if phot_mode in ['aperture', 'both']:
+                product_list.append(total_product_obj.point_cat_filename)
+            if phot_mode in ['segment', 'both']:
+                product_list.append(total_product_obj.segment_cat_filename)
     return product_list
 
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -169,6 +169,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
             # phot_mode.  If the point or segmentation algorithms found sources, need to continue
             # processing for that (those) algorithm(s) only.
 
+
             # When both algorithms have been requested...
             if input_phot_mode == 'both':
                 # If no sources found with either algorithm, skip to the next total detection product
@@ -870,23 +871,28 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_lev
             pickle.dump(pickle_dict, pickle_out)
             pickle_out.close()
             log.info("Wrote hla_flag_filter param pickle file {} ".format(out_pickle_filename))
-        # TODO: REMOVE ABOVE CODE ONCE FLAGGING PARAMS ARE OPTIMIZED
 
-        filter_product_catalogs.catalogs[cat_type].source_cat = hla_flag_filter.run_source_list_flagging(drizzled_image,
-                                                                                                         flt_list,
-                                                                                                         param_dict,
-                                                                                                         exptime,
-                                                                                                         plate_scale,
-                                                                                                         median_sky,
-                                                                                                         catalog_name,
-                                                                                                         catalog_data,
-                                                                                                         cat_type,
-                                                                                                         drz_root_dir,
-                                                                                                         filter_product_obj.hla_flag_msk,
-                                                                                                         ci_lookup_file_path,
-                                                                                                         output_custom_pars_file,
-                                                                                                         log_level,
-                                                                                                         diagnostic_mode)
+        # TODO: REMOVE ABOVE CODE ONCE FLAGGING PARAMS ARE OPTIMIZED
+        if len(catalog_data) > 0:
+             source_cat = hla_flag_filter.run_source_list_flagging(drizzled_image,
+                                                                   flt_list,
+                                                                   param_dict,
+                                                                   exptime,
+                                                                   plate_scale,
+                                                                   median_sky,
+                                                                   catalog_name,
+                                                                   catalog_data,
+                                                                   cat_type,
+                                                                   drz_root_dir,
+                                                                   filter_product_obj.hla_flag_msk,
+                                                                   ci_lookup_file_path,
+                                                                   output_custom_pars_file,
+                                                                   log_level,
+                                                                   diagnostic_mode)
+        else:
+            source_cat = catalog_data
+
+        filter_product_catalogs.catalogs[cat_type].source_cat = source_cat
 
     return filter_product_catalogs
 

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1500,6 +1500,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                                                      check_big_island_only=False,
                                                                                      rw2d_biggest_source=self._rw2d_biggest_source,
                                                                                      rw2d_source_fraction=self._rw2d_source_fraction)
+            segm_img_orig = copy.deepcopy(g_segm_img)
 
             # If the science field via the segmentation map is deemed crowded or has big sources/islands, compute the
             # RickerWavelet2DKernel and call detect_and_eval_segments() again. Still use the custom fwhm as it
@@ -1995,7 +1996,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         -------
 
         """
-        if self.sources.nlabels == 0:
+        if self.sources is None or self.sources.nlabels == 0:
             # Report configuration values to log
             log.info("{}".format("=" * 80))
             log.info("")
@@ -2003,8 +2004,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
             log.info("image name: {}".format(self.imgname))
             log.info("Generating empty segment catalog.")
             log.info("")
-            # define this attribute for use by the .write method
-            self._define_empty_table()
 
             # Capture specified filter columns in order to append to the total detection table
             self.subset_filter_source_cat = Table(names=["ID", "MagAp2", "CI", "Flags"])
@@ -2415,7 +2414,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
         self.source_cat = empty_table
         self.sources = copy.deepcopy(segm_img)
-        self.sources.nlabels = 0  # Insure nlabels is set to 0 to indicate no valid sources
+        if self.sources:
+            self.sources.nlabels = 0  # Insure nlabels is set to 0 to indicate no valid sources
 
 
     def _define_total_table(self, updated_table):

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2585,11 +2585,16 @@ class HAPSegmentCatalog(HAPCatalogBase):
         Nothing
 
         """
-        if not reject_catalogs:
-            # Write out catalog to ecsv file
-            self.source_cat = self.annotate_table(self.source_cat, self.param_dict_qc, proc_type="segment", product=self.image.ghd_product)
-            self.source_cat.write(self.sourcelist_filename, format=self.catalog_format)
-            log.info("Wrote catalog file '{}' containing {} sources".format(self.sourcelist_filename, len(self.source_cat)))
+        self.source_cat = self.annotate_table(self.source_cat, self.param_dict_qc, proc_type="segment",
+                                              product=self.image.ghd_product)
+        if reject_catalogs:
+            # We still want to write out empty files
+            # This will delete all rows from the existing table
+            self.source_cat.remove_rows(slice(0, None))
+
+        # Write out catalog to ecsv file
+        self.source_cat.write(self.sourcelist_filename, format=self.catalog_format)
+        log.info("Wrote catalog file '{}' containing {} sources".format(self.sourcelist_filename, len(self.source_cat)))
 
         # For debugging purposes only, create a "regions" files to use for ds9 overlay of the segm_img.
         # Create the image regions file here in case there is a failure.  This diagnostic portion of the

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -577,7 +577,6 @@ class HAPCatalogs:
         # The syntax here is EXTREMELY cludgy, but until a more compact way to do this is found,
         #  it will have to do...
         self.catalogs = {}
-
         if 'segment' in self.types:
             self.catalogs['segment'] = HAPSegmentCatalog(self.image, self.param_dict, self.param_dict_qc,
                                                          self.diagnostic_mode, tp_sources=tp_sources)
@@ -678,7 +677,6 @@ class HAPCatalogs:
             Supported types of catalogs include: 'aperture', 'segment'.
         """
         # Make sure we at least have a default 2D background computed
-
         for catalog in self.catalogs.values():
             if catalog.source_cat is None:
                 catalog.source_cat = catalog.sources
@@ -1500,7 +1498,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                                                      check_big_island_only=False,
                                                                                      rw2d_biggest_source=self._rw2d_biggest_source,
                                                                                      rw2d_source_fraction=self._rw2d_source_fraction)
-            segm_img_orig = copy.deepcopy(g_segm_img)
 
             # If the science field via the segmentation map is deemed crowded or has big sources/islands, compute the
             # RickerWavelet2DKernel and call detect_and_eval_segments() again. Still use the custom fwhm as it
@@ -1802,7 +1799,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # a final message for this particular total detection product and return.
             if segm_img is None:
                 log.warning("End processing for the segmentation catalog due to no sources detected with the current kernel.")
-                log.warning("No segmentation catalog will be produced for this total detection product, {}.".format(self.imgname))
+                log.warning("An empty catalog will be produced for this total detection product, {}.".format(self.imgname))
                 is_big_crowded = True
                 big_island = 1.0
                 source_fraction = 1.0
@@ -2004,6 +2001,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             log.info("image name: {}".format(self.imgname))
             log.info("Generating empty segment catalog.")
             log.info("")
+            self._define_empty_table(None)
 
             # Capture specified filter columns in order to append to the total detection table
             self.subset_filter_source_cat = Table(names=["ID", "MagAp2", "CI", "Flags"])

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1248,13 +1248,19 @@ class HAPPointCatalog(HAPCatalogBase):
         Nothing!
 
         """
-        if not reject_catalogs:
-            # Write out catalog to ecsv file
-            self.source_cat = self.annotate_table(self.source_cat, self.param_dict_qc, proc_type="aperture", product=self.image.ghd_product)
-            # self.source_cat.meta['comments'] = \
-            #     ["NOTE: The X and Y coordinates in this table are 0-indexed (i.e. the origin is (0,0))."]
-            self.source_cat.write(self.sourcelist_filename, format=self.catalog_format)
-            log.info("Wrote catalog file '{}' containing {} sources".format(self.sourcelist_filename, len(self.source_cat)))
+        # Insure catalog has all necessary metadata
+        self.source_cat = self.annotate_table(self.source_cat, self.param_dict_qc, proc_type="aperture",
+                                              product=self.image.ghd_product)
+        if reject_catalogs:
+            # We still want to write out empty files
+            # This will delete all rows from the existing table
+            self.source_cat.remove_rows(slice(0, None))
+
+        # Write out catalog to ecsv file
+        # self.source_cat.meta['comments'] = \
+        #     ["NOTE: The X and Y coordinates in this table are 0-indexed (i.e. the origin is (0,0))."]
+        self.source_cat.write(self.sourcelist_filename, format=self.catalog_format)
+        log.info("Wrote catalog file '{}' containing {} sources".format(self.sourcelist_filename, len(self.source_cat)))
 
         # Write out region file if in diagnostic_mode.
         if self.diagnostic_mode:
@@ -1667,7 +1673,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 # No segments were detected in the total data product - no further processing done for this TDP,
                 # but processing of another TDP should proceed.
                 elif not rw_segm_img:
-                    self._define_empty_table(segm_img)
+                    self._define_empty_table(rw_segm_img)
                     return
 
             # The first round custom/Gaussian segmentation image is good, continue with the processing
@@ -1679,7 +1685,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # No segments were detected in the total data product - no further processing done for this TDP,
             # but processing of another TDP should proceed.
             elif not g_segm_img:
-                self._define_empty_table(segm_img)
+                self._define_empty_table(g_segm_img)
                 return
 
             # Deblend the segmentation image

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -206,7 +206,8 @@ class HAPProduct:
                                                                      full_catalog=True)
 
                     # Add a weight column which is based upon proper motion measurements
-                    if ref_catalog.meta['converted'] and ref_catalog['RA_error'][0] != np.nan:
+                    if 'converted' in ref_catalog.meta and ref_catalog.meta['converted'] \
+                            and ref_catalog['RA_error'][0] != np.nan:
                         ref_weight = np.sqrt(ref_catalog['RA_error'] ** 2 + ref_catalog['DEC_error'] ** 2)
                         ref_weight = np.nan_to_num(ref_weight, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
                     else:


### PR DESCRIPTION
These changes insure that empty catalog files get written to disk when no sources are identified in either/both of the segment or point-source catalogs.  The changes also includes updates to the logic for rejecting both the point and source catalogs based on the HLA's algorithm implemented here in the 'verify_crthresh()' function so that if the catalogs are rejected, it simply deletes all the rows when writing them out.  This insures that catalogs ALWAYS get generated, even if empty. 

It was tested on data from 'ib2t06' and 'id7r03' (a case where sources were found).  