### PR TITLE
Update pyproject file for public release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ requires = ["setuptools>=42.0",
             "setuptools_scm[toml]>=3.4",
             "wheel",
             "oldest-supported-numpy",
-            "astropy>=4.3"]
+            "astropy>=4.3",
+            "markupsafe<=2.0.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Update pyproject file to include markupsafe version limit for astropy 5.0 use to (hopefully) enable code to be published to PyPI.