### PR TITLE
Set NMATCH limits for fitgeoms to INS requested values

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -1233,12 +1233,14 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
             hdulist[sci_extn].header['CRDER1'] = info['RMS_RA'].value if info['RMS_RA'] is not None else -1.0
             hdulist[sci_extn].header['CRDER2'] = info['RMS_DEC'].value if info['RMS_DEC'] is not None else -1.0
             hdulist[sci_extn].header['NMATCHES'] = len(info['ref_mag']) if info['ref_mag'] is not None else 0
+            hdulist[sci_extn].header['FITGEOM'] = info['fitgeom'] if info['fitgeom'] is not None else 'N/A'
         else:
             hdulist[sci_extn].header['RMS_RA'] = -1.0
             hdulist[sci_extn].header['RMS_DEC'] = -1.0
             hdulist[sci_extn].header['CRDER1'] = -1.0
             hdulist[sci_extn].header['CRDER2'] = -1.0
             hdulist[sci_extn].header['NMATCHES'] = 0
+            hdulist[sci_extn].header['FITGEOM'] = "N/A"
 
         # Update value of 'nmatches' in fit_info so that this value will get
         # used in writing out the headerlet as a file.

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/hrc/acs_hrc_alignment_all.json
@@ -16,7 +16,7 @@
       "MAX_FIT_LIMIT": 150,
       "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
       "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-      "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 3, "rshift": 4, "rscale": 6, "general": 6}
     },
   "generate_source_catalogs":
     {

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_alignment_all.json
@@ -16,7 +16,7 @@
       "MAX_FIT_LIMIT": 150,
       "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
       "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-      "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 3, "rshift": 4, "rscale": 6, "general": 6}
     },
   "generate_source_catalogs":
     {

--- a/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/wfc/acs_wfc_alignment_all.json
@@ -16,7 +16,7 @@
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-        "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 3, "rshift": 4, "rscale": 6, "general": 6}
       },
     "generate_source_catalogs":
       {

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/ir/wfc3_ir_alignment_all.json
@@ -16,7 +16,7 @@
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-        "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 3, "rshift": 4, "rscale": 6, "general": 6}
       },
     "generate_source_catalogs":
       {

--- a/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/wfc3/uvis/wfc3_uvis_alignment_all.json
@@ -16,7 +16,7 @@
         "MAX_FIT_LIMIT": 150,
         "mosaic_catalog_list": ["GAIAeDR3", "GSC242", "2MASS"],
         "mosaic_fit_list": ["match_relative_fit", "match_2dhist_fit", "match_default_fit"],
-        "mosaic_fitgeom_list": {"shift": 1, "rshift": 3, "rscale": 4, "general": 6}
+        "mosaic_fitgeom_list": {"shift": 3, "rshift": 4, "rscale": 6, "general": 6}
       },
     "generate_source_catalogs":
       {


### PR DESCRIPTION
This codifies the limits on minimum number of cross-matches that are acceptable for each type of fit (e.g., rscale, rshift,...) that gets performed during alignment as requested by INS. 