### PR TITLE
Remove logic from align

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -364,8 +364,7 @@ def perform_align(input_list, catalog_list, num_sources, archive=False, clobber=
             index = np.where(alignment_table.filtered_table['imageName'] == imgname)[0][0]
 
             # First ensure sources were found
-
-            if table is None or not table[1]:
+            if table is None:
                 log.warning("No sources found in image {}".format(imgname))
                 alignment_table.filtered_table[:]['status'] = 1
                 alignment_table.filtered_table[:]['processMsg'] = "No sources found"


### PR DESCRIPTION
This simple change addresses the bug reported in HLA-689 that related to checking for alignment results in align.py when it was apparently not necessary.   Removing this logic should allow more data to successfully align to GAIA.  