### PR TITLE
Revise logic for when mask keywords are computed

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -370,7 +370,7 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
         # Update the SkyCellProduct objects with their associated configuration information.
         for filter_item in total_obj_list:
             _ = filter_item.generate_metawcs(custom_limits=custom_limits)
-            filter_item.generate_footprint_mask(save_mask=False)
+            filter_item.generate_footprint_mask()
 
             # Optionally rename output products
             if output_file_prefix or custom_limits:

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -370,7 +370,9 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
         # Update the SkyCellProduct objects with their associated configuration information.
         for filter_item in total_obj_list:
             _ = filter_item.generate_metawcs(custom_limits=custom_limits)
-            filter_item.generate_footprint_mask()
+            # Compute mask keywords early in processing for use in determining what
+            # parameters need to be used for processing.
+            filter_item.generate_footprint_mask(save_mask=False)
 
             # Optionally rename output products
             if output_file_prefix or custom_limits:

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -143,10 +143,6 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
             # Make sure this is re-initialized for the new total product
             phot_mode = input_phot_mode
 
-            # Generate an "n" exposure mask which has the image footprint set to the number
-            # of exposures which constitute each pixel.
-            total_product_obj.generate_footprint_mask()
-
             # Instantiate filter catalog product object
             total_product_catalogs = HAPCatalogs(total_product_obj.drizzle_filename,
                                                  total_product_obj.configobj_pars.get_pars('catalog generation'),


### PR DESCRIPTION
These changes insure that when the mask keywords such as MEANEXPT are expected to be written to the output product headers, that they have already been computed.  This insures that all SVM filter and total products and all MVM (filter) products get updated as expected with this set of keywords.  These keywords are not added to the SVM exposure time products since it makes no sense to do so.  

This was tested using data from visit 'ib6807' and from skycell p1889x07y19.  