### PR TITLE
Add explicit dependency on spherical-geometry and set min version (#1…

### DIFF
--- a/doc/.rtd-environment.yml
+++ b/doc/.rtd-environment.yml
@@ -15,7 +15,7 @@ dependencies:
       - sphinx_rtd_theme
       - sphinx_automodapi
       - matplotlib
-      - spherical_geometry
+      - "spherical_geometry>=1.2.22"
       - fitsblender
       - nictools
       - pyregion

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'astropy<5.0.0',
         'fitsblender',
         'nictools',
-        'numpy<1.22',
+        'numpy>=1.19',
         'scipy',
         'matplotlib',
         'scikit-learn>=0.20',
@@ -97,6 +97,7 @@ setup(
         'stregion',
         'requests',
         # HAP-pipeline specific:
+        "spherical_geometry>=1.2.22",
         'astroquery>=0.4',
         'bokeh',
         'pandas',


### PR DESCRIPTION
…232)

* Add explicit dependency on spherical-geometry and set min version

* Undo restricting numpy version to <1.22