### PR TITLE
Convert the masked values/empty strings ("") and nans to a numeric indicator

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -289,7 +289,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
             # At this point the total product catalog contains all columns contributed
             # by each filter catalog. However, some of the columns originating in one or more of
             # the filter catalogs contain no measurements for a particular source.  Remove all
-            # rows which contain empty strings (masked values) for all measurements for all
+            # rows which contain empty strings (masked values) for *all* measurements for *all*
             # of the filter catalogs.
             for cat_type in total_product_catalogs.catalogs.keys():
                 good_rows_index = []


### PR DESCRIPTION
As the subject indicates the masked values in the catalog (represented as -- in memory and as "" in the ecsv file), as well as the nan values are converted to numeric values of -9999.9 or -9999 before the output catalogs are written.  This was done so the catalogs could be ingested into a database, for example, without further data table manipulation.

A small utility function was created, fill_nans_maskvalues(), and is invoked in the write_catalog method of the catalog classes.
