### PR TITLE
Minimize use of fitting for shift only

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -832,7 +832,6 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_lev
             pickle.dump(pickle_dict, pickle_out)
             pickle_out.close()
             log.info("Wrote hla_flag_filter param pickle file {} ".format(out_pickle_filename))
-
         # TODO: REMOVE ABOVE CODE ONCE FLAGGING PARAMS ARE OPTIMIZED
         if catalog_data is not None and len(catalog_data) > 0:
              source_cat = hla_flag_filter.run_source_list_flagging(drizzled_image,

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -175,7 +175,7 @@ class AlignmentTable:
                     log.info("Recomputing BACKGROUND after applying single-image CR clean")
                     for chip in range(1, catimg.num_sci + 1):
                         sciarr = amutils.crclean_image(catimg.imghdu[("SCI", chip)].data, catimg.threshold[chip],
-                                                       catimg.kernel, catimg.kernel_fwhm)
+                                                       catimg.kernel, catimg.kernel_fwhm, background=catimg.bkg[chip])
                         catimg.imghdu[("SCI", chip)].data = sciarr
                     # recompute now that the CRs have been removed (set to 0) from the science arrays
                     catimg.compute_background(box_size=self.alignment_pars['box_size'],

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -184,7 +184,9 @@ class AlignmentTable:
                                               bkg_estimator=self.alignment_pars['bkg_estimator'],
                                               rms_estimator=self.alignment_pars['rms_estimator'],
                                               threshold_flag=self.alignment_pars['threshold'])
+                    log.info("Finished computing revised BACKROUND")
                     catimg.build_kernel(fwhmpsf)
+                    log.info("Finished determining revised kernel")
 
                 # Use FWHM from first good exposure as default for remainder of exposures
                 if not default_fwhm_set and catimg.kernel is not None:

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -20,6 +20,7 @@ import inspect
 import sys
 import time
 from distutils.version import LooseVersion
+import copy
 
 import numpy as np
 import scipy.stats as st
@@ -1159,31 +1160,49 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
     return tbl, segm, dqmap
 
 
-def crclean_image(imgarr, segment_threshold, kernel, fwhm, source_box=7):
+def crclean_image(imgarr, segment_threshold, kernel, fwhm,
+                  source_box=7, deblend=False):
+    """ Apply moments-based single-image CR clean algorithm to image
 
+    Returns
+    -------
+    imgarr : ndarray
+        Input array with pixels flagged as CRs set to 0.0
+    """
+    # Perform basic image segmentation to look for sources in image
     segm = detect_sources(imgarr, segment_threshold, npixels=source_box,
                           filter_kernel=kernel, connectivity=4)
 
+    log.debug("Detected {} sources of all types ".format(segm.nlabels))
     # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0
     if segm is None or segm.nlabels == 0:
         log.info("No sources to identify as cosmic-rays!")
         return imgarr
 
-    segm = deblend_sources(imgarr, segm, npixels=5,
+    if deblend:
+        segm = deblend_sources(imgarr, segm, npixels=5,
                                filter_kernel=kernel, nlevels=32,
                                contrast=0.01)
 
+    # Measure segment sources to compute centralized moments for each source
     cat = SourceCatalog(imgarr, segm)
     # Remove likely cosmic-rays based on central_moments classification
-    bad_srcs = np.where(classify_sources(cat, fwhm) == 0)[0]
+    bad_srcs = classify_sources(cat, fwhm)
+    # Get the label IDs for sources flagged as CRs, IDs are 1-based not 0-based
+    bad_ids = np.where(bad_srcs == 0)[0] + 1
+    log.debug("Recognized {} sources as cosmic-rays".format(len(bad_ids)))
 
-    # segm.remove_labels(bad_srcs)
     # Instead of ignoring them by removing them from the catalog
     # zero all these sources out from the image itself.
-    for src in bad_srcs:
-        src_slice = segm.segments[src].slices
-        src_mask = (np.clip(segm.segments[src], 0, 1) == 1)
-        imgarr[src_slice][src_mask] = 0.0  # segment_threshold[src_slice][src_mask]
+    # Create a mask from the segmentation image with only the flagged CRs
+    cr_segm = copy.deepcopy(segm)
+    cr_segm.keep_labels(bad_ids)
+    cr_mask = np.where(cr_segm.data > 0)
+    # Use the mask to multiply all pixels associated with the CRs by 0.0
+    imgarr[cr_mask] *= 0.0
+    del cr_segm
+
+    log.debug("Finshed zeroing out cosmic-rays")
 
     return imgarr
 
@@ -1210,29 +1229,29 @@ def classify_sources(catalog, fwhm, sources=None):
         An ndarray where a value of 1 indicates a likely valid, non-cosmic-ray
         source, and a value of 0 indicates a likely cosmic-ray.
     """
-    moments = catalog.moments_central
-    semiminor_axis = catalog.semiminor_sigma
-    elon = catalog.elongation
+    # All these return ndarray objects
+    moments = catalog.moments_central  # (num_sources, 4, 4)
+    semiminor_axis = catalog.semiminor_sigma.to_value()  # (num_sources,)
+    elon = catalog.elongation.to_value()  # (num_sources,)
+    # Determine how many sources we have.
     if sources is None:
         sources = (0, len(moments))
     num_sources = sources[1] - sources[0]
     srctype = np.zeros((num_sources,), np.int32)
-    for src in range(sources[0], sources[1]):
-        # Protect against spurious detections
-        src_x = catalog[src].xcentroid
-        src_y = catalog[src].ycentroid
-        if np.isnan(src_x) or np.isnan(src_y):
-            continue
-        # This identifies moment of maximum value
-        x, y = np.where(moments[src] == moments[src].max())
-        valid_src = (x[0] > 1) and (y[0] > 1)
-        # These look for CR streaks (not delta CRs)
-        valid_width = semiminor_axis[src].value < (0.75 * fwhm)  # skinny source
-        valid_elon = elon[src].value > 2  # long source
-        valid_streak = valid_width and valid_elon  # long and skinny...
-        # If either a delta CR or a CR streak are identified, remove it
-        if valid_src and not valid_streak:
-            srctype[src] = 1
+
+    mx = np.array([np.where(moments[src] == moments[src].max())[0][0] for src in range(num_sources)], np.int32)
+    my = np.array([np.where(moments[src] == moments[src].max())[1][0] for src in range(num_sources)], np.int32)
+    src_x = catalog.xcentroid  # (num_sources, )
+    src_y = catalog.ycentroid  # (num_sources, )
+    valid_xy = ~np.bitwise_or(np.isnan(src_x), np.isnan(src_y))
+
+    valid_src = np.bitwise_and(mx > 1, my > 1)[valid_xy]
+    valid_width = (semiminor_axis < (0.75 * fwhm))[valid_xy]
+    valid_elon = (elon > 2)[valid_xy]
+    valid_streak = ~np.bitwise_and(valid_width, valid_elon)
+    src_cr = np.bitwise_and(valid_src, valid_streak)
+    srctype[src_cr] = 1
+
     return srctype
 
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -295,6 +295,7 @@ def create_astrometric_catalog(inputs, catalog="GAIAedr3", output="ref_cat.ecsv"
     ref_table.meta['catalog'] = catalog
     ref_table.meta['gaia_only'] = gaia_only
     ref_table.meta['epoch'] = epoch
+    ref_table.meta['converted'] = False
 
     # Convert common set of columns into standardized column names
     convert_astrometric_table(ref_table, catalog)

--- a/drizzlepac/haputils/astroquery_utils.py
+++ b/drizzlepac/haputils/astroquery_utils.py
@@ -47,6 +47,17 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False,
     clobber : Boolean, optional
         Download and Overwrite existing files? Default is "False".
 
+    product_type : str, optional
+        Specify what type of product you want from the archive, either 'pipeline'
+        or 'HAP' or 'both' (default).  By default, all versions of the products
+        processed for the requested datasets will be returned.  This would include:
+          - pipeline : files processed by `runastrodriz` to include the latest
+                       distortion calibrations and the best possible alignment to GAIA
+                       with `ipppssoot_fl[tc].fits` filenames for FLT/FLC files.
+          - HAP : files processed as a single visit and aligned (as possible) to GAIA
+                  with `hst_<propid>_<visit>_<instr>_<det>_<filter>_<ipppssoo>_fl[tc].fits`
+                  filenames.
+
     Returns
     -------
     local_files : list

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1686,7 +1686,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 self._define_empty_table(g_segm_img)
                 return
 
-            # Deblend the segmentation image sources that are larger than the PSF kernel
+            # Deblend the segmentation image
             ncount += 1
             segm_img = self.deblend_segments(segm_img,
                                              imgarr,

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1498,6 +1498,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                                                      check_big_island_only=False,
                                                                                      rw2d_biggest_source=self._rw2d_biggest_source,
                                                                                      rw2d_source_fraction=self._rw2d_source_fraction)
+            segm_img_orig = copy.deepcopy(g_segm_img)
 
             # If the science field via the segmentation map is deemed crowded or has big sources/islands, compute the
             # RickerWavelet2DKernel and call detect_and_eval_segments() again. Still use the custom fwhm as it

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1842,14 +1842,13 @@ class HAPSegmentCatalog(HAPCatalogBase):
         """
 
         log.info("Computing the threshold value used for source detection.")
-
         if not self.tp_masks:
             threshold = bkg_mean + (nsigma * bkg_rms)
         else:
             threshold = np.zeros_like(self.tp_masks[0]['rel_weight'])
             log.info("Using WHT masks as a scale on the RMS to compute threshold detection limit.")
             for wht_mask in self.tp_masks:
-                threshold_rms = bkg_rms * np.sqrt(wht_mask['mask'] / wht_mask['rel_weight'].max())
+                threshold_rms = bkg_rms * np.sqrt(wht_mask['scale'] * wht_mask['mask'] / wht_mask['rel_weight'].max())
                 threshold_rms_median = np.nanmedian(threshold_rms[threshold_rms > 0])
                 threshold_item = bkg_mean + (nsigma * threshold_rms_median)
                 threshold += threshold_item

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -22,7 +22,7 @@
     {
       "box_size":27,
       "win_size":3,
-      "nsigma":5.0,
+      "nsigma":3.0,
       "centering_mode": "starfind",
       "bkg_estimator": "MedianBackground",
       "rms_estimator": "StdBackgroundRMS",

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -29,7 +29,7 @@
       "num_sources": 250,
       "deblend": false,
       "fwhmpsf": 0.13,
-      "classify": true,
+      "classify": false,
       "threshold": -1.1
     },
   "generate_astrometric_catalog":

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -22,7 +22,7 @@
     {
       "box_size":27,
       "win_size":3,
-      "nsigma":5.0,
+      "nsigma":3.0,
       "centering_mode": "starfind",
       "bkg_estimator": "MedianBackground",
       "rms_estimator": "StdBackgroundRMS",

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -22,7 +22,7 @@
       {
         "box_size":27,
         "win_size":3,
-        "nsigma":5.0,
+        "nsigma":3.0,
         "centering_mode": "starfind",
         "bkg_estimator": "SExtractorBackground",
         "rms_estimator": "StdBackgroundRMS",

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -22,7 +22,7 @@
       {
         "box_size":27,
         "win_size":3,
-        "nsigma":5.0,
+        "nsigma":3.0,
         "centering_mode": "starfind",
         "bkg_estimator": "MedianBackground",
         "rms_estimator": "StdBackgroundRMS",

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -27,7 +27,7 @@
         "bkg_estimator": "SExtractorBackground",
         "rms_estimator": "StdBackgroundRMS",
         "num_sources": 500,
-        "deblend": true,
+        "deblend": false,
         "fwhmpsf": 0.13,
         "classify": true,
         "threshold": -1.1

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -22,12 +22,12 @@
       {
         "box_size":27,
         "win_size":3,
-        "nsigma":5.0,
+        "nsigma":3.0,
         "centering_mode": "starfind",
         "bkg_estimator": "SExtractorBackground",
         "rms_estimator": "StdBackgroundRMS",
         "num_sources": 500,
-        "deblend": false,
+        "deblend": true,
         "fwhmpsf": 0.13,
         "classify": true,
         "threshold": -1.1


### PR DESCRIPTION
These changes update the logic used for fitting to an astrometric catalog to limit when minobj < 4 to only those cases where only 4 or less sources are identified in the input images to start with.  This eliminates cases when too many sources in the input image are identified and a fit to 'shift' only (nmatches=1) results in mis-identified cross-matched sources leading to errors being introduced in the relative alignment of the images.  The goal of this PR is to only allow "fitting to GAIA" when the chance of confusion and mistakes in cross-identification are minimized in order to preserve relative alignment.  

