### PR TITLE
Add product rules files for deletion

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -211,6 +211,9 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
         filt_obj.rules_file = proc_utils.get_rules_file(filt_obj.edp_list[0].full_filename,
                                                         rules_type='MVM',
                                                         rules_root=filt_obj.drizzle_filename)
+        # add filter rules files to dict of all rules files for deletion later
+        rules_files[filt_obj.drizzle_filename] = filt_obj.rules_file
+
         log.info("~" * 118)
         # Get the common WCS for all images which are part of a total detection product,
         # where the total detection product is detector-dependent.

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -387,6 +387,9 @@ def create_drizzle_products(total_obj_list):
                 log.info("~" * 118)
                 filt_obj.rules_file = proc_utils.get_rules_file(filt_obj.edp_list[0].full_filename,
                                                                 rules_root=filt_obj.drizzle_filename)
+                # add filter rules files to dict of all rules files for deletion later
+                rules_files[filt_obj.drizzle_filename] = filt_obj.rules_file
+
                 print(f"Filter RULES_FILE: {filt_obj.rules_file}")
                 log.info("CREATE DRIZZLE-COMBINED FILTER IMAGE: {}\n".format(filt_obj.drizzle_filename))
                 filt_obj.wcs_drizzle_product(meta_wcs)
@@ -410,6 +413,9 @@ def create_drizzle_products(total_obj_list):
             log.info("CREATE DRIZZLE-COMBINED TOTAL IMAGE: {}\n".format(total_obj.drizzle_filename))
             total_obj.rules_file = proc_utils.get_rules_file(total_obj.edp_list[0].full_filename,
                                                                 rules_root=total_obj.drizzle_filename)
+            # add total rules files to dict of all rules files for deletion later
+            rules_files[total_obj.drizzle_filename] = total_obj.rules_file
+
             print(f"Total product RULES_FILE: {total_obj.rules_file}")
             total_obj.wcs_drizzle_product(meta_wcs)
             product_list.append(total_obj.drizzle_filename)


### PR DESCRIPTION
Logic for deleting all the rules files generated during SVM and MVM processing gets updated with these changes to include the rules files created for the filter and total products as well.  Previously, these rules files were not included in the list of rules files which get deleted during processing resulting in these intermediate files being left behind after successful processing and causing confusion for subsequent processing.   