### PR TITLE
Only remove rows where all flags are bad

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -291,7 +291,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
 
                 # work out what rows have flag values > flag_limit in ALL flag columns
                 flag_bitmasks = [np.logical_or(filled_flag_columns[col] > flag_trim_value,
-                                               filled_flag_columns[col] == -9999.9)
+                                               np.isclose(filled_flag_columns[col], -9999.9))
                                  for col in filled_flag_columns.colnames]
                 flag_mask = np.logical_and.reduce(flag_bitmasks)
                 # Get indices of all good rows


### PR DESCRIPTION
Revise the logic for trimming the catalogs based on flag values to only remove rows where flags for ALL filters are bad.  The change actually should make this part of the code more efficient as well by eliminating explicit loop over each row.  It also moved the logic from being done for each filter to only being done for the total catalogs.  

This code was tested on data from visit 'ibku01'. 