### PR TITLE
Add Python 3.10 to Azure test matrix

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -48,6 +48,20 @@ bc2 = utils.copy(bc1)
 bc2.name = '3.8-dev'
 bc2.build_cmds[1] = "pip install -r requirements-dev.txt --upgrade -e '.[test]'"
 
+bc3 = new BuildConfig()
+bc3.nodetype = 'linux'
+bc3.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
+bc3.name = '3.10-dev'
+bc3.conda_channels = ['http://ssb.stsci.edu/astroconda']
+bc3.conda_packages = ['python=3.8']
+bc3.build_cmds = ["pip install numpy astropy codecov pytest-cov",
+		 "pip install -r requirements-dev.txt --upgrade -e '.[test]'",
+                 "pip freeze"]
+bc3.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml results.xml --bigdata",
+                "codecov"]
+bc3.test_configs = [data_config]
+
+
 // Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host (or workdir) for each combination and run in parallel.
 // Also apply the job configuration defined in `jobconfig` above.

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -53,7 +53,7 @@ bc3.nodetype = 'linux'
 bc3.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc3.name = '3.10-dev'
 bc3.conda_channels = ['http://ssb.stsci.edu/astroconda']
-bc3.conda_packages = ['python=3.8']
+bc3.conda_packages = ['python=3.10']
 bc3.build_cmds = ["pip install numpy astropy codecov pytest-cov",
 		 "pip install -r requirements-dev.txt --upgrade -e '.[test]'",
                  "pip freeze"]

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -10,8 +10,8 @@ jobs:
 
   strategy:
     matrix:
-      Python310:
-        python.version: '3.10'
+      # Python310:
+      #  python.version: '3.10'
       Python39:
         python.version: '3.9'
       # Python37:

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -10,6 +10,8 @@ jobs:
 
   strategy:
     matrix:
+      Python310:
+        python.version: '3.10'
       Python39:
         python.version: '3.9'
       # Python37:


### PR DESCRIPTION
These changes are the changes needed to add Python 3.10 testing to the nightly Jenkins regression tests, while also documenting how to add Python 3.10 to the Azure tests as well.