### PR TITLE
skip building wheels on i686 (#1296)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,6 +10,8 @@ jobs:
     with:
       test: false
       build_platform_wheels: true # Set to true if your package contains a C extension
+    env:
+      CIBW_SKIP: "*-manylinux_i686"
     secrets:
       user: ${{ secrets.PYPI_USERNAME_STSCI_MAINTAINER }}
       password: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }} # WARNING: Do not hardcode secret values here! If you want to use a different user or password, you can override this secret by creating one with the same name in your Github repository settings.


### PR DESCRIPTION
Update publish script to avoid trying to build i686 wheels.  