### PR TITLE
Update requirements to allow astropy 5.0 use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0",
             "setuptools_scm[toml]>=3.4",
             "wheel",
             "oldest-supported-numpy",
-            "astropy<5.0"]
+            "astropy>=4.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.8
 setup_requires=
     setuptool_scm
 install_requires =
-    astropy<5.0.0
+    astropy>=4.3.0
     fitsblender
     scipy
     matplotlib
@@ -52,6 +52,7 @@ install_requires =
     PyPDF2
     scikit-image>=0.14.2
     tables
+    typing_extensions>4.0
 
 [options.extras_require]
 


### PR DESCRIPTION
This simply updates the dependency requirements for the package to allow use of the latest version of astropy; namely, astropy 5.0.  The addition of the 'typing_extensions' dependency is needed since astropy 5.0.1 does not include this itself, as it was only added to astropy installation with [Astropy PR #12812](https://github.com/astropy/astropy/pull/12812) after 5.0.1 was released.  

The results of using astropy 5.0.1 are identical to using astropy 4.3.post1 based on comparisons of data from visit 'iacs01' along with running the 'hap' pytests.  