### PR TITLE
Turn on Python 3.10 Jenkins testing

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -65,4 +65,4 @@ bc3.test_configs = [data_config]
 // Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host (or workdir) for each combination and run in parallel.
 // Also apply the job configuration defined in `jobconfig` above.
-utils.run([bc, bc1, jobconfig])
+utils.run([bc, bc1, bc3, jobconfig])


### PR DESCRIPTION
Python 3.10 configurations added in #1208 now need to be turned on in Jenkins with these changes.