### PR TITLE
Function mvm_analyze_wrapper determines the viability of an image for MVM processing

### DIFF
--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -56,7 +56,7 @@ class Messages(Enum):
     OK, WARN, NOPROC = 1, -1, -2
 
 
-def mvm_analyze_wrapper(input_filename, log_level=logutil.logging.DEBUG):
+def mvm_analyze_wrapper(input_filename, log_level=logutil.logging.NOTSET):
     """
     Thin wrapper for the analyze_data function to return a viability indicator regarding a image for MVM processing.
 


### PR DESCRIPTION
Added a new function, mvm_analyze_wrapper, which uses the functionality in the underlying
analyze_data routine to examine FITS keywords and determine the viability of the data to
be used in the MVM processing.  The mvm_analyze_wrapper works on a single image at a time.
Added an optional parameter to analyze_data so the routine can determine when MVM processing
is wanted as MVM processing does not allow anything to be done for GRISM/PRISM images.
Updated doc strings.