### PR TITLE
Apply default alignment fit parameters for zero exptime exposures

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1710,7 +1710,10 @@ def _update_wcs_fit_keywords(fltfile, flcfile):
         sci_extn = ('SCI', extnum)
         for kw in fit_kws_sci:
             src_hdr = hdulist_flc[sci_extn].header
-            hdulist[sci_extn].header.set(kw[0], value=src_hdr[kw[0]], after='WCSNAME')
+            # Account for situations where FLC was not updated due to
+            # EXPTIME=0 or other condition
+            src_val = src_hdr[kw[0]] if kw[0] in src_hdr else kw[1]
+            hdulist[sci_extn].header.set(kw[0], value=src_val, after='WCSNAME')
 
     hdulist.flush()
     hdulist.close()


### PR DESCRIPTION
New logic was added to the updating of header keywords to report on the quality of the alignment fit to report default values for zero-exptime exposures that are members of an ASN where the other members are valid (exptime > 0).  