### PR TITLE
Limit markupsafe version for astropy use (#1286)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     scikit-image>=0.14.2
     tables
     typing_extensions>4.0
+    markupsafe<2.1.0
 
 [options.extras_require]
 


### PR DESCRIPTION
Update release branch to allow publishing to PyPI to work.