### PR TITLE
Fix use of filename in get_sky_cells

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -1677,6 +1677,8 @@ def ckmeans_test():
 
 def extract_visit(filename):
     """Extract the VISIT ID from the input filename"""
+    # First, make sure we are only working with a filename, not a full path+filename
+    filename = os.path.basename(filename)
     if filename.startswith('hst_'):
         rootname = filename.split('_')[-2]
         visit_id = rootname[:6]


### PR DESCRIPTION
Simple fix for 'haputils/get_sky_cells' to properly use the filename without path in validating the WCS.  