### PR TITLE
Add FWHM measurement to the output Segmentation filter catalogs

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2357,7 +2357,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                           "RA": "degrees", "DEC": "degrees",
                           "Bck": "electrons/s",
                           "Area": "pixels**2",
-                          "FWHM": "unitless",
+                          "FWHM": "pixels",
                           "MagAp1": "ABMAG",
                           "MagErrAp1": "ABMAG",
                           "FluxAp1": "electrons/s",


### PR DESCRIPTION
Added the FWHM measurement to the output Segmentation filter catalog. The FWHM measurement
only exists in versions of Photutils > 1.1.0.  The code accommodates older versions of
Photutils by including the FWHM column in the output Segmentation catalog, but the entire
column is zero-filled.