### PR TITLE
Insure only photutils 1.1.0 gets used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
         'astroquery>=0.4',
         'bokeh',
         'pandas',
-        'photutils>=1.0.0',
+        'photutils<1.2.0',
         'lxml',
         'PyPDF2',
         'scikit-image',


### PR DESCRIPTION
Simple change to insure that v1.2.0 of photutils does not get used with this version of Drizzlepac at this point.  