### PR TITLE
RickerWavelet Kernel for SBC needs to have dimensions which are odd

### DIFF
--- a/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/default_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -35,7 +35,7 @@
         "nlevels": 64,
         "contrast": 0.001,
         "border": 10,
-        "rw2d_size": 24,
+        "rw2d_size": 23,
         "rw2d_nsigma": 10.0,
         "rw2d_biggest_source": 0.045,
         "rw2d_source_fraction": 0.15,


### PR DESCRIPTION
RickerWavelet Kernel for SBC needs to have dimensions which are odd.
Changed to 23 from 24.  Tested with j8ep07.