### PR TITLE
Add the Kron radius as an output measurement for the catalog

### DIFF
--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -41,6 +41,8 @@
         "rw2d_source_fraction": 0.15,
         "biggest_source_deblend_limit": 0.15,
         "source_fraction_deblend_limit": 0.20,
-        "ratio_bigsource_limit": 2
+        "ratio_bigsource_limit": 2,
+        "kron_scaling_radius": 2.5,
+        "kron_minimum_radius": 3.5
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -41,6 +41,8 @@
         "rw2d_source_fraction": 0.15,
         "biggest_source_deblend_limit": 0.15,
         "source_fraction_deblend_limit": 0.20,
-        "ratio_bigsource_limit": 2
+        "ratio_bigsource_limit": 2,
+        "kron_scaling_radius": 2.5,
+        "kron_minimum_radius": 3.5
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -41,7 +41,9 @@
         "rw2d_source_fraction": 0.075,
         "biggest_source_deblend_limit": 0.15,
         "source_fraction_deblend_limit": 0.20,
-        "ratio_bigsource_limit": 2
+        "ratio_bigsource_limit": 2,
+        "kron_scaling_radius": 2.5,
+        "kron_minimum_radius": 3.5
        
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -41,6 +41,8 @@
         "rw2d_source_fraction": 0.15,
         "biggest_source_deblend_limit": 0.15,
         "source_fraction_deblend_limit": 0.20,
-        "ratio_bigsource_limit": 2
+        "ratio_bigsource_limit": 2,
+        "kron_scaling_radius": 2.5,
+        "kron_minimum_radius": 3.5
     }
 }

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -41,6 +41,8 @@
         "rw2d_source_fraction": 0.075,
         "biggest_source_deblend_limit": 0.15,
         "source_fraction_deblend_limit": 0.20,
-        "ratio_bigsource_limit": 2
+        "ratio_bigsource_limit": 2,
+        "kron_scaling_radius": 2.5,
+        "kron_minimum_radius": 3.5
     }
 }


### PR DESCRIPTION
Added the Kron radius as an output measurement for the catalog.  This change required providing
"kron_params" to the SourceCatalog instantiation.  The "kron_params" are a list of two values that
are used to determine how the Kron radius and flux are calculated.  The two values, kron_scaling_radius
and kron_minimum_radius, are stored as two new configuration values in the catalog configuration file
associated with each of the detectors.