### PR TITLE
Define segment thresholds for basically empty images

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1586,6 +1586,12 @@ class HAPSegmentCatalog(HAPCatalogBase):
                         sigma_for_threshold = self._nsigma * 2.0
                         rw2d_sigma_for_threshold = self._rw2d_nsigma * 2.0
 
+                    # Define thresholds for empty/zero background
+                    else:
+                        log.info("Defining the threshold image based on nsigma for source detection.")
+                        sigma_for_threshold = self._nsigma
+                        rw2d_sigma_for_threshold = self._rw2d_nsigma
+
                     # Detect segments and evaluate the detection in terms of big sources/islands or crowded fields
                     # Round 2
                     ncount += 1


### PR DESCRIPTION
This adds logic to catch the leftover case for an if_elif statment when setting detection thresholds for segment catalog source identification.  The previous logic only looked for 2 types of backgrounds based on '.bkg_type' when there were actually 4 possibilities.  

This addresses the error seen in the 2021-10-05 1k test results.  