### PR TITLE
MVM: Insure SVM-derived WCS gets used as input to MVM processing

### DIFF
--- a/drizzlepac/devutils/search_skyframes.py
+++ b/drizzlepac/devutils/search_skyframes.py
@@ -101,7 +101,7 @@ def augment_results(results):
     # populate dateobs_list, path_list
     for idx in results.index:
         rootname = results.exposure[idx]
-        imgname = make_poller_files.locate_fitspath_from_rootname(rootname)
+        imgname = make_poller_files.locate_fitsfile(rootname)
         dateobs_list.append(fits.getval(imgname, "DATE-OBS"))
         path_list.append(imgname)
 

--- a/drizzlepac/devutils/search_skyframes.py
+++ b/drizzlepac/devutils/search_skyframes.py
@@ -305,7 +305,7 @@ if __name__ == '__main__':
     parser.add_argument('-f', '--spec', required=False, default="None",
                         help='Filter name(s) to search for. To search for ACS observations that use two '
                              'spectral elements, enter the names of both spectral elements in any order '
-                             'seperated by a dash. Example two-spectral element input: f606w-pol60v')
+                             'separated by a dash. Example two-spectral element input: f606w-pol60v')
     parser.add_argument('-m', '--master_observations_file', required=False,
                         default=os.getenv("ALL_EXP_FILE"),
                         help='Name of the master observations .csv file containing comma-separated columns '

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -27,7 +27,6 @@ import datetime
 import fnmatch
 import logging
 import os
-import pdb
 import pickle
 import sys
 import traceback

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -27,6 +27,7 @@ import datetime
 import fnmatch
 import logging
 import os
+import pdb
 import pickle
 import sys
 import traceback

--- a/drizzlepac/haputils/make_poller_files.py
+++ b/drizzlepac/haputils/make_poller_files.py
@@ -60,7 +60,7 @@ def generate_poller_file(input_list, poller_file_type='svm', output_poller_filen
         imghdu = fits.open(fullfilepath)
         imghdr = imghdu[0].header
         linelist.append("{}".format(imghdr['proposid']))
-        linelist.append(imgname[1:4].upper())
+        linelist.append(imgname.split("_")[-2][1:4].upper())
         linelist.append(imghdr['linenum'].split(".")[0])
         linelist.append("{}".format(imghdr['exptime']))
         if imghdr['INSTRUME'].lower() == "acs":
@@ -70,7 +70,10 @@ def generate_poller_file(input_list, poller_file_type='svm', output_poller_filen
         linelist.append(filter.upper())
         linelist.append(imghdr['detector'].upper())
         if poller_file_type == 'mvm':  # Additional stuff to add to MVM poller files
-            linelist.append("skycell-{}".format(skycell_name))
+            if skycell_name.startswith("skycell-"):
+                linelist.append("{}".format(skycell_name))
+            if skycell_name.startswith("p"):
+                linelist.append("skycell-{}".format(skycell_name))
             linelist.append("NEW")
         linelist.append(fullfilepath)
         imghdu.close()

--- a/drizzlepac/haputils/make_poller_files.py
+++ b/drizzlepac/haputils/make_poller_files.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """Makes .out files used as input to runsinglehap.py, runmultihap.py based on the files or rootnames listed
-user-specifed list file."""
+user-specified list file."""
 
 import argparse
 import os
@@ -12,6 +12,7 @@ from astropy.io import fits
 from drizzlepac.haputils import poller_utils
 
 __taskname__ = 'make_poller_files'
+
 
 def generate_poller_file(input_list, poller_file_type='svm', output_poller_filename="poller_file.out",
                          skycell_name=None):

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -651,7 +651,7 @@ def parse_obset_tree(det_tree, log_level):
                 # easier for the user by having the same WCS in both the direct and
                 # Grism/Prism products.
                 #
-                # The GrismExposureProduct is only an attibutes of the TotalProduct.
+                # The GrismExposureProduct is only an attribute of the TotalProduct.
                 prod_list = prod_info.split(" ")
 
                 # Determine if this image is a Grism/Prism or a nominal direct exposure
@@ -659,8 +659,9 @@ def parse_obset_tree(det_tree, log_level):
                 if prod_list[5].lower().find('g') != -1 or prod_list[5].lower().find('pr') != -1:
                     is_grism = True
                     filt_indx -= 1
-                    grism_sep_obj = GrismExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
-                                                         filename[1], prod_list[5], prod_list[6], log_level)
+                    grism_sep_obj = GrismExposureProduct(prod_list[0], prod_list[1], prod_list[2],
+                                                         prod_list[3], filename[1], prod_list[5],
+                                                         prod_list[6], log_level)
                 else:
                     sep_obj = ExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
                                               filename[1], prod_list[5], prod_list[6], log_level)
@@ -1199,7 +1200,8 @@ def add_primary_fits_header_as_attr(hap_obj, log_level=logutil.logging.NOTSET):
         object to update
 
     log_level : int, optional.
-        The desired level of verboseness in the log statements displayed on the screen and written to the .log file.
+        The desired level of verboseness in the log statements displayed on the screen and written to the
+        .log file.
 
     Returns
     -------

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -309,7 +309,21 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
     # Now create the output product objects
     log.debug("Parse the observation set tree and create the exposure, filter, and total detection objects.")
     obset_dict, tdp_list = parse_mvm_tree(obset_tree, all_mvm_exposures, log_level)
+    for key in vars(tdp_list[0]).keys():
+        try:
+            print("vars(tdp_list[0])[{}]: {}".format(key, vars(tdp_list[0])[key]))
+        except:
+            print("vars(tdp_list[0])[{}]: {}".format(key, "MISSING"))
+    print("\n")
+    for key in vars(tdp_list[0]).keys():
+        try:
+            print("vars(tdp_list[0].edp_list[0])[{}]: {}".format(key, vars(tdp_list[0].edp_list[0])[key]))
+        except:
+            print("vars(tdp_list[0].edp_list[0])[{}]: {}".format(key, "MISSING"))
 
+    #
+    print("\a\a")
+    pdb.set_trace()
     # Now we need to merge any pre-existing layer products with the new products
     # This will add the exposure products from the pre-existing definitions of
     # the overlapping sky cell layers with those defined for the new exposures
@@ -458,7 +472,7 @@ def parse_mvm_tree(det_tree, all_mvm_exposures, log_level):
                 # Parse the first filename[1] to determine if the products are flt or flc
                 if det_indx != prev_det_indx:
                     filetype = "drc"
-                    if filename[1][10:13].lower().endswith("flt"):
+                    if filename[1][-8:-5].lower().endswith("flt"):
                         filetype = "drz"
                     prev_det_indx = det_indx
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -7,6 +7,7 @@ parse_obset_tree, converts the tree into product catagories.
 """
 from collections import OrderedDict
 import os
+import pdb
 import shutil
 import sys
 
@@ -283,7 +284,7 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
         obset_table = copy.deepcopy(user_table)
 
     # Add INSTRUMENT column
-    instr = [INSTRUMENT_DICT[fname[0]] for fname in obset_table['filename']]
+    instr = [INSTRUMENT_DICT[fname.split("_")[-2][0]] for fname in obset_table['filename']]
     # convert input to an Astropy Table for parsing
     obset_table.add_column(Column(instr, name='instrument'))
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -309,21 +309,7 @@ def interpret_mvm_input(results, log_level, layer_method='all', exp_limit=2.0, u
     # Now create the output product objects
     log.debug("Parse the observation set tree and create the exposure, filter, and total detection objects.")
     obset_dict, tdp_list = parse_mvm_tree(obset_tree, all_mvm_exposures, log_level)
-    for key in vars(tdp_list[0]).keys():
-        try:
-            print("vars(tdp_list[0])[{}]: {}".format(key, vars(tdp_list[0])[key]))
-        except:
-            print("vars(tdp_list[0])[{}]: {}".format(key, "MISSING"))
-    print("\n")
-    for key in vars(tdp_list[0]).keys():
-        try:
-            print("vars(tdp_list[0].edp_list[0])[{}]: {}".format(key, vars(tdp_list[0].edp_list[0])[key]))
-        except:
-            print("vars(tdp_list[0].edp_list[0])[{}]: {}".format(key, "MISSING"))
 
-    #
-    print("\a\a")
-    pdb.set_trace()
     # Now we need to merge any pre-existing layer products with the new products
     # This will add the exposure products from the pre-existing definitions of
     # the overlapping sky cell layers with those defined for the new exposures

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -7,7 +7,6 @@ parse_obset_tree, converts the tree into product catagories.
 """
 from collections import OrderedDict
 import os
-import pdb
 import shutil
 import sys
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -910,8 +910,11 @@ class SkyCellExposure(HAPProduct):
                 New MVM-compatible HAP filename for input exposure
 
         """
-        suffix = filename.split("_")[1]
-        sce_filename = '_'.join([self.product_basename, suffix])
+        if filename.startswith("hst"):
+            sce_filename = "{}_{}".format(self.product_basename, filename.split("_")[-1])
+        else:
+            suffix = filename.split("_")[1]
+            sce_filename = '_'.join([self.product_basename, suffix])
         log.info("Copying {} to MVM input: \n    {}".format(filename, sce_filename))
         try:
             shutil.copy(filename, sce_filename)

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -14,6 +14,7 @@ import copy
 import logging
 import sys
 import os
+import pdb
 import traceback
 import shutil
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -1078,9 +1078,7 @@ class SkyCellProduct(HAPProduct):
                   .format(meta_wcs, self.trl_logname))
 
         edp_filenames = [element.full_filename for element in self.edp_list]
-        print(edp_filenames)
-        import pdb
-        pdb.set_trace()
+
         astrodrizzle.AstroDrizzle(input=edp_filenames,
                                   output=self.drizzle_filename,
                                   **drizzle_pars)

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -14,7 +14,6 @@ import copy
 import logging
 import sys
 import os
-import pdb
 import traceback
 import shutil
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -795,10 +795,14 @@ class SkyCellExposure(HAPProduct):
         # layer: [filter_str, pscale_str, exptime_str, epoch_str]
         # e.g.: [f160w, coarse, all, all]
         #
-        if layer[1] == 'coarse':
-            layer_vals = [layer[1], layer[2], self.exposure_name]
+        if filename.startswith("hst"):
+            exposure_name = filename.split("_")[-2]
         else:
-            layer_vals = ['all', self.exposure_name]
+            exposure_name = self.exposure_name
+        if layer[1] == 'coarse':
+            layer_vals = [layer[1], layer[2], exposure_name]
+        else:
+            layer_vals = ['all', exposure_name]
         layer_str = '-'.join(layer_vals)
 
         cell_id = "p{}{}".format(prop_id, obset_id)

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -1078,6 +1078,9 @@ class SkyCellProduct(HAPProduct):
                   .format(meta_wcs, self.trl_logname))
 
         edp_filenames = [element.full_filename for element in self.edp_list]
+        print(edp_filenames)
+        import pdb
+        pdb.set_trace()
         astrodrizzle.AstroDrizzle(input=edp_filenames,
                                   output=self.drizzle_filename,
                                   **drizzle_pars)

--- a/drizzlepac/haputils/which_skycell.py
+++ b/drizzlepac/haputils/which_skycell.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Returns the name(s) of the projection cell(s)/skycell(s) that the observations in the user-specified input
+ file occupy."""
+
+import argparse
+import glob
+import os
+import pdb
+import sys
+
+from drizzlepac.haputils import cell_utils
+
+
+__version__ = 0.1
+__version_date__ = '08-Sept-2021'
+# ------------------------------------------------------------------------------------------------------------
+
+def identify_pc_sc(img_list):
+    """identifies the projection cell(s) and skycell(s) that the observations in the user-specified input
+    list occupy.
+
+    Parameters
+    ----------
+    img_list : list
+        list of the images to process
+
+    Returns
+    -------
+    Nothing!
+    """
+    skycell_dict = cell_utils.get_sky_cells(img_list)
+    print("\n")
+    for skycell_name in skycell_dict.keys():
+        print("Skycell {} contains {} image(s)".format(skycell_name, len(skycell_dict[skycell_name].members)))
+        for imgname in skycell_dict[skycell_name].members:
+            print("     {}".format(imgname))
+        print("\n")
+
+# ------------------------------------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='identifies the projection cell(s) and skycell(s) that the '
+                                                 'user-specified observations occupy')
+    parser.add_argument('-i', '--input_list', required=False, default="NONE",
+                        help='Name of a file containing a list of calibrated fits files (ending with '
+                             '"_flt.fits" or "_flc.fits") to process. If not explicitly specified, all '
+                             'flc/flt fits files in the current working directory will be processed.')
+    in_args = parser.parse_args()
+    if in_args.input_list is "NONE":
+        img_list = glob.glob("*_fl?.fits")
+        if len(img_list) > 0:
+            identify_pc_sc(img_list)
+        else:
+            sys.exit("ERROR: No flc/flt fits files found in current path {}/".format(os.getcwd()))
+    elif os.path.exists(in_args.input_list):
+        with open(sys.argv[1]) as fin:
+            img_list = fin.read().splitlines()
+        identify_pc_sc(img_list)
+    else:
+        sys.exit("ERROR: Input file {} does not exist!".format(in_args.input_list))

--- a/drizzlepac/haputils/which_skycell.py
+++ b/drizzlepac/haputils/which_skycell.py
@@ -15,9 +15,9 @@ __version_date__ = '08-Sept-2021'
 # ------------------------------------------------------------------------------------------------------------
 
 
-def identify_pc_sc(img_list):
-    """identifies the projection cell(s) and skycell(s) that the observations in the user-specified input
-    list occupy.
+def report_skycells(img_list):
+    """reports the names of the projection cell(s)/skycell(s) that the observations in the user-specified
+    input list occupy.
 
     Parameters
     ----------
@@ -50,12 +50,12 @@ if __name__ == '__main__':
     if in_args.input_list is "NONE":
         img_list = glob.glob("*_fl?.fits")
         if len(img_list) > 0:
-            identify_pc_sc(img_list)
+            report_skycells(img_list)
         else:
             sys.exit("ERROR: No flc/flt fits files found in current path {}/".format(os.getcwd()))
     elif os.path.exists(in_args.input_list):
         with open(sys.argv[1]) as fin:
             img_list = fin.read().splitlines()
-        identify_pc_sc(img_list)
+        report_skycells(img_list)
     else:
         sys.exit("ERROR: Input file {} does not exist!".format(in_args.input_list))

--- a/drizzlepac/haputils/which_skycell.py
+++ b/drizzlepac/haputils/which_skycell.py
@@ -5,7 +5,6 @@
 import argparse
 import glob
 import os
-import pdb
 import sys
 
 from drizzlepac.haputils import cell_utils

--- a/drizzlepac/haputils/which_skycell.py
+++ b/drizzlepac/haputils/which_skycell.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Returns the name(s) of the projection cell(s)/skycell(s) that the observations in the user-specified input
+"""Reports the name(s) of the projection cell(s)/skycell(s) that the observations in the user-specified input
  file occupy."""
 
 import argparse

--- a/drizzlepac/haputils/which_skycell.py
+++ b/drizzlepac/haputils/which_skycell.py
@@ -14,6 +14,7 @@ __version__ = 0.1
 __version_date__ = '08-Sept-2021'
 # ------------------------------------------------------------------------------------------------------------
 
+
 def identify_pc_sc(img_list):
     """identifies the projection cell(s) and skycell(s) that the observations in the user-specified input
     list occupy.

--- a/drizzlepac/make_custom_mosaic.py
+++ b/drizzlepac/make_custom_mosaic.py
@@ -177,7 +177,7 @@ def create_poller_file(img_list, proj_cell_dict):
     poller_filename = "temp_{}_mvm.out".format(skycell_name)
     rootname_list = []
     for imgname in img_list:
-        rootname_list.append(imgname.split("_")[0]+"\n")
+        rootname_list.append(imgname+"\n")
     tf = tempfile.NamedTemporaryFile(mode='w+t', dir=os.getcwd())
     with open(tf.name, 'w') as f:
         f.writelines(rootname_list)


### PR DESCRIPTION
**Related JIRA Ticket**
- [HLA-598](https://jira.stsci.edu/browse/HLA-598)

**High-level Summary**
- Modified MVM pipeline code so that it can process both non-pipeline-processed flc/flt fits files (as it did previously) and SVM pipeline-processed flc/flt fits files as well. This gives the MVM pipeline the ability to utilize the WCS solutions that were previously derived by the SVM pipeline.   The vast majority of the changes were to account for the differences in the filename formatting between the SVM pipeline-processed  and the non-SVM pipeline-processed input flc/flt fits files. 

**Additional Code Additions**
- Added new script which_skycell.py. This script is basically just a command-line interface for cell_utils.get_sky_cells() and as the name of the script suggests, allows users to determine which skycell(s) a given set of observations occupy.
