### PR TITLE
Fix bug caused by Astropy Tables being interpreted as QTables

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1415,7 +1415,9 @@ class HAPPointCatalog(HAPCatalogBase):
         for col2del in ['sharpness', 'roundness1', 'roundness2', 'npix', 'sky', 'peak', 'flux', 'mag']:
             if col2del in self.sources.colnames:
                 self.sources.remove_column(col2del)
-        self.sources = join(self.sources, subset_table, keys="ID", join_type="left")
+
+        # Cast the QTable back to a Table to avoid complications
+        self.sources = join(Table(self.sources), subset_table, keys="ID", join_type="left")
 
 # ----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Since the introduction of proper astropy units (Git PR#1316), some variables were interpreted to be QTable instead of Table. This caused errors not seen previously. Simply casting the variable back to a Table at the point where the error was raised fixed the problem.