### PR TITLE
Limit markupsafe version for astropy use

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     scikit-image>=0.14.2
     tables
     typing_extensions>4.0
+    markupsafe<2.1.0
 
 [options.extras_require]
 


### PR DESCRIPTION
This simple change insures that the version of the markupsafe package used by astropy will allow astropy to still work, as markupsafe v2.1.0 removed functionality which astropy used up through 5.0.1.  This will allow the publish to PyPI scripts to work for drizzlepac as well. 