### PR TITLE
Synchronize output WCS specifications for SVM processing

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -594,7 +594,6 @@ class FilterProduct(HAPProduct):
         # start by pulling out the specific parameters for the final refimage as
         # separate input parameters
         # rot and scale are specified in the config pars json files
-        # drizzle_pars["final_refimage"] = meta_wcs
         drizzle_pars["final_ra"] = meta_wcs.wcs.crval[0]
         drizzle_pars["final_dec"] = meta_wcs.wcs.crval[1]
         drizzle_pars["final_crpix1"] = meta_wcs.wcs.crpix[0]

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -128,10 +128,14 @@ class HAPProduct:
         log.debug("The following images will be used: ")
         log.debug("{}\n".format(exposure_filenames))
 
+        # Extract final output rot and scale from AstroDrizzle parameters to be used
+        final_rot = self.configobj_pars.pars['astrodrizzle'].outpars['final_rot']
+        final_scale = self.configobj_pars.pars['astrodrizzle'].outpars['final_scale']
         # Set the rotation to 0.0 to force North as up
         if exposure_filenames:
-            meta_wcs = wcs_functions.make_mosaic_wcs(exposure_filenames, rot=0.0)
-
+            meta_wcs = wcs_functions.make_mosaic_wcs(exposure_filenames,
+                                                     rot=final_rot,
+                                                     scale=final_scale)
         # Used in generation of SkyFootprints
         self.meta_wcs = meta_wcs
 
@@ -587,7 +591,17 @@ class FilterProduct(HAPProduct):
         # Retrieve the configuration parameters for astrodrizzle
         drizzle_pars = self.configobj_pars.get_pars("astrodrizzle")
         # ...and set parameters which are computed on-the-fly
-        drizzle_pars["final_refimage"] = meta_wcs
+        # start by pulling out the specific parameters for the final refimage as
+        # separate input parameters
+        # rot and scale are specified in the config pars json files
+        # drizzle_pars["final_refimage"] = meta_wcs
+        drizzle_pars["final_ra"] = meta_wcs.wcs.crval[0]
+        drizzle_pars["final_dec"] = meta_wcs.wcs.crval[1]
+        drizzle_pars["final_crpix1"] = meta_wcs.wcs.crpix[0]
+        drizzle_pars["final_crpix2"] = meta_wcs.wcs.crpix[1]
+        drizzle_pars["final_outnx"] = meta_wcs.pixel_shape[0]
+        drizzle_pars["final_outny"] = meta_wcs.pixel_shape[1]
+
         drizzle_pars["runfile"] = self.trl_logname
         # Setting "preserve" to false so the OrIg_files directory is deleted as the purpose
         # of this directory is now obsolete.

--- a/drizzlepac/wcs_functions.py
+++ b/drizzlepac/wcs_functions.py
@@ -1049,6 +1049,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
         hwcs = altwcs.pc2cd(hwcs, key=wcskey)
     return hwcs
 
+
 def make_mosaic_wcs(filenames, rot=None, scale=None):
     """Combine WCSs from all input files into a single meta-WCS
 
@@ -1079,8 +1080,18 @@ def make_mosaic_wcs(filenames, rot=None, scale=None):
     output_wcs = utils.output_wcs(hstwcs_list, undistort=True)
     output_wcs.wcs.cd = make_perfect_cd(output_wcs)
 
-    mosaic_wcs = mergeWCS(output_wcs, {'rot': rot, 'scale': scale})
+    # Apply each parameter in order, as this is effectively what is
+    # done by AstroDrizzle.  This insures that all rounding effects
+    # are applied
+    if rot is not None:
+        mosaic_wcs = mergeWCS(output_wcs, {'rot': rot})
+    else:
+        mosaic_wcs = output_wcs
+    if scale is not None:
+        mosaic_wcs = mergeWCS(mosaic_wcs, {'rot':rot, 'scale': scale})
+
     return mosaic_wcs
+
 
 def create_mosaic_pars(mosaic_wcs):
     """Return dict of values to use with AstroDrizzle to specify output mosaic


### PR DESCRIPTION
The specification of the output WCS used in determining the backgrounds during catalog generation, and all throughout SVM processing, are now synchronized between what AstroDrizzle computes and what the SVM determines for the meta_wcs.  Hard-coded values and interpreted WCS objects were removed in favor of exact user and/or config-file specified output WCS values which eliminates a source of rounding error when trying to use the AstroDrizzle products with the SVM computations.  

These changes address the problems seen when processing some ACS/HRC datasets where an IndexError like:

```
 File "/ifs/pipeline/dms/rhel7/pkgs/miniconda3/envs/caldp_mvmbeta/lib/python3.8/site-packages/drizzlepac/haputils/catalog_utils.py", line 275, in compute_background
    num_of_zeros = np.count_nonzero(imgdata[self.footprint_mask] == 0)
IndexError: boolean index did not match indexed array along dimension 0; dimension is 1462 but corresponding boolean dimension is 1461
```

The problems were reproduced using data from visits 'j6d508' and 'j8ep07', and those same datasets (along with all HAP pytest tests) were used to verify that the problem was fixed with these changes. 