### PR TITLE
Ignore git information for installations in conda envs

### DIFF
--- a/drizzlepac/haputils/comparison_utils.py
+++ b/drizzlepac/haputils/comparison_utils.py
@@ -352,6 +352,10 @@ def slFiles2dataTables(slNames):
             compData_in = Table.read(slNames[1], format='ascii.daophot')
         except Exception:
             compData_in = Table.read(slNames[1], format='ascii')
+    # Need to watch for empty catalogs being provided for comparison
+    if len(refData_in)==0 or len(compData_in)==0:
+        return [refData_in, compData_in]
+
     titleSwapDict_dao1 = {"X": "X-Center", "Y": "Y-Center", "RA": "RA", "DEC": "DEC", "FLUX1": "n/a",
                           "FLUX2": "Flux(0.15)", "MAGNITUDE1": "MagAp(0.05)", "MAGNITUDE2": "MagAp(0.15)",
                           "MERR1": "MagErr(0.05)", "MERR2": "MagErr(0.15)", "MSKY": "MSky(0.15)",

--- a/drizzlepac/haputils/get_git_rev_info.py
+++ b/drizzlepac/haputils/get_git_rev_info.py
@@ -106,6 +106,12 @@ def get_rev_id(local_repo_path):
     start_path = os.getcwd()
     try:
         os.chdir(local_repo_path)
+        # If not installed in 'develop' mode, git information
+        # will not be present, so look for it explicitly and
+        # exit with the correct message before triggering a
+        # fatal error.
+        if not os.path.exists('.git'):
+            raise OSError("git revision info not found.")
 
         if 'win' not in sys.platform:
             instream = os.popen("git --no-pager log --max-count=1 | head -1")
@@ -118,10 +124,15 @@ def get_rev_id(local_repo_path):
         else:
             instream = os.popen("git --no-pager log --max-count=1 | more")
             for streamline in instream.readlines():
-                rv = streamline.split(' ')[0]
+                rv = streamline.split(' ')[1]
                 break
     except Exception:
         log.warning("Problem encountered getting git revision ID")
+        # If no git version was found, assume it was installed from master.
+        # Even if installed from a release branch, if there is no git information
+        # it was installed separate from the source directory, so it is a
+        # at least a release branch which is comparable to master.
+        rv = 'master'
     finally:
         os.chdir(start_path)
     return(rv)

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -409,6 +409,12 @@ def compare_ra_dec_crossmatches(hap_obj, json_timestamp=None, json_time_since_ep
     sl_lengths = [len(point_data['RA']), len(seg_data['RA'])]
     json_results_dict['point catalog length'] = sl_lengths[0]
     json_results_dict['segment catalog length'] = sl_lengths[1]
+    # Guard against empty catalogs being compared
+    if min(sl_lengths) == 0:
+        log.warning("*** No matching sources were found. Comparisons cannot be computed. "
+                    "No json file will be produced.***")
+        return
+
     matching_lines_ref, matching_lines_img = cu.getMatchedLists(sl_names, img_names, sl_lengths,
                                                                 log_level=log_level)
     json_results_dict['number of cross-matches'] = len(matching_lines_ref)
@@ -430,8 +436,8 @@ def compare_ra_dec_crossmatches(hap_obj, json_timestamp=None, json_time_since_ep
                                                                                  / float(sl_lengths[1]))))
     # return without creating a .json if no cross-matches are found
     if len(matching_lines_ref) == 0 or len(matching_lines_img) == 0:
-        log.error("*** No matching sources were found. Comparisons cannot be computed. "
-                  "No json file will be produced.***")
+        log.warning("*** No matching sources were found. Comparisons cannot be computed. "
+                    "No json file will be produced.***")
         return
     # 2: Create masks to remove missing values or values not considered "good" according to user-specified
     # good bit values


### PR DESCRIPTION
These changes add logic to guard against trying to cross-match empty catalogs in svm_quality_analysis which would otherwise cause an Exception reporting an "Unrecognized format.  Exiting...".  

In addition, these changes look to see whether or not the package has been installed outside the source tree, like it would be when installed under a conda envs site-packages directory.  If no git information is present, it instead reports the commit id as 'master' as a default rather than raising an Exception.  

Finally, some changes were also included to clean up the git hash returned under Windows so that is is valid.