### PR TITLE
Remove the prefix "hst_" from the manifest filename for MVM products.

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -365,7 +365,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                 # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
                 # to use only one of the SkyCellProducts to generate the manifest name as the name
                 # is only dependent on the sky cell.
-                # Example: hst_skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., hst_skycell-p0797x12y05_manifest.txt)
+                # Example: skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., skycell-p0797x12y05_manifest.txt)
                 manifest_name = total_obj_list[0].manifest_name
                 log.info("\nGenerate the manifest name for this multi-visit: {}.".format(manifest_name))
                 log.info("The manifest will contain the names of all the output products.")
@@ -494,26 +494,26 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                 # information is in column 8 (1-based), and only the first entry is needed.
                 if type(input_filename) == str:
                     output_skycell = ascii.read(input_filename, format='no_header')["col8"][0]
-                    manifest_name = "hst_"+ output_skycell.lower() + "_manifest.txt"
+                    manifest_name = output_skycell.lower() + "_manifest.txt"
 
                 # Maybe the input filename was actually a Python list
                 elif type(input_filename) == list:
                     skycell_dict = cell_utils.get_sky_cells([input_filename[0]])
                     output_skycell = next(iter(skycell_dict.keys()))
-                    manifest_name = "hst_"+ output_skycell.lower() + "_manifest.txt"
+                    manifest_name = output_skycell.lower() + "_manifest.txt"
 
                 # Problem case - try to use the name of the input file
                 else:
                     if re.search(MATCH_STRING, input_filename.lower()):
-                        manifest_name = "hst_" + input_filename.lower().replace("input.out", "manifest.txt")
+                        manifest_name = input_filename.lower().replace("input.out", "manifest.txt")
                     else:
-                        manifest_name = "hst_skycell-p0000x00y00_manifest.txt"
+                        manifest_name = "skycell-p0000x00y00_manifest.txt"
                 # Bigger problem case - try to use the name of the input file
             except Exception:
                 if re.search(MATCH_STRING, input_filename.lower()):
-                    manifest_name = "hst_" + input_filename.lower().replace("input.out", "manifest.txt")
+                    manifest_name = input_filename.lower().replace("input.out", "manifest.txt")
                 else:
-                    manifest_name = "hst_skycell-p0000x00y00_manifest.txt"
+                    manifest_name = "skycell-p0000x00y00_manifest.txt"
 
         log.info("Writing empty manifest file: {}".format(manifest_name))
 

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -81,6 +81,8 @@ envvar_qa_svm = "SVM_QUALITY_TESTING"
 envvar_cat_mvm = {"MVM_INCLUDE_SMALL": 'true',
                   "MVM_ONLY_CTE": 'false'}
 
+DEFAULT_MANIFEST_NAME = "skycell-p0000x00y00_manifest.txt"
+
 MATCH_STRING = "skycell-p\d{4}x\d{2}y\d{2}_input\.out"
 
 # --------------------------------------------------------------------------------------------------------------
@@ -352,6 +354,15 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
         # The product_list is a list of all the output products which will be put into the manifest file
         product_list = []
 
+        # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
+        # to use only one of the SkyCellProducts to generate the manifest name as the name
+        # is only dependent on the sky cell.
+        # Example: skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., skycell-p0797x12y05_manifest.txt)
+        manifest_defined = hasattr(total_obj_list[0], "manifest_name") and total_obj_list[0].manifest_name not in ["", None]
+        manifest_name = total_obj_list[0].manifest_name if manifest_defined else DEFAULT_MANIFEST_NAME
+        log.info("\nGenerate the manifest name for this multi-visit: {}.".format(manifest_name))
+        log.info("The manifest will contain the names of all the output products.")
+
         # Update the SkyCellProduct objects with their associated configuration information.
         for filter_item in total_obj_list:
             _ = filter_item.generate_metawcs(custom_limits=custom_limits)
@@ -360,15 +371,6 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
             # Optionally rename output products
             if output_file_prefix or custom_limits:
                 filter_item = rename_output_products(filter_item, output_file_prefix=output_file_prefix)
-
-            if 'manifest_name' not in locals():
-                # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
-                # to use only one of the SkyCellProducts to generate the manifest name as the name
-                # is only dependent on the sky cell.
-                # Example: skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., skycell-p0797x12y05_manifest.txt)
-                manifest_name = total_obj_list[0].manifest_name
-                log.info("\nGenerate the manifest name for this multi-visit: {}.".format(manifest_name))
-                log.info("The manifest will contain the names of all the output products.")
 
             log.info("Preparing configuration parameter values for filter product {}".format(filter_item.drizzle_filename))
             filter_item.configobj_pars = config_utils.HapConfig(filter_item,
@@ -507,13 +509,13 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
                     if re.search(MATCH_STRING, input_filename.lower()):
                         manifest_name = input_filename.lower().replace("input.out", "manifest.txt")
                     else:
-                        manifest_name = "skycell-p0000x00y00_manifest.txt"
+                        manifest_name = DEFAULT_MANIFEST_NAME
                 # Bigger problem case - try to use the name of the input file
             except Exception:
                 if re.search(MATCH_STRING, input_filename.lower()):
                     manifest_name = input_filename.lower().replace("input.out", "manifest.txt")
                 else:
-                    manifest_name = "skycell-p0000x00y00_manifest.txt"
+                    manifest_name = DEFAULT_MANIFEST_NAME
 
         log.info("Writing empty manifest file: {}".format(manifest_name))
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -1025,7 +1025,7 @@ class SkyCellProduct(HAPProduct):
         # Generate the name for the manifest file which is for the entire multi-visit.  It is fine
         # to use only one of the SkyCellProducts to generate the manifest name as the name
         # is only dependent on the sky cell.
-        # Example: hst_skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., hst_skycell-p0797x12y05_manifest.txt)
+        # Example: skycell-p<PPPP>x<XX>y<YY>_manifest.txt (e.g., skycell-p0797x12y05_manifest.txt)
         self.manifest_name = '_'.join([skycell_name, 'manifest.txt'])
 
         # Define HAPLEVEL value for this product

--- a/drizzlepac/runmultihap.py
+++ b/drizzlepac/runmultihap.py
@@ -108,7 +108,7 @@ def main():
                              'Specifying "critical" will only record/display "critical" log statements, and '
                              'specifying "error" will record/display both "error" and "critical" log '
                              'statements, and so on.')
-    parser.add_argument('-s', '--skip_gaia_alignment', required=False, action='store_true',
+    parser.add_argument('-s', '--skip_gaia_alignment', required=False, default=True, action='store_true',
                         help='Skip alignment of all input images to known Gaia/HSC sources in the input '
                              'image footprint? If this option is turned on, the existing input image '
                              'alignment solution will be used instead. The default is False.')


### PR DESCRIPTION
This prefix was inadvertently re-introduced when handling the special cases
of no data being available for processing or some other error when reading
the poller file so the total data product attributes were never set.  Hence,
no default manifest filename was defined.