### PR TITLE
Remove IPPPSSOO keyword from MVM product headers (again)

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -199,8 +199,7 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
     for imgname in edp_names:
         rules_files[imgname] = proc_utils.get_rules_file(imgname, rules_type='MVM')
 
-    print('Generated RULES_FILE names of: \n{}\n'.format(rules_files))
-
+    log.debug(f'Generated LAYER RULES_FILE name of: \n\t{rules_files}\n')
     # Keep track of all the products created for the output manifest
     product_list = []
 
@@ -211,6 +210,8 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
         filt_obj.rules_file = proc_utils.get_rules_file(filt_obj.edp_list[0].full_filename,
                                                         rules_type='MVM',
                                                         rules_root=filt_obj.drizzle_filename)
+        log.debug(f'Generated LAYER RULES_FILE name of: \n\t{filt_obj.rules_file}\n')
+
         # add filter rules files to dict of all rules files for deletion later
         rules_files[filt_obj.drizzle_filename] = filt_obj.rules_file
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -1174,6 +1174,7 @@ class SkyCellProduct(HAPProduct):
         # ...and set parameters which are computed on-the-fly
         drizzle_pars["final_refimage"] = meta_wcs
         drizzle_pars["runfile"] = self.trl_logname
+        drizzle_pars['rules_file'] = self.rules_file
         # Setting "preserve" to false so the OrIg_files directory is deleted as the purpose
         # of this directory is now obsolete.
         drizzle_pars["preserve"] = False


### PR DESCRIPTION
This corrects an oversight in the drizzling of MVM products, where the rules file intended for generating the MVM products was not being explicitly passed to AstroDrizzle.  The changes here now insures that the correct rules file gets used so that the IPPPSSOO keyword no longer appears in ANY MVM product header.  