### PR TITLE
Generate correct HDRNAME (finally?)

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -1233,7 +1233,7 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
 
         # update header with new WCS info
         sci_extn = sci_ext_dict["{}".format(item.meta['chip'])]
-        hdr_name = "{}_{}-hlet.fits".format(image_name.rstrip(".fits"), wcs_name)
+        hdr_name = "{}_{}-hlet.fits".format(image_name.rstrip("fits")[:-1], wcs_name)
         updatehdr.update_wcs(hdulist, sci_extn, item.wcs, wcsname=wcs_name, reusename=True)
         info = item.meta['fit_info']
         if info['catalog'] and info['catalog'] != '':


### PR DESCRIPTION
This simple change corrects the use of 'rstrip' in the generation of the HDRNAME keyword so that it comes out as expected.  

Using '.rstrip(".fits")' on a full filename results in chopping the last character of the filename before the ".fits" (don't ask me why!).  However, using '.rstrip("fits")' leaves the '.' from the full filename at the end of the string.  This simply uses that behavior to correctly strip the '.fits' from a full filename and not chop the 'flt' or 'flc' to be 'fl'. 