### PR TITLE
Remove nictools as a dependency

### DIFF
--- a/drizzlepac/wfc3Data.py
+++ b/drizzlepac/wfc3Data.py
@@ -7,7 +7,6 @@
 
 """
 from stsci.tools import fileutil
-from nictools import readTDD
 from .imageObject import imageObject
 import numpy as np
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ setup_requires=
 install_requires =
     astropy<5.0.0
     fitsblender
-    nictools
     scipy
     matplotlib
     stsci.tools>=4.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from astropy import wcs
 from glob import glob
 from setuptools import setup, find_packages, Extension
 
-print("NUMPY VERSION IS ", numpy.__version__)
+
 # Setup C module include directories
 include_dirs = []
 numpy_includes = [numpy.get_include()]


### PR DESCRIPTION
`nictools` does not appear to be maintained, removing it makes drizzlepac's build system just a bit more robust.
Copied the code fro nictools to drizzlepac/nicmosData.py.

Should be merged after #1244.