### PR TITLE
MVM: Make alignment to GAIA optional

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -246,7 +246,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=False, diagnostic_mod
         part of the multi-visit.
 
     skip_gaia_alignment : bool, optional
-        Skip alignment of all input images to known Gaia/HSC sources in the FOV as reference sources? If set
+        Skip alignment of all input images to known Gaia/HSC sources in the input image footprint? If set to
         'True', The existing input image alignment solution will be used instead. The default is False.
 
     diagnostic_mode : bool, optional

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -247,7 +247,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=False, diagnostic_mod
 
     skip_gaia_alignment : bool, optional
         Skip alignment of all input images to known Gaia/HSC sources in the input image footprint? If set to
-        'True', The existing input image alignment solution will be used instead. The default is False.
+        'True', the existing input image alignment solution will be used instead. The default is False.
 
     diagnostic_mode : bool, optional
         Allows printing of additional diagnostic information to the log.  Also, can turn on

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -231,9 +231,10 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_configs=True,
-                       input_custom_pars_file=None, output_custom_pars_file=None, phot_mode="both",
-                       custom_limits=None, output_file_prefix=None, log_level=logutil.logging.INFO):
+def run_mvm_processing(input_filename, skip_gaia_alignment=False, diagnostic_mode=False,
+                       use_defaults_configs=True, input_custom_pars_file=None, output_custom_pars_file=None,
+                       phot_mode="both", custom_limits=None, output_file_prefix=None,
+                       log_level=logutil.logging.INFO):
 
     """Run the HST Advanced Products (HAP) generation code.  This routine is the sequencer or
     controller which invokes the high-level functionality to process the multi-visit data.
@@ -243,6 +244,10 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
     input_filename: string
         The 'poller file' where each line contains information regarding an exposures considered
         part of the multi-visit.
+
+    skip_gaia_alignment : bool, optional
+        Skip alignment of all input images to known Gaia/HSC sources in the FOV as reference sources? If set
+        'True', The existing input image alignment solution will be used instead. The default is False.
 
     diagnostic_mode : bool, optional
         Allows printing of additional diagnostic information to the log.  Also, can turn on
@@ -355,11 +360,15 @@ def run_mvm_processing(input_filename, diagnostic_mode=False, use_defaults_confi
         log.info("The configuration parameters have been read and applied to the drizzle objects.")
 
         # TODO: This is the place where updated WCS info is migrated from drizzlepac params to filter objects
-
-        reference_catalog = run_align_to_gaia(total_obj_list, custom_limits=custom_limits,
-                                              log_level=log_level, diagnostic_mode=diagnostic_mode)
-        if reference_catalog:
-            product_list += [reference_catalog]
+        if skip_gaia_alignment:
+            log.info("Gaia alignment step skipped. Existing input image alignment solution will be used instead.")
+        else:
+            reference_catalog = run_align_to_gaia(total_obj_list,
+                                                  custom_limits=custom_limits,
+                                                  log_level=log_level,
+                                                  diagnostic_mode=diagnostic_mode)
+            if reference_catalog:
+                product_list += [reference_catalog]
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))

--- a/drizzlepac/make_custom_mosaic.py
+++ b/drizzlepac/make_custom_mosaic.py
@@ -313,7 +313,7 @@ def determine_projection_cell(img_list):
 # ------------------------------------------------------------------------------------------------------------
 
 
-def perform(input_image_source, log_level='info', output_file_prefix=None):
+def perform(input_image_source, log_level='info', output_file_prefix=None, skip_gaia_alignment=False):
     """Main calling subroutine
 
     Parameters
@@ -339,6 +339,10 @@ def perform(input_image_source, log_level='info', output_file_prefix=None):
         that the "<n|s>" denotes if the declination is north (positive) or south (negative). Example: For
         skycell = 1974, ra = 201.9512, and dec = +26.0012, The filename prefix would be
         "skycell-p1974-ra201d9512-decn26d0012".
+
+    skip_gaia_alignment : bool, optional
+        Skip alignment of all input images to known Gaia/HSC sources in the input image footprint? If set to
+        'True', The existing input image alignment solution will be used instead. The default is False.
 
     Returns
     -------
@@ -384,7 +388,8 @@ def perform(input_image_source, log_level='info', output_file_prefix=None):
         return_value = hapmultisequencer.run_mvm_processing(poller_filename,
                                                             custom_limits=custom_limits,
                                                             log_level=logging_level,
-                                                            output_file_prefix=output_file_prefix)
+                                                            output_file_prefix=output_file_prefix,
+                                                            skip_gaia_alignment=skip_gaia_alignment)
 
     except Exception:
         if return_value == 0:
@@ -443,8 +448,15 @@ def main():
                              'Note that the "<n|s>" denotes if the declination is north (positive) or south '
                              '(negative). Example: For skycell = 1974, ra = 201.9512, and dec = +26.0012, '
                              'The filename prefix would be "skycell-p1974-ra201d9512-decn26d0012".')
+    parser.add_argument('-s', '--skip_gaia_alignment', required=False, action='store_true',
+                        help='Skip alignment of all input images to known Gaia/HSC sources in the input '
+                             'image footprint? This option is turned on, the existing input image alignment '
+                             'solution will be used instead. The default is False.')
     user_args = parser.parse_args()
-    return_value = perform(user_args.input_image_source, user_args.log_level, user_args.output_file_prefix)
+    return_value = perform(user_args.input_image_source,
+                           log_level=user_args.log_level,
+                           output_file_prefix=user_args.output_file_prefix,
+                           skip_gaia_alignment=user_args.skip_gaia_alignment)
 # ------------------------------------------------------------------------------------------------------------
 
 

--- a/drizzlepac/make_custom_mosaic.py
+++ b/drizzlepac/make_custom_mosaic.py
@@ -450,8 +450,8 @@ def main():
                              'The filename prefix would be "skycell-p1974-ra201d9512-decn26d0012".')
     parser.add_argument('-s', '--skip_gaia_alignment', required=False, action='store_true',
                         help='Skip alignment of all input images to known Gaia/HSC sources in the input '
-                             'image footprint? This option is turned on, the existing input image alignment '
-                             'solution will be used instead. The default is False.')
+                             'image footprint? If this option is turned on, the existing input image '
+                             'alignment solution will be used instead. The default is False.')
     user_args = parser.parse_args()
     return_value = perform(user_args.input_image_source,
                            log_level=user_args.log_level,

--- a/drizzlepac/runmultihap.py
+++ b/drizzlepac/runmultihap.py
@@ -105,8 +105,9 @@ def main():
                              'specifying "error" will record/display both "error" and "critical" log '
                              'statements, and so on.')
     parser.add_argument('-s', '--skip_gaia_alignment', required=False, action='store_true',
-                        help='If this option is turned on, additional log messages will be displayed and '
-                             'additional files will be created during the course of the run.')
+                        help='Skip alignment of all input images to known Gaia/HSC sources in the input '
+                             'image footprint? This option is turned on, the existing input image alignment '
+                             'solution will be used instead. The default is False.')
     user_args = parser.parse_args()
 
     print("Multi-visit processing started for: {}".format(user_args.input_filename))

--- a/drizzlepac/runmultihap.py
+++ b/drizzlepac/runmultihap.py
@@ -106,8 +106,8 @@ def main():
                              'statements, and so on.')
     parser.add_argument('-s', '--skip_gaia_alignment', required=False, action='store_true',
                         help='Skip alignment of all input images to known Gaia/HSC sources in the input '
-                             'image footprint? This option is turned on, the existing input image alignment '
-                             'solution will be used instead. The default is False.')
+                             'image footprint? If this option is turned on, the existing input image '
+                             'alignment solution will be used instead. The default is False.')
     user_args = parser.parse_args()
 
     print("Multi-visit processing started for: {}".format(user_args.input_filename))

--- a/drizzlepac/runmultihap.py
+++ b/drizzlepac/runmultihap.py
@@ -104,12 +104,16 @@ def main():
                              'Specifying "critical" will only record/display "critical" log statements, and '
                              'specifying "error" will record/display both "error" and "critical" log '
                              'statements, and so on.')
+    parser.add_argument('-s', '--skip_gaia_alignment', required=False, action='store_true',
+                        help='If this option is turned on, additional log messages will be displayed and '
+                             'additional files will be created during the course of the run.')
     user_args = parser.parse_args()
 
     print("Multi-visit processing started for: {}".format(user_args.input_filename))
     rv = perform(user_args.input_filename,
                  diagnostic_mode=user_args.diagnostic_mode,
-                 log_level=user_args.log_level)
+                 log_level=user_args.log_level,
+                 skip_gaia_alignment=user_args.skip_gaia_alignment)
     print("Return Value: ", rv)
     return rv
 


### PR DESCRIPTION
**Relevant Ticket:**
- [HLA-617](https://jira.stsci.edu/browse/HLA-617)

**Summary of Changes:**
- hapmultisequencer.py: 
  - added logic to run_mvm_processing() to optionally skip execution of run_align_to_gaia().
  - Added new optional subroutine input 'skip_gaia_alignment' in run_mvm_processing() to control the new feature.
- runmultihap.py: added new optional command-line switch to allow users to skip gaia alignment of input images
- make_custom_mosaic.py: updated code to support new "skip_gaia_alignment" functionality in hapmultisequencer.