### PR TITLE
Update apriori test to be more explicit with errors

### DIFF
--- a/drizzlepac/haputils/testutils.py
+++ b/drizzlepac/haputils/testutils.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import traceback
 
 from astropy.io import fits
 
@@ -128,6 +129,9 @@ def compare_wcs_alignment(dataset, force=False):
                                               product_type='pipeline')
             results = align_table.filtered_table
             alignment[wcs] = extract_results(results)
+    except Exception as err:
+        print(traceback.format_exc())
+        raise err
 
     finally:
         # Regardless of what happens, always reset the environment variable

--- a/tests/hap/test_apriori.py
+++ b/tests/hap/test_apriori.py
@@ -30,6 +30,7 @@ def compare_apriori(dataset):
     # Perform alignment of all WCS solutions with GAIA
     results_dict = testutils.compare_wcs_alignment(dataset)
     limit = 0.001
+    abs_limit = 0.1  # absolute limit above which fit may be suspect
 
     # Now compare results to see whether the a priori solutions succeeded
     # in improving the astrometry compared to default telescope pointing
@@ -65,9 +66,9 @@ def compare_apriori(dataset):
 
         # Check that rotation and scale are within
         rot = np.allclose(results['rotation'], pipeline_results['rotation'],
-                          rtol=limit, atol=0)
+                          rtol=limit, atol=abs_limit)
         scale = np.allclose(results['scale'], pipeline_results['scale'],
-                            rtol=limit, atol=0)
+                            rtol=limit, atol=abs_limit)
 
         # Determine success/failure of this dataset's fit
         if all([status, fit_qual, delta, rot, scale]):
@@ -79,14 +80,25 @@ def compare_apriori(dataset):
             print("FAILED  due to:")
             if not status:
                 print("\t* invalid STATUS")
+                print(results['status'])
             if not fit_qual:
                 print("\t* invalid fit quality")
+                print(results['fit_qual'])
             if not delta:
                 print("\t* increased offset from GAIA.")
+                print(offset)
+                print(pipeline_offset)
+                print(delta)
             if not rot:
                 print("\t* larger rotation from fit.")
+                print(results['rotation'])
+                print(pipeline_results['rotation'])
+                print(rot)
             if not scale:
                 print("\t* larger scale from fit.")
+                print(results['scale'])
+                print(pipeline_results['scale'])
+                print(scale)
 
     assert success
 


### PR DESCRIPTION
These changes make the 'test_apriori' tests less stringent while also reporting a lot more information on failures or Exceptions.  The less stringent limits for this test do not impact the validity of the test since they are looking for situations where the fitting ended up acting singular (wildly wrong, yet successful).  Small variations in the results can come from differences in the proper motions used in the catalog source positions as well as implemented (expected) changes to the sigma-clipping in the fitting itself amongst other valid reasons.  