### PR TITLE
Add build-backend to pyproject.toml, to force PEP517 build (#1121)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = ["setuptools>=30.3.0", "wheel", "oldest-supported-numpy", "astropy"]
 
 [tool.stsci-bot]


### PR DESCRIPTION
Co-authored-by: Zane.Geiger <zgeiger@stsci.edu>