### PR TITLE
Fix an issue with WFPC2 flat field file extension name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-3.3.1 (unreleased)
+3.3.2 (unreleased)
 ==================
 
 - Detect extension name from WFPC2 flatfield files. [#1193]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,14 @@ The following notes provide some details on what has been revised for each
 version in reverse chronological order (most recent version at the top
 of the list).
 
-3.3.0 (28-Sep-2021)
+3.3.1 (unreleased)
 ==================
+
+- Detect extension name from WFPC2 flatfield files. [#1193]
+
+
+3.3.0 (28-Sep-2021)
+===================
 This version includes all the functionality needed to generate
 source catalogs, both point source and extended (segment) source
 catalogs, during single-visit mosaic (SVM) processing.  In fact,

--- a/drizzlepac/imageObject.py
+++ b/drizzlepac/imageObject.py
@@ -511,7 +511,7 @@ class baseImageObject:
     def getGain(self, exten):
         return self._image[exten]._gain
 
-    def getflat(self, chip):
+    def getflat(self, chip, flat_ext=None):
         """
         Method for retrieving a detector's flat field.
 
@@ -522,6 +522,8 @@ class baseImageObject:
             **units of electrons**.
 
         """
+        if flat_ext is None:
+            flat_ext = self.scienceExt
         sci_chip = self._image[self.scienceExt, chip]
         # The keyword for ACS flat fields in the primary header of the flt
         # file is pfltfile.  This flat file is already in the required
@@ -533,8 +535,8 @@ class baseImageObject:
         hdulist = None
         try:
             hdulist = fileutil.openImage(filename, mode='readonly',
-                                         memmap=False)
-            data = hdulist[(self.scienceExt, chip)].data
+                                         memmap=False, writefits=False)
+            data = hdulist[(flat_ext, chip)].data
 
             if data.shape[0] != sci_chip.image_shape[0]:
                 ltv2 = int(np.round(sci_chip.ltv2))

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -164,7 +164,7 @@ class WFPC2InputImage (imageObject):
         # Convert the science data to electrons
         self.doUnitConversions()
 
-    def getflat(self,chip):
+    def getflat(self, chip, flat_ext=None):
         """
         Method for retrieving a detector's flat field.
 
@@ -176,7 +176,14 @@ class WFPC2InputImage (imageObject):
         """
         # For the WFPC2 flat we need to invert
         # for use in Multidrizzle
-        flat = 1.0 / super().getflat(chip)
+        if flat_ext is None:
+            filename = fileutil.osfn(self._image["PRIMARY"].header[self.flatkey])
+            h = fileutil.openImage(filename, mode='readonly', memmap=False,
+                                   writefits=False)
+            flat_ext = h[0].header.get('FILETYPE', '')
+            flat_ext = h[1].header.get('EXTNAME', flat_ext)
+            h.close()
+        flat = 1.0 / super().getflat(chip, flat_ext)
         return flat
 
     def doUnitConversions(self):

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -33,6 +33,8 @@ class WFPC2InputImage (imageObject):
 
     SEPARATOR = '_'
 
+    flat_file_map = {}
+
     def __init__(self, filename, output=None, group=None):
         super().__init__(filename, output=output, group=group)
         # define the cosmic ray bits value to use in the dq array
@@ -164,26 +166,53 @@ class WFPC2InputImage (imageObject):
         # Convert the science data to electrons
         self.doUnitConversions()
 
-    def getflat(self, chip, flat_ext=None):
+    def getflat(self, chip, flat_file=None, flat_ext=None):
         """
         Method for retrieving a detector's flat field.
 
+        Parameters
+        ----------
+        chip : int
+            Chip number. Same as FITS ``EXTVER``.
+
+        flat_file : str, None
+            Flat field file name. If not specified, it will be determined
+            automatically from image header.
+
+        flat_ext : str, None
+            Flat field extension name (same as FITS ``EXTNAME``). Specifies
+            extension name containing flat field data.
+
         Returns
         -------
-        flat : array
+        flat : numpy.ndarray
             The flat-field array in the same shape as the input image.
 
         """
         # For the WFPC2 flat we need to invert
         # for use in Multidrizzle
-        if flat_ext is None:
+        if flat_file is None:
             filename = fileutil.osfn(self._image["PRIMARY"].header[self.flatkey])
-            h = fileutil.openImage(filename, mode='readonly', memmap=False,
+            if filename in WFPC2InputImage.flat_file_map:
+                flat_file, mef_flat_ext = WFPC2InputImage.flat_file_map[filename]
+            else:
+                h = fileutil.openImage(filename, mode='readonly', memmap=False)
+                flat_file = h.filename()
+                mef_flat_ext = h[0].header.get('FILETYPE', '')
+                mef_flat_ext = h[1].header.get('EXTNAME', mef_flat_ext)
+                h.close()
+                WFPC2InputImage.flat_file_map[filename] = (flat_file, mef_flat_ext)
+            if flat_ext is None:
+                flat_ext = mef_flat_ext
+
+        elif flat_ext is None:
+            h = fileutil.openImage(flat_file, mode='readonly', memmap=False,
                                    writefits=False)
             flat_ext = h[0].header.get('FILETYPE', '')
             flat_ext = h[1].header.get('EXTNAME', flat_ext)
             h.close()
-        flat = 1.0 / super().getflat(chip, flat_ext)
+
+        flat = 1.0 / super().getflat(chip, flat_file, flat_ext)
         return flat
 
     def doUnitConversions(self):


### PR DESCRIPTION
This PR addresses an issue with WFPC flat filed files having extension name `FLT` instead of the expected (by the code) extension `SCI`. When trying to drizzle WFPC2 image with IVM weighting, this unexpected extension type would result in a crash.