### PR TITLE
Protect actions being performed on a potentially NoneType object

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -372,7 +372,8 @@ def perform_align(input_list, catalog_list, num_sources, archive=False, clobber=
             # The catalog of observable sources must have at least MIN_OBSERVABLE_THRESHOLD entries to be useful
             total_num_sources = 0
             for chipnum in table.keys():
-                total_num_sources += len(table[chipnum])
+                if table[chipnum] is not None:
+                    total_num_sources += len(table[chipnum])
 
             # Update filtered table with number of found sources
             alignment_table.filtered_table[index]['foundSources'] = total_num_sources


### PR DESCRIPTION
Update to handle the situation where the one chip has sources, but the other chip has no sources, and the data is stored in a dictionary. The "table" is actually a dictionary so the len function on len(table[chipnum]) where table[chipnum] is NoneType caused an exception.