### PR TITLE
Generate SVM QA JSONs again

### DIFF
--- a/drizzlepac/haputils/diagnostic_utils.py
+++ b/drizzlepac/haputils/diagnostic_utils.py
@@ -211,9 +211,9 @@ class HapDiagnostic(object):
             time_since_epoch = time.time()
         self.out_dict['general information']['seconds since epoch'] = time_since_epoch
         # add git commit id
-        reporootpath = "/"
-        for item in __file__.split("/")[0:-3]:
-            reporootpath = os.path.join(reporootpath, item)
+        reporootpath = os.path.dirname(__file__)
+        for i in range(2):
+            reporootpath = os.path.dirname(reporootpath)
         self.out_dict['general information']['commit id'] = get_git_rev_info.get_rev_id(reporootpath)
         del reporootpath
         # add data_source and description # TODO: THESE MAY BE REMOVED LATER ON

--- a/drizzlepac/haputils/get_git_rev_info.py
+++ b/drizzlepac/haputils/get_git_rev_info.py
@@ -66,7 +66,7 @@ def print_rev_id(local_repo_path):
             # for Windows, 'head' command doesn't exist
             instream = os.popen('git log --oneline |more')
             for line in instream:
-                log.info("{}\n".format(instream[0].strip()))
+                log.info("{}\n".format(line.strip()))
                 # Only print out first entry, then quit
                 break
         else:

--- a/drizzlepac/haputils/get_git_rev_info.py
+++ b/drizzlepac/haputils/get_git_rev_info.py
@@ -62,9 +62,17 @@ def print_rev_id(local_repo_path):
             log.info("{}".format(streamline.strip()))
 
         log.info("\n===== Most Recent Commit =====")
-        instream = os.popen('git log |head -1')
-        for streamline in instream:
-            log.info("{}\n".format(streamline.strip()))
+        if 'win' in sys.platform:
+            # for Windows, 'head' command doesn't exist
+            instream = os.popen('git log --oneline |more')
+            for line in instream:
+                log.info("{}\n".format(instream[0].strip()))
+                # Only print out first entry, then quit
+                break
+        else:
+            instream = os.popen('git log |head -1')
+            for streamline in instream:
+                log.info("{}\n".format(streamline.strip()))
 
         rv = 0
 
@@ -99,13 +107,19 @@ def get_rev_id(local_repo_path):
     try:
         os.chdir(local_repo_path)
 
-        instream = os.popen("git --no-pager log --max-count=1 | head -1")
-        for streamline in instream.readlines():
-            streamline = streamline.strip()
-            if streamline.startswith("commit "):
-                rv = streamline.replace("commit ", "")
-            else:
-                raise ValueError("Git revision information not found.")
+        if 'win' not in sys.platform:
+            instream = os.popen("git --no-pager log --max-count=1 | head -1")
+            for streamline in instream.readlines():
+                streamline = streamline.strip()
+                if streamline.startswith("commit "):
+                    rv = streamline.replace("commit ", "")
+                else:
+                    raise ValueError("Git revision information not found.")
+        else:
+            instream = os.popen("git --no-pager log --max-count=1 | more")
+            for streamline in instream.readlines():
+                rv = streamline.split(' ')[0]
+                break
     except Exception:
         log.warning("Problem encountered getting git revision ID")
     finally:

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1044,7 +1044,7 @@ def find_hap_point_sources(filt_obj, log_level=logutil.logging.NOTSET):
     log.info("DAOStarFinder(fwhm={}, threshold={}*{})".format(img_obj.kernel_fwhm,
                                                               nsigma, img_obj.bkg_rms_median))
     daofind = DAOStarFinder(fwhm=img_obj.kernel_fwhm, threshold=nsigma * img_obj.bkg_rms_median)
-    sources = daofind(image, mask=exclusion_mask)
+    sources = Table(daofind(image, mask=exclusion_mask))
     cat_name = filt_obj.product_basename + "_point-cat-fxm.ecsv"
 
     return {"filt_obj": filt_obj, "sources": sources, "cat_name": cat_name}


### PR DESCRIPTION
The JSON files now can be generated for SVM processing with **'SVM_QUALITY_TESTING'** turned on as a result of these changes.  Updating _photutils_ to v1.2.0 resulted in the table of point sources to be returned as a **QTable** instead of a simpler **Table** object, and the **QTable** object can not (at this time anyway) be serialized as a **JSON** object.  Casting the output from _photutils_ to a simpler **Table** object fixes this problem with no consequences.  This allows the SVM testing using the _'svm_quality_analysis'_ module to succeed regardless of the version of _photutils_.  

In addition, a couple of changes were implemented to allow this code to be more platform independent; specifically, the git information can now be reported successfully even when run on Windows.  

These changes were tested under both Windows 10 and Linux on data from visit 'iacs01'.