### PR TITLE
Reduce memory use in hapmultisequencer

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -368,7 +368,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                                                                          only_cte=cat_switches['MVM_ONLY_CTE'])
         h = hp.heap()
         heapdict[1] = {'log': str(h), 'indisize': h.indisize}
-
+        log.info("[HEAPY][1] indisize: {}".format(h.indisize))
         # The product_list is a list of all the output products which will be put into the manifest file
         product_list = []
 
@@ -406,6 +406,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
         log.info("The configuration parameters have been read and applied to the drizzle objects.")
         h = hp.heap()
         heapdict[2] = {'log': str(h), 'indisize': h.indisize}
+        log.info("[HEAPY][2] indisize: {}".format(h.indisize))
 
         # TODO: This is the place where updated WCS info is migrated from drizzlepac params to filter objects
         if skip_gaia_alignment:
@@ -419,6 +420,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                 product_list += [reference_catalog]
         h = hp.heap()
         heapdict[3] = {'log': str(h), 'indisize': h.indisize}
+        log.info("[HEAPY][3] indisize: {}".format(h.indisize))
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))
@@ -428,6 +430,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
         h = hp.heap()
         heapdict[-1] = {'log': str(h), 'indisize': h.indisize}
         pickle.dump(heapdict, open('heapy_memory_log.pickle', 'wb'))
+        log.info("[HEAPY][-1] indisize: {}".format(h.indisize))
 
         # Store total_obj_list to a pickle file to speed up development
         if False:

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -375,7 +375,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
         # Update the SkyCellProduct objects with their associated configuration information.
         for filter_item in total_obj_list:
             _ = filter_item.generate_metawcs(custom_limits=custom_limits)
-            filter_item.generate_footprint_mask()
+            filter_item.generate_footprint_mask(save_mask=False)
 
             # Optionally rename output products
             if output_file_prefix or custom_limits:

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -48,6 +48,8 @@ import sys
 import traceback
 
 from astropy.io import ascii
+from guppy import hpy  # For memory profiling only...
+
 from astropy.table import Table
 import numpy as np
 import drizzlepac
@@ -163,7 +165,7 @@ def rename_output_products(filter_obj, output_file_prefix=None):
 # --------------------------------------------------------------------------------------------------------------
 
 
-def create_drizzle_products(total_obj_list, custom_limits=None):
+def create_drizzle_products(total_obj_list, custom_limits=None, heap=None, heapdict=None):
     """
     Run astrodrizzle to produce products specified in the total_obj_list.
 
@@ -183,6 +185,7 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
     product_list: list
         A list of output products
     """
+    hp = heap
     # Get rules files
     rules_files = {}
 
@@ -202,6 +205,10 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
     # Keep track of all the products created for the output manifest
     product_list = []
 
+    heapindex = 4
+    h = hp.heap()
+    heapdict[heapindex] = {'log': str(h), 'indisize': h.indisize}
+
     # For each detector (as the total detection product are instrument- and detector-specific),
     # create the drizzle-combined filtered image, the drizzled exposure (aka single) images,
     # and finally the drizzle-combined total detection image.
@@ -212,11 +219,17 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
         # Get the common WCS for all images which are part of a total detection product,
         # where the total detection product is detector-dependent.
         meta_wcs = filt_obj.generate_metawcs(custom_limits=custom_limits)
+        heapindex += 1
+        h = hp.heap()
+        heapdict[heapindex] = {'log': str(h), 'indisize': h.indisize}
 
         log.info("CREATE DRIZZLE-COMBINED FILTER IMAGE: {}\n".format(filt_obj.drizzle_filename))
         filt_obj.wcs_drizzle_product(meta_wcs)
         product_list.append(filt_obj.drizzle_filename)
         product_list.append(filt_obj.trl_filename)
+        heapindex += 1
+        h = hp.heap()
+        heapdict[heapindex] = {'log': str(h), 'indisize': h.indisize}
 
         # Add individual single input images with updated WCS headers to manifest
         for exposure_obj in filt_obj.edp_list:
@@ -317,6 +330,11 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
     return_value: integer
         A return exit code used by the calling Condor/OWL workflow code: 0 (zero) for success, 1 for error
     """
+    # Initialize memory profiler
+    hp = hpy()
+    hp.setrelheap()
+    heapdict = {}  # structure used to keep track of memory usage results
+
     # This routine needs to return an exit code, return_value, for use by the calling
     # Condor/OWL workflow code: 0 (zero) for success, 1 for error condition
     return_value = 0
@@ -348,6 +366,8 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                                                                          layer_method='all',
                                                                          include_small=cat_switches['MVM_INCLUDE_SMALL'],
                                                                          only_cte=cat_switches['MVM_ONLY_CTE'])
+        h = hp.heap()
+        heapdict[1] = {'log': str(h), 'indisize': h.indisize}
 
         # The product_list is a list of all the output products which will be put into the manifest file
         product_list = []
@@ -384,6 +404,8 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                                                             input_custom_pars_file=input_custom_pars_file,
                                                             output_custom_pars_file=output_custom_pars_file)
         log.info("The configuration parameters have been read and applied to the drizzle objects.")
+        h = hp.heap()
+        heapdict[2] = {'log': str(h), 'indisize': h.indisize}
 
         # TODO: This is the place where updated WCS info is migrated from drizzlepac params to filter objects
         if skip_gaia_alignment:
@@ -395,11 +417,17 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                                                   diagnostic_mode=diagnostic_mode)
             if reference_catalog:
                 product_list += [reference_catalog]
+        h = hp.heap()
+        heapdict[3] = {'log': str(h), 'indisize': h.indisize}
 
         # Run AstroDrizzle to produce drizzle-combined products
         log.info("\n{}: Create drizzled imagery products.".format(str(datetime.datetime.now())))
-        driz_list = create_drizzle_products(total_obj_list, custom_limits=custom_limits)
+        driz_list = create_drizzle_products(total_obj_list, custom_limits=custom_limits, heap=hp, heapdict=heapdict)
         product_list += driz_list
+
+        h = hp.heap()
+        heapdict[-1] = {'log': str(h), 'indisize': h.indisize}
+        pickle.dump(heapdict, open('heapy_memory_log.pickle', 'wb'))
 
         # Store total_obj_list to a pickle file to speed up development
         if False:

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -461,7 +461,7 @@ class SkyFootprint(object):
             if member not in self.exp_masks:
                 raise ValueError("Member {} not added to footprint".format(member))
             # Recompute mask specifically for this member
-            #mask = self.exp_masks[member]['mask']
+            # mask = self.exp_masks[member]['mask']
             exp_mask = self.exp_masks[member]['mask']
             mask = np.zeros(self.meta_wcs.array_shape, dtype=np.int16)
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -1134,7 +1134,7 @@ class SkyCellProduct(HAPProduct):
         # as exposures which have been previously processed (all are listed in the original
         # poller file).
         mvm_footprint = cell_utils.SkyFootprint(wcs)
-        print(self.all_mvm_exposures)
+        log.debug(self.all_mvm_exposures)
         mvm_footprint.build(self.all_mvm_exposures)
 
         # This is the exposure-dependent WCS.

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -41,8 +41,7 @@ MASK_KWS = {"NPIXFRAC": [None, "Fraction of pixels with data"],
             "MEANEXPT": [None, "Mean exposure time per pixel with data"],
             "MEDEXPT": [None, "Median exposure time per pixel with data"],
             "MEANNEXP": [None, "Mean number of exposures per pixel with data"],
-            "MEDNEXP": [None, "Median number of exposures per pixel with data"],
-            "computed": False
+            "MEDNEXP": [None, "Median number of exposures per pixel with data"]
             }
 
 
@@ -82,6 +81,7 @@ class HAPProduct:
         self.meta_wcs = None
         self.mask = None
         self.mask_kws = MASK_KWS.copy()
+        self.mask_computed = False
 
     # def print_info(self):
         # """ Generic print at this time to indicate the information used in the
@@ -107,7 +107,7 @@ class HAPProduct:
 
         # Compute footprint-based SVM-specific keywords for product image header
         good_pixels = footprint.total_mask > 0
-        self.mask_kws['computed'] = True
+        self.mask_computed = True
         self.mask_kws['NPIXFRAC'][0] = good_pixels.sum() / footprint.total_mask.size
         self.mask_kws['MEANEXPT'][0] = np.mean(footprint.scaled_mask[good_pixels])
         self.mask_kws['MEDEXPT'][0] = np.median(footprint.scaled_mask[good_pixels])
@@ -565,7 +565,7 @@ class FilterProduct(HAPProduct):
         # This insures that keywords related to the footprint are generated for this
         # specific object to use in updating the output drizzle product.
         self.meta_wcs = meta_wcs
-        if self.mask is None:
+        if self.mask_computed is False:
             self.generate_footprint_mask()
 
         # Retrieve the configuration parameters for astrodrizzle
@@ -1150,7 +1150,7 @@ class SkyCellProduct(HAPProduct):
         # This insures that keywords related to the footprint are generated for this
         # specific object to use in updating the output drizzle product.
         self.meta_wcs = meta_wcs
-        if self.mask is None:
+        if self.mask_computed is False:
             self.generate_footprint_mask()
 
         # Retrieve the configuration parameters for astrodrizzle

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -42,6 +42,7 @@ MASK_KWS = {"NPIXFRAC": [None, "Fraction of pixels with data"],
             "MEDEXPT": [None, "Median exposure time per pixel with data"],
             "MEANNEXP": [None, "Mean number of exposures per pixel with data"],
             "MEDNEXP": [None, "Median number of exposures per pixel with data"],
+            "computed": False
             }
 
 
@@ -88,7 +89,7 @@ class HAPProduct:
         # """
         # print("Object information: {}".format(self.info))
 
-    def generate_footprint_mask(self):
+    def generate_footprint_mask(self, save_mask=True):
         """ Create a footprint mask for a set of exposure images
 
             Create a mask which is True/1/on for the illuminated portion of the image, and
@@ -101,15 +102,17 @@ class HAPProduct:
         # This mask actually represents the number of chips per pixel, not True/False.
         # To have the True/False mask it should be self.mask = footprint.footprint.
         # Do not fix this until it can be verified that a change will not have repercussions.
-        self.mask = copy.deepcopy(footprint.total_mask)
+        if save_mask:
+            self.mask = copy.deepcopy(footprint.total_mask)
 
         # Compute footprint-based SVM-specific keywords for product image header
-        good_pixels = self.mask > 0
-        self.mask_kws['NPIXFRAC'][0] = good_pixels.sum() / self.mask.size
+        good_pixels = footprint.total_mask > 0
+        self.mask_kws['computed'] = True
+        self.mask_kws['NPIXFRAC'][0] = good_pixels.sum() / footprint.total_mask.size
         self.mask_kws['MEANEXPT'][0] = np.mean(footprint.scaled_mask[good_pixels])
         self.mask_kws['MEDEXPT'][0] = np.median(footprint.scaled_mask[good_pixels])
-        self.mask_kws['MEANNEXP'][0] = np.mean(self.mask[good_pixels])
-        self.mask_kws['MEDNEXP'][0] = np.median(self.mask[good_pixels])
+        self.mask_kws['MEANNEXP'][0] = np.mean(footprint.total_mask[good_pixels])
+        self.mask_kws['MEDNEXP'][0] = np.median(footprint.total_mask[good_pixels])
         del footprint
 
     def generate_metawcs(self):

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -101,7 +101,7 @@ class HAPProduct:
         # This mask actually represents the number of chips per pixel, not True/False.
         # To have the True/False mask it should be self.mask = footprint.footprint.
         # Do not fix this until it can be verified that a change will not have repercussions.
-        self.mask = footprint.total_mask
+        self.mask = copy.deepcopy(footprint.total_mask)
 
         # Compute footprint-based SVM-specific keywords for product image header
         good_pixels = self.mask > 0
@@ -110,6 +110,7 @@ class HAPProduct:
         self.mask_kws['MEDEXPT'][0] = np.median(footprint.scaled_mask[good_pixels])
         self.mask_kws['MEANNEXP'][0] = np.mean(self.mask[good_pixels])
         self.mask_kws['MEDNEXP'][0] = np.median(self.mask[good_pixels])
+        del footprint
 
     def generate_metawcs(self):
         """ A method to build a unique WCS for each TotalProduct product which is
@@ -1130,10 +1131,13 @@ class SkyCellProduct(HAPProduct):
         # as exposures which have been previously processed (all are listed in the original
         # poller file).
         mvm_footprint = cell_utils.SkyFootprint(wcs)
+        print(self.all_mvm_exposures)
         mvm_footprint.build(self.all_mvm_exposures)
 
         # This is the exposure-dependent WCS.
-        self.meta_bounded_wcs = mvm_footprint.bounded_wcs
+        self.meta_bounded_wcs = copy.deepcopy(mvm_footprint.bounded_wcs)
+        del mvm_footprint
+
         return self.meta_bounded_wcs
 
     def wcs_drizzle_product(self, meta_wcs):


### PR DESCRIPTION
These changes fix problems with memory use during processing with hapmultisequencer.  Specifically, footprint masks are properly defined one per layer, not one per exposure, and they are deleted as soon as they are no longer needed by the processing.  This reduces the memory usage during this stage of processing to a maximum of about 2Gb based on the memory used by an array of a single full skycell layer.  