### PR TITLE
Reset tasknames to work with TEAL

### DIFF
--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -31,7 +31,7 @@ from . import __version__
 
 __all__ = ['blot', 'runBlot', 'help', 'getHelpAsString']
 
-__taskname__ = 'drizzlepac.ablot'
+__taskname__ = 'ablot'
 _blot_step_num_ = 5
 
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -37,7 +37,7 @@ __all__ = ['drizzle', 'run', 'drizSeparate', 'drizFinal', 'mergeDQarray',
            'get_data', 'create_output', 'help', 'getHelpAsString']
 
 
-__taskname__ = "drizzlepac.adrizzle"
+__taskname__ = "adrizzle"
 _single_step_num_ = 3
 _final_step_num_ = 7
 

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -48,7 +48,7 @@ from . import wcs_functions
 from . import __version__
 
 
-__taskname__ = "drizzlepac.astrodrizzle"
+__taskname__ = "astrodrizzle"
 
 
 # Pointer to the included Python class for WCS-based coordinate transformations

--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -42,7 +42,7 @@ import numpy as np
 
 from . import processInput, util
 
-__taskname__ = 'drizzlepac.buildmask'
+__taskname__ = 'buildmask'
 #
 #### Interactive interface
 #

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -18,7 +18,7 @@ from stwcs import distortion, wcsutil
 from stwcs.wcsutil import headerlet
 from . import __version__
 
-__taskname__ = 'drizzlepac.buildwcs'
+__taskname__ = 'buildwcs'
 
 # These default parameter values have the same keys as the parameters from
 # the configObj interface

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -25,7 +25,7 @@ from .adrizzle import _single_step_num_
 from . import __version__
 
 # look in drizzlepac for createMedian.cfg:
-__taskname__ = "drizzlepac.createMedian"
+__taskname__ = "createMedian"
 _step_num_ = 4  # this relates directly to the syntax in the cfg file
 
 BUFSIZE = 1024*1024   # 1MB cache size

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -25,7 +25,7 @@ if util.can_parallel:
     import multiprocessing
 
 
-__taskname__ = "drizzlepac.drizCR"  # looks in drizzlepac for sky.cfg
+__taskname__ = "drizCR"  # looks in drizzlepac for sky.cfg
 _STEP_NUM = 6  # this relates directly to the syntax in the cfg file
 
 

--- a/drizzlepac/imagefindpars.py
+++ b/drizzlepac/imagefindpars.py
@@ -9,7 +9,7 @@ from stsci.tools import teal
 from . import util
 from . import __version__
 
-__taskname__ = 'drizzlepac.imagefindpars'
+__taskname__ = 'imagefindpars'
 
 
 __doc__ = util._def_help_functions(

--- a/drizzlepac/mapreg.py
+++ b/drizzlepac/mapreg.py
@@ -18,7 +18,7 @@ from . import util
 from .regfilter import fast_filter_outer_regions
 
 
-__taskname__ = 'drizzlepac.mapreg'
+__taskname__ = 'mapreg'
 __author__ = 'Mihai Cara'
 
 

--- a/drizzlepac/photeq.py
+++ b/drizzlepac/photeq.py
@@ -25,7 +25,7 @@ from astropy.io import fits
 from . import __version__
 
 __all__ = ['photeq']
-__taskname__ = 'drizzlepac.photeq'
+__taskname__ = 'photeq'
 __author__ = 'Mihai Cara'
 
 

--- a/drizzlepac/pixreplace.py
+++ b/drizzlepac/pixreplace.py
@@ -63,7 +63,7 @@ from . import util
 
 
 __all__ = ['replace', 'help', 'getHelpAsString']
-__taskname__ = 'drizzlepac.pixreplace'
+__taskname__ = 'pixreplace'
 
 
 def replace(input, **pars):

--- a/drizzlepac/pixtopix.py
+++ b/drizzlepac/pixtopix.py
@@ -101,7 +101,7 @@ from . import wcs_functions
 from . import util
 from . import __version__
 
-__taskname__ = 'drizzlepac.pixtopix'
+__taskname__ = 'pixtopix'
 
 
 def tran(inimage, outimage, direction='forward', x=None, y=None,

--- a/drizzlepac/pixtosky.py
+++ b/drizzlepac/pixtosky.py
@@ -92,7 +92,7 @@ import stwcs
 from stwcs import distortion, wcsutil
 from . import __version__
 
-__taskname__ = 'drizzlepac.pixtosky'
+__taskname__ = 'pixtosky'
 
 blank_list = [None, '', ' ']
 

--- a/drizzlepac/refimagefindpars.py
+++ b/drizzlepac/refimagefindpars.py
@@ -10,7 +10,7 @@ from stsci.tools import teal
 from . import util
 from . import __version__
 
-__taskname__ = 'drizzlepac.refimagefindpars'
+__taskname__ = 'refimagefindpars'
 
 
 __doc__ = util._def_help_functions(

--- a/drizzlepac/resetbits.py
+++ b/drizzlepac/resetbits.py
@@ -72,7 +72,7 @@ from stsci.tools.bitmask import interpret_bit_flags
 from . import util
 from . import __version__
 
-__taskname__ = "drizzlepac.resetbits"
+__taskname__ = "resetbits"
 
 
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)

--- a/drizzlepac/skytopix.py
+++ b/drizzlepac/skytopix.py
@@ -80,7 +80,7 @@ import stwcs
 from stwcs import distortion,wcsutil
 from . import __version__
 
-__taskname__ = 'drizzlepac.skytopix'
+__taskname__ = 'skytopix'
 
 blank_list = [None, '', ' ']
 

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -20,7 +20,7 @@ from stsci.imagestats import ImageStats
 from . import util
 from . import processInput
 
-__taskname__ = "drizzlepac.staticMask"
+__taskname__ = "staticMask"
 _step_num_ = 1
 
 

--- a/drizzlepac/tweakback.py
+++ b/drizzlepac/tweakback.py
@@ -29,7 +29,7 @@ from . import util
 from . import __version__
 
 
-__taskname__ = 'drizzlepac.tweakback'
+__taskname__ = 'tweakback'
 
 
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -29,7 +29,7 @@ from . import imagefindpars
 from . import refimagefindpars
 from . import __version__
 
-__taskname__ = 'drizzlepac.tweakreg'
+__taskname__ = 'tweakreg'
 
 PSET_SECTION        = '_SOURCE FINDING PARS_'
 PSET_SECTION_REFIMG = '_REF IMAGE SOURCE FINDING PARS_'

--- a/drizzlepac/updatenpol.py
+++ b/drizzlepac/updatenpol.py
@@ -65,7 +65,7 @@ C version of MultiDrizzle (astrodrizzle).
 """
 __docformat__ = 'restructuredtext'
 
-__taskname__ = "drizzlepac.updatenpol"
+__taskname__ = "updatenpol"
 
 import os,sys,shutil
 

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -1213,7 +1213,7 @@ def base_taskname(taskname, packagename=None):
 
 def _get_help_as_string(docstring, show_ver, module_file, task_name, module_doc):
     install_dir = os.path.dirname(module_file)
-    taskname = base_taskname(task_name, __package__)
+    taskname = base_taskname(task_name)
     htmlfile = os.path.join(install_dir, 'htmlhelp', taskname + '.html')
     helpfile = os.path.join(install_dir, taskname + '.help')
 
@@ -1230,7 +1230,7 @@ def _get_help_as_string(docstring, show_ver, module_file, task_name, module_doc)
 
 
 def _def_help_functions(module, module_file, task_name, module_doc):
-    tname = base_taskname(task_name, __package__)
+    tname = base_taskname(task_name)
 
     def getHelpAsString(docstring=False, show_ver=True):
         return _get_help_as_string(docstring, show_ver, module_file=module_file,


### PR DESCRIPTION
These changes reset the values of the `__taskname__` variable for each task/module in drizzlepac so that code which calls teal to get the default parameters using these tasknames will actually work again.  This will enable many of the pytest tests to also run successfully again as well.  