### PR TITLE
Fix logic to not align grism data in standard pipeline

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -68,7 +68,7 @@ class AlignmentTable:
         * **apply_fit** : Updates all input image WCSs with the result of the selected 'best' fit
 
     """
-    def __init__(self, input_list, clobber=False, dqname='DQ',
+    def __init__(self, input_list, clobber=False, dqname='DQ', process_type='',
                  log_level=logutil.logging.NOTSET, **alignment_pars):
         """
         Parameters
@@ -82,6 +82,10 @@ class AlignmentTable:
         dqname : str, optional
             Allows the user to customize the name of the extension (`extname`) containing the
             data quality flags to be applied to the data during source identification.
+
+        process_type : str, optional
+            Specifies what type of data processing is being done on the input data.
+            Values include: '' (default for pipeline processing), 'SVM', 'MVM'.
 
         log_level : int, optional
             Set the logging level for this processing
@@ -141,7 +145,7 @@ class AlignmentTable:
         # Apply filter to input observations to insure that they meet minimum criteria for being able to be aligned
         log.info(
             "{} AlignmentTable: Filter STEP {}".format("-" * 20, "-" * 63))
-        self.filtered_table = analyze.analyze_data(input_list, type="SVM")
+        self.filtered_table = analyze.analyze_data(input_list, type=process_type)
         log.debug("Input sorted as: \n{}".format(self.filtered_table))
 
         if self.filtered_table['doProcess'].sum() == 0:

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -415,7 +415,7 @@ def analyze_data(input_file_list, log_level=logutil.logging.DEBUG, type=""):
         split_sfilter = sfilter.upper().split('_')
         for item in split_sfilter:
             # This is the only circumstance when Grism/Prism data WILL be processed.
-            if item.startswith(('G', 'PR')) and not is_zero and type.upper() != "MVM":
+            if item.startswith(('G', 'PR')) and not is_zero and type.upper() == "SVM":
                 no_proc_key = None
                 no_proc_value = None
                 log.info("The Grism/Prism data, {}, will be processed.".format(input_file))

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -137,7 +137,7 @@ class HAPProduct:
 
         return meta_wcs
 
-    def align_to_gaia(self, catalog_list=[], output=True,
+    def align_to_gaia(self, catalog_list=[], output=True, process_type='SVM',
                       fit_label='SVM', align_table=None, fitgeom=''):
         """Extract the flt/flc filenames from the exposure product list, as
            well as the corresponding headerlet filenames to use legacy alignment
@@ -183,6 +183,7 @@ class HAPProduct:
                 # If necessary, generate the alignment table only once
                 if align_table is None:
                     align_table = align_utils.AlignmentTable(exposure_filenames,
+                                                             process_type=process_type,
                                                              log_level=self.log_level,
                                                              **alignment_pars)
                     align_table.find_alignment_sources(output=output, crclean=crclean)


### PR DESCRIPTION
These changes correctly(?) utilize the logic in analyze_data to skip alignment of grism/prism data during standard pipeline processing while allowing the (partial) processing of grism/prism data for SVM processing as needed to sync WCSs with the direct images.  

The data from visit 'ibtt98' with grism ASNs 'ibtt98010' and 'ibtt98020' were used to verify the correct behavior of this logic for both standard pipeline processing and SVM processing.