### PR TITLE
Statistics for SVM and MVM 

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -80,7 +80,7 @@ class HAPProduct:
         # Initialize attributes for use in generating the output products
         self.meta_wcs = None
         self.mask = None
-        self.mask_kws = MASK_KWS.copy()
+        self.mask_kws = copy.deepcopy(MASK_KWS)
         self.mask_computed = False
 
     # def print_info(self):


### PR DESCRIPTION
This ticket addresses a majority of HLA-338 HLA-687.  

Also, fixed a bug which manifested itself by inserting incorrect statistics into each SkyCell layer.  The statistics for the last layer processed were used for all layers.  The problem was a shallow copy of the default dictionary was used to initialize the object attribute when a deepcopy was needed.  The stats are in SCI header only.

WHT statistics.