### PR TITLE
SVM/MVM: Update/fix HAP code "exit" statement handling

### DIFF
--- a/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
+++ b/drizzlepac/devutils/comparison_tools/compare_sourcelists.py
@@ -1615,7 +1615,8 @@ def slFiles2dataTables(slNames):
                 log.info("titleSwapDict_point")
                 titleSwapDict = titleSwapDict_point
             else:
-                sys.exit("ERROR: Unrecognized format. Exiting...")
+                log.error("ERROR: Unrecognized format. Exiting...")
+                sys.exit(1)
         elif ("XCENTER" in list(dataTable.keys()) and "FLUX1" in list(dataTable.keys())):
             log.info("titleSwapDict_daoTemp")
             titleSwapDict = titleSwapDict_daoTemp
@@ -1635,7 +1636,8 @@ def slFiles2dataTables(slNames):
             log.info("titleSwapDict_segment")
             titleSwapDict = titleSwapDict_segment
         else:
-            sys.exit("ERROR: Unrecognized format. Exiting...")
+            log.error("ERROR: Unrecognized format. Exiting...")
+            sys.exit(1)
         outTable = Table()
         for swapKey in list(titleSwapDict.keys()):
             if titleSwapDict[swapKey] != "n/a":

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -646,7 +646,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
         logging.exception("message")
-
+    # TODO: put "except BaseException" code here (see hapmultisequencer.py, line 482)
     finally:
         # If poller_utils.py did not exit with an exception, the manifest filename exists.
         # If the manifest filename does not exist, need to construct a filename by using the

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -646,7 +646,12 @@ def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
         logging.exception("message")
-    # TODO: put "except BaseException" code here (see hapmultisequencer.py, line 482)
+    # This except handles sys.exit() which raises the SystemExit exception which inherits from BaseException.
+    except BaseException:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        formatted_lines = traceback.format_exc().splitlines()
+        log.info(formatted_lines[-1])
+        return_value = exc_value
     finally:
         # If poller_utils.py did not exit with an exception, the manifest filename exists.
         # If the manifest filename does not exist, need to construct a filename by using the

--- a/drizzlepac/haputils/comparison_utils.py
+++ b/drizzlepac/haputils/comparison_utils.py
@@ -411,7 +411,8 @@ def slFiles2dataTables(slNames):
                 log.info("titleSwapDict_point")
                 titleSwapDict = titleSwapDict_point
             else:
-                sys.exit("ERROR: Unrecognized format. Exiting...")
+                log.error("ERROR: Unrecognized format. Exiting...")
+                sys.exit(1)
         elif ("XCENTER" in list(dataTable.keys()) and "FLUX1" in list(dataTable.keys())):
             log.info("titleSwapDict_daoTemp")
             titleSwapDict = titleSwapDict_daoTemp
@@ -431,7 +432,8 @@ def slFiles2dataTables(slNames):
             log.info("titleSwapDict_segment")
             titleSwapDict = titleSwapDict_segment
         else:
-            sys.exit("ERROR: Unrecognized format. Exiting...")
+            log.error("ERROR: Unrecognized format. Exiting...")
+            sys.exit(1)
         outTable = Table()
         for swapKey in list(titleSwapDict.keys()):
             if titleSwapDict[swapKey] != "n/a":

--- a/drizzlepac/haputils/config_utils.py
+++ b/drizzlepac/haputils/config_utils.py
@@ -115,7 +115,7 @@ class HapConfig(object):
             if hasattr(prod_obj, "skycell"):
                 n_exp = int(round(prod_obj.mask_kws['MEANNEXP'][0]))  # Use mean number of exposures in skycell instead of just simple number of input images for MVM
             else:
-                n_exp = len(prod_obj.edp_list) # use simple number of input images for SVM
+                n_exp = len(prod_obj.edp_list)  # use simple number of input images for SVM
 
         # determine product type, initialize and build conditions list
         if hasattr(prod_obj, "edp_list") and hasattr(prod_obj, "fdp_list"):  # For total products
@@ -168,7 +168,7 @@ class HapConfig(object):
                         if n_exp >= 6:
                             self.conditions.append("acs_wfc_any_n6")
                     else:
-                        log.error("INVALID ACS DETECTOR!")
+                        log.error("{} is an invalid ACS detector!".format(self.detector))
                         sys.exit(1)
                 elif self.instrument == "wfc3":
                     if self.detector == "ir":
@@ -203,10 +203,10 @@ class HapConfig(object):
                             if n_exp >= 6:
                                 self.conditions.append("wfc3_uvis_any_pre_n6")
                     else:
-                        log.error("INVALID WFC3 DETECTOR!")
+                        log.error("{} is an invalid WFC3 detector!".format(self.detector))
                         sys.exit(1)
                 else:
-                    log.error("INVALID HST INSTRUMENT!")
+                    log.error("{} is an invalid HST instrument!".format(self.instrument))
                     sys.exit(1)
         else:  # For single-exposure products
             self.conditions = ["single_basic"]

--- a/drizzlepac/haputils/config_utils.py
+++ b/drizzlepac/haputils/config_utils.py
@@ -49,7 +49,8 @@ class HapConfig(object):
         """
         log.setLevel(log_level)
         if input_custom_pars_file and input_custom_pars_file and input_custom_pars_file == output_custom_pars_file:
-            sys.exit("ERROR: Input and output parameter files must have unique names!")
+            log.error("ERROR: Input and output parameter files must have unique names!")
+            sys.exit(1)
         self.label = "hap_config"
         self.description = "A set of routines to generate appropriate set of configuration parameters"
         self.instrument = prod_obj.instrument
@@ -167,7 +168,8 @@ class HapConfig(object):
                         if n_exp >= 6:
                             self.conditions.append("acs_wfc_any_n6")
                     else:
-                        sys.exit("INVALID ACS DETECTOR!")
+                        log.error("INVALID ACS DETECTOR!")
+                        sys.exit(1)
                 elif self.instrument == "wfc3":
                     if self.detector == "ir":
                         if self.filters.lower() in ["g102", "g141"]:
@@ -201,9 +203,11 @@ class HapConfig(object):
                             if n_exp >= 6:
                                 self.conditions.append("wfc3_uvis_any_pre_n6")
                     else:
-                        sys.exit("INVALID WFC3 DETECTOR!")
+                        log.error("INVALID WFC3 DETECTOR!")
+                        sys.exit(1)
                 else:
-                    sys.exit("INVALID HST INSTRUMENT!")
+                    log.error("INVALID HST INSTRUMENT!")
+                    sys.exit(1)
         else:  # For single-exposure products
             self.conditions = ["single_basic"]
             if prod_obj.is_singleton:

--- a/drizzlepac/haputils/config_utils.py
+++ b/drizzlepac/haputils/config_utils.py
@@ -249,8 +249,8 @@ class HapConfig(object):
         if step_name in step_list:
             return self.pars[step_name].outpars
         else:
-            log.critical("'{}' is not a recognized step name.".format(step_name))
-            log.critical("Recognized step names: \n{}".format(str(step_list)[2:-2].replace("', '", "\n")))
+            log.error("'{}' is not a recognized step name.".format(step_name))
+            log.error("Recognized step names: \n{}".format(str(step_list)[2:-2].replace("', '", "\n")))
             sys.exit(1)
 
 

--- a/drizzlepac/haputils/get_git_rev_info.py
+++ b/drizzlepac/haputils/get_git_rev_info.py
@@ -108,7 +108,6 @@ def get_rev_id(local_repo_path):
                 raise ValueError("Git revision information not found.")
     except Exception:
         log.warning("Problem encountered getting git revision ID")
-        sys.exit(1)
     finally:
         os.chdir(start_path)
     return(rv)

--- a/drizzlepac/haputils/get_git_rev_info.py
+++ b/drizzlepac/haputils/get_git_rev_info.py
@@ -79,8 +79,7 @@ def print_rev_id(local_repo_path):
             sys.exit(rv)
 # -------------------------------------------------------------------------------------------------
 def get_rev_id(local_repo_path):
-    """returns the current full git revision id of the specified local repository. Expected method of execution: python
-    subroutine call
+    """returns the current full git revision id of the specified local repository.
 
     Parameters
     ----------
@@ -108,10 +107,10 @@ def get_rev_id(local_repo_path):
             else:
                 raise ValueError("Git revision information not found.")
     except Exception:
-        pass
+        log.warning("Problem encountered getting git revision ID")
+        sys.exit(1)
     finally:
         os.chdir(start_path)
-
     return(rv)
 # -------------------------------------------------------------------------------------------------
 if(__name__ == '__main__'):

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -439,8 +439,10 @@ class TotalProduct(HAPProduct):
     def update_drizpars(self):
         """ Update ALL products with final name of trailer file """
         # Update this total product
-        fits.setval(self.drizzle_filename, 'DRIZPARS', value=self.trl_filename)
-
+        if os.path.exists(self.drizzle_filename):
+            fits.setval(self.drizzle_filename, 'DRIZPARS', value=self.trl_filename)
+        else:
+            log.warning("File {} not found. DRIZPARS header value update failed.".format(self.drizzle_filename))
         # Update all filter drizzle products that were actually written out
         for fdp in self.fdp_list:
             if os.path.exists(fdp.drizzle_filename):


### PR DESCRIPTION
**Relevant Issues and Tickets**
- [HLA-677](https://jira.stsci.edu/browse/HLA-677)
- Issue #1212
- [HLA-712](https://jira.stsci.edu/browse/HLA-712)
- Issue #1260 

**Summary of Changes**
- The main goal here was to standardize execution of the sys.exit() command by any and all code ultimately run by either the SVM or MVM pipeline.
- At the site of any sys.exit() command in  any code that is ultimately run by either the SVM or MVM pipeline I...
      - ensured that there was a descriptive message in a log.error() statement
      - ensured that the sys.exit() command returned an integer value, which was typically 1, but could also be 0, 55 or 65 in specific cases.
 - A small section of code was copied from hapmultisequencer.py to  hapsequencer.py to handle BaseExceptions raised when a sys.exit() command is executed.