### PR TITLE
Fix incorrect drizzling of 0-weight input pixels

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,9 +22,13 @@ of the list).
 
 - Refactored the build system to be PEP-517 ad PEP-518 complient. [#1244]
 
+- Fixed a bug in the drizzle algorithm due to which input pixels with
+  zero weights may still contribute to the output image. [#1222]
+
 
 3.3.0 (28-Sep-2021)
 ===================
+
 This version includes all the functionality needed to generate
 source catalogs, both point source and extended (segment) source
 catalogs, during single-visit mosaic (SVM) processing.  In fact,

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -322,16 +322,18 @@ update_context(struct driz_param_t* p, const integer_t ii, const integer_t jj,
 inline_macro static void
 update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
             const float d, const float vc, const float dow) {
-  const double vc_plus_dow = vc + dow;
+  double vc_plus_dow;
+
+  if (dow == 0.0f) return;
+
+  vc_plus_dow = vc + dow;
 
   /* Just a simple calculation without logical tests */
   if (vc == 0.0) {
     *output_data_ptr(p, ii, jj) = d;
   } else {
-    if (vc_plus_dow != 0.0) {
-      *output_data_ptr(p, ii, jj) =
-        (*output_data_ptr(p, ii, jj) * vc + dow * d) / (vc_plus_dow);
-    }
+    *output_data_ptr(p, ii, jj) =
+      (*output_data_ptr(p, ii, jj) * vc + dow * d) / (vc_plus_dow);
   }
 
   *output_counts_ptr(p, ii, jj) = vc_plus_dow;

--- a/tests/drizzle/test_drizzle.py
+++ b/tests/drizzle/test_drizzle.py
@@ -1,0 +1,37 @@
+import numpy as np
+from astropy import wcs
+
+from drizzlepac import cdriz
+
+def test_zero_input_weight():
+    """
+    Test do_driz square kernel with grid
+    """
+    insci = np.ones((200, 400), dtype=np.float32)
+    inwht = np.ones((200, 400), dtype=np.float32)
+    inwht[:, 150:155] = 0
+    tflux = np.sum(inwht)
+
+    for kernel in ['square', 'point', 'turbo']:
+        # initialize output:
+        outsci = np.zeros((210, 410), dtype=np.float32)
+        outwht = np.zeros((210, 410), dtype=np.float32)
+        outctx = np.zeros((210, 410), dtype=np.int32)
+
+        w = wcs.WCS()
+        w.wcs.ctype = ['RA---CAR', 'DEC--CAR']
+        w.wcs.crpix = [201, 101]
+        w.wcs.crval = [10, 10]
+        w.wcs.cdelt = [1e-3, 1e-3]
+        w.wcs.set()
+
+        mapping = cdriz.DefaultWCSMapping(w, w, 400, 200, 1)
+
+        cdriz.tdriz(
+            insci, inwht, outsci, outwht,
+            outctx, 1, 0, 1, 1, insci.shape[0],
+            1.0, 1.0, 1.0, 'center', 1.0,
+            kernel, 'cps', 1.0, 1.0,
+            'INDEF', 0, 0, 1, mapping)
+
+        assert np.allclose(np.sum(outwht), tflux)

--- a/tests/drizzle/test_drizzle.py
+++ b/tests/drizzle/test_drizzle.py
@@ -1,37 +1,52 @@
+import pytest
+
 import numpy as np
 from astropy import wcs
 
 from drizzlepac import cdriz
 
-def test_zero_input_weight():
+@pytest.mark.parametrize(
+    'kernel', ['square', 'point', 'turbo', 'gaussian', 'lanczos3']
+)
+def test_zero_input_weight(kernel):
     """
     Test do_driz square kernel with grid
     """
+    # initialize input:
     insci = np.ones((200, 400), dtype=np.float32)
     inwht = np.ones((200, 400), dtype=np.float32)
     inwht[:, 150:155] = 0
-    tflux = np.sum(inwht)
 
-    for kernel in ['square', 'point', 'turbo']:
-        # initialize output:
-        outsci = np.zeros((210, 410), dtype=np.float32)
-        outwht = np.zeros((210, 410), dtype=np.float32)
-        outctx = np.zeros((210, 410), dtype=np.int32)
+    # initialize output:
+    outsci = np.zeros((210, 410), dtype=np.float32)
+    outwht = np.zeros((210, 410), dtype=np.float32)
+    outctx = np.zeros((210, 410), dtype=np.int32)
 
-        w = wcs.WCS()
-        w.wcs.ctype = ['RA---CAR', 'DEC--CAR']
-        w.wcs.crpix = [201, 101]
-        w.wcs.crval = [10, 10]
-        w.wcs.cdelt = [1e-3, 1e-3]
-        w.wcs.set()
+    # define coordinate mapping:
+    w1 = wcs.WCS()
+    w1.wcs.ctype = ['RA---CAR', 'DEC--CAR']
+    w1.wcs.crpix = [201, 101]
+    w1.wcs.crval = [10, 10]
+    w1.wcs.cdelt = [1e-3, 1e-3]
+    w1.wcs.set()
 
-        mapping = cdriz.DefaultWCSMapping(w, w, 400, 200, 1)
+    w2 = wcs.WCS()
+    w2.wcs.ctype = ['RA---CAR', 'DEC--CAR']
+    w2.wcs.crpix = [206, 106]
+    w2.wcs.crval = [10, 10]
+    w2.wcs.cdelt = [1e-3, 1e-3]
+    w2.wcs.set()
 
-        cdriz.tdriz(
-            insci, inwht, outsci, outwht,
-            outctx, 1, 0, 1, 1, insci.shape[0],
-            1.0, 1.0, 1.0, 'center', 1.0,
-            kernel, 'cps', 1.0, 1.0,
-            'INDEF', 0, 0, 1, mapping)
+    mapping = cdriz.DefaultWCSMapping(w1, w2, 400, 200, 1)
 
-        assert np.allclose(np.sum(outwht), tflux)
+    # resample:
+    cdriz.tdriz(
+        insci, inwht, outsci, outwht,
+        outctx, 1, 0, 1, 1, 200,
+        1.0, 1.0, 1.0, 'center', 1.0,
+        kernel, 'cps', 1.0, 1.0,
+        'INDEF', 0, 0, 1, mapping
+    )
+
+    # check that no pixel with 0 weight has any counts:
+    assert np.allclose(np.sum(np.abs(outsci[(outwht == 0)])), 0)


### PR DESCRIPTION
This PR fixes a bug in the C code of the core drizzle algorithm due to which flux from the input image could be dropped onto the output (resampled) image even though those input pixels have zero weights.

This is a port of the bug fix from https://github.com/spacetelescope/drizzle/pull/79