### PR TITLE
Modified azure-pipeline.yml to use ubuntu-latest versus ubuntu-16.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
 
 - job: 'PEP8'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
 
   steps:
   - task: UsePythonVersion@0

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -6,7 +6,7 @@ jobs:
     ${{ if eq(parameters.os, 'macos') }}:
       vmImage: macOS-10.14
     ${{ if eq(parameters.os, 'linux') }}:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-latest
 
   strategy:
     matrix:


### PR DESCRIPTION
 Modified azure-pipeline.yml to use ubuntu-latest versus ubuntu-16.04.  This was necessary
as support for Ubuntu 16.04 was removed from Azure DevOps on 18 October 2021.  See this
URL for details: https://github.com/actions/virtual-environments/issues/3287