### PR TITLE
Add explicit dependency on spherical-geometry and set min version

### DIFF
--- a/doc/.rtd-environment.yml
+++ b/doc/.rtd-environment.yml
@@ -15,7 +15,7 @@ dependencies:
       - sphinx_rtd_theme
       - sphinx_automodapi
       - matplotlib
-      - spherical_geometry
+      - "spherical_geometry>=1.2.22"
       - fitsblender
       - nictools
       - pyregion

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setup(
         'stregion',
         'requests',
         # HAP-pipeline specific:
+        "spherical_geometry>=1.2.22",
         'astroquery>=0.4',
         'bokeh',
         'pandas',

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'astropy<5.0.0',
         'fitsblender',
         'nictools',
-        'numpy<1.22',
+        'numpy>=1.19',
         'scipy',
         'matplotlib',
         'scikit-learn>=0.20',


### PR DESCRIPTION
This PR explicitly adds `spherical_geometry` to the list of dependencies in the `setup.py` because it is used by HAP code and I also set the minimum  version requirement for the `spherical_geometry` to `1.2.22` as previous versions may cause memory corruption.