### PR TITLE
update how make_poller_files.py generates visit numbers to account an edge case

### DIFF
--- a/drizzlepac/haputils/diagnostic_utils.py
+++ b/drizzlepac/haputils/diagnostic_utils.py
@@ -176,7 +176,10 @@ class HapDiagnostic(object):
             self.out_dict['general information'][dict_keys[key]] = self.header[key]
         # Now, add items which require more interpretation
         try:
-            self.out_dict['general information']['visit'] = self.header['linenum'].split(".")[0]
+            if self.header['primesi'].lower() == self.header['instrume']:
+                self.out_dict['general information']['visit'] = self.header['linenum'].split(".")[0]
+            else:
+                self.out_dict['general information']['visit'] = self.header['filename'].split("_")[2]
         except:
             self.out_dict['general information']['visit'] = self.header['filename'].split("_")[2]
         # determine filter...

--- a/drizzlepac/haputils/make_poller_files.py
+++ b/drizzlepac/haputils/make_poller_files.py
@@ -103,7 +103,10 @@ def generate_poller_file(input_list, poller_file_type='svm', output_poller_filen
         imghdr = imghdu[0].header
         linelist.append("{}".format(imghdr['proposid']))
         linelist.append(imgname.split("_")[-2][1:4].upper())
-        linelist.append(imghdr['linenum'].split(".")[0])
+        if imghdr['primesi'].lower() == imghdr['instrume']:
+            linelist.append(imghdr['linenum'].split(".")[0])
+        else:
+            linelist.append(imghdr['rootname'][-5:-3].upper())
         linelist.append("{}".format(imghdr['exptime']))
         if imghdr['INSTRUME'].lower() == "acs":
             filter = poller_utils.determine_filter_name("{};{}".format(imghdr['FILTER1'], imghdr['FILTER2']))


### PR DESCRIPTION
**RELATED ISSUES AND TICKETS**
- #1216 
- [HLA-680](https://jira.stsci.edu/browse/HLA-680)

**BACKGROUND**
- For a small number of edge case images (those with header values "PRIMESI" != "INSTRUME"), the first two characters of header value "LINENUM" do not match the values in the 5th and 6th places of the filename or header value "ROOTNAME".
- make_poller_files.py was populating the "visit number" column of .out files with the incorrect value because it was using the first two characters of header value "LINENUM" for these edge case images.

**SUMMARY OF CHANGES**
- Added logic to check for the edge case and if detected, use the 5th and 6th characters of "ROOTNAME" header value rather than "LINENUM" to produce "visit number" values. 
- For all other non-edge case images, "visit number" values are still derived as they were before based on the "LINENUM" header value.
- A similar issue was found in diagnostic_utils.py. A similar fix was applied to account for the edge case when generating a value for visit number.