### PR TITLE
Remove unmodified input files from disk and manifest file

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -475,7 +475,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
 
 def run_align_to_gaia(total_obj_list, custom_limits=None, log_level=logutil.logging.INFO, diagnostic_mode=False):
     # Run align.py on all input images sorted by overlap with GAIA bandpass
-    log.info("\n{}: Align the all filters to GAIA with the same fit".format(str(datetime.datetime.now())))
+    log.info("\n{}: Align all the filters to GAIA with the same fit".format(str(datetime.datetime.now())))
     gaia_obj = None
     # Start by creating a FilterProduct instance which includes ALL input exposures
     for tot_obj in total_obj_list:

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -639,9 +639,6 @@ class ExposureProduct(HAPProduct):
         # Flag whether to use single-image CR identification with this exposure
         self.crclean = False
 
-        # Flag to indicate whether input exposure was modified (typically, with new WCS)
-        self.input_updated = False
-
         log.info("Exposure object {} created.".format(self.full_filename[0:9]))
 
     def find_member(self, name):
@@ -859,6 +856,9 @@ class SkyCellExposure(HAPProduct):
 
         # Flag whether to use single-image CR identification with this exposure
         self.crclean = False
+
+        # Flag to indicate whether input exposure was modified (typically, with new WCS)
+        self.input_updated = False
 
         log.info("Create SkyCellExposure object:\n    {}".format(self.full_filename))
 


### PR DESCRIPTION
Input FLC/FLT images which never get aligned during MVM processing will be deleted from disk and not included in the output manifest file since they are simply unmodified copies of the SVM updated versions of the FLC/FLT files.  These changes are implemented to only be performed when not running in diagnostic_mode (for debugging purposes).  

The logic is currently only implemented for updates to the input files applied by aligning to GAIA, but could be expanded later to keep the files for other reasons such as after the input files had their DQ arrays updated to reflect cosmic-rays identified during MVM processing.  As it is, regardless of DQ array updates, the files will be removed if they are not aligned to GAIA. 