### PR TITLE
Add MEANWHT and MEDWHT keywords to drizzle products

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -529,7 +529,7 @@ class TotalProduct(HAPProduct):
             # Now that the drizzle product is created, compute the mean and median
             # of the WHT image
             wht = hdu["WHT", 1].data
-            wht_mask = self.mask > 0 if self.mask else wht > 0.0
+            wht_mask = self.mask > 0 if hasattr(self.mask, 'shape') else wht > 0.0
             self.mask_whtkws['MEANWHT'][0] = np.mean(wht[wht_mask])
             self.mask_whtkws['MEDWHT'][0] = np.median(wht[wht_mask])
 
@@ -649,7 +649,7 @@ class FilterProduct(HAPProduct):
             # Now that the drizzle product is created, compute the mean and median
             # of the WHT image
             wht = hdu["WHT", 1].data
-            wht_mask = self.mask > 0 if self.mask else wht > 0.0
+            wht_mask = self.mask > 0 if hasattr(self.mask, 'shape') else wht > 0.0
             self.mask_whtkws['MEANWHT'][0] = np.mean(wht[wht_mask])
             self.mask_whtkws['MEDWHT'][0] = np.median(wht[wht_mask])
 
@@ -1256,7 +1256,7 @@ class SkyCellProduct(HAPProduct):
             # Now that the drizzle product is created, compute the mean and median
             # of the WHT image
             wht = hdu["WHT", 1].data
-            wht_mask = self.mask > 0 if self.mask else wht > 0.0
+            wht_mask = self.mask > 0 if hasattr(self.mask, 'shape') else wht > 0.0
             self.mask_whtkws['MEANWHT'][0] = np.mean(wht[wht_mask])
             self.mask_whtkws['MEDWHT'][0] = np.median(wht[wht_mask])
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -524,14 +524,17 @@ class TotalProduct(HAPProduct):
         # Update product with SVM-specific keywords based on the footprint
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
-                hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
+                hdu[0].header[kw] = tuple(self.mask_kws[kw])
 
+            # Now that the drizzle product is created, compute the mean and median
+            # of the WHT image
             wht = hdu["WHT", 1].data
-            wht_mask = wht > 0.0
+            wht_mask = self.mask > 0 if self.mask else wht > 0.0
             self.mask_whtkws['MEANWHT'][0] = np.mean(wht[wht_mask])
             self.mask_whtkws['MEDWHT'][0] = np.median(wht[wht_mask])
+
             for kw in self.mask_whtkws:
-                hdu[("WHT", 1)].header[kw] = tuple(self.mask_whtkws[kw])
+                hdu[0].header[kw] = tuple(self.mask_whtkws[kw])
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Total combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
@@ -641,14 +644,17 @@ class FilterProduct(HAPProduct):
         # Update product with SVM-specific keywords based on the footprint
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
-                hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
+                hdu[0].header[kw] = tuple(self.mask_kws[kw])
 
+            # Now that the drizzle product is created, compute the mean and median
+            # of the WHT image
             wht = hdu["WHT", 1].data
-            wht_mask = wht > 0.0
+            wht_mask = self.mask > 0 if self.mask else wht > 0.0
             self.mask_whtkws['MEANWHT'][0] = np.mean(wht[wht_mask])
             self.mask_whtkws['MEDWHT'][0] = np.median(wht[wht_mask])
+
             for kw in self.mask_whtkws:
-                hdu[("WHT", 1)].header[kw] = tuple(self.mask_whtkws[kw])
+                hdu[0].header[kw] = tuple(self.mask_whtkws[kw])
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Filter combined image {} composed of: {}".format(self.drizzle_filename, edp_filenames))
@@ -1242,23 +1248,20 @@ class SkyCellProduct(HAPProduct):
         # Update product with MVM-specific keywords based on the footprint
         with fits.open(self.drizzle_filename, mode='update') as hdu:
             for kw in self.mask_kws:
-                hdu[("SCI", 1)].header[kw] = tuple(self.mask_kws[kw])
+                hdu[0].header[kw] = tuple(self.mask_kws[kw])
 
             # Add SCELLID keyword to MVM product
-            hdu[("SCI", 1)].header['SCELLID'] = self.cell_id
+            hdu[0].header['SCELLID'] = self.cell_id
 
             # Now that the drizzle product is created, compute the mean and median
-            # exposure times based on the WHT image
+            # of the WHT image
             wht = hdu["WHT", 1].data
-            wht_mask = wht > 0.0
-            # MDD TMP
-            wht_mean = np.mean(wht[wht_mask])
-            wht_median = np.median(wht[wht_mask])
-            log.info("WHT Mean: {}   WHT Median: {}".format(wht_mean, wht_median))
+            wht_mask = self.mask > 0 if self.mask else wht > 0.0
             self.mask_whtkws['MEANWHT'][0] = np.mean(wht[wht_mask])
             self.mask_whtkws['MEDWHT'][0] = np.median(wht[wht_mask])
+
             for kw in self.mask_whtkws:
-                hdu[("WHT", 1)].header[kw] = tuple(self.mask_whtkws[kw])
+                hdu[0].header[kw] = tuple(self.mask_whtkws[kw])
 
         # Rename Astrodrizzle log file as a trailer file
         log.debug("Sky-cell layer image {} composed of: {}".format(self.drizzle_filename, edp_filenames))


### PR DESCRIPTION
Add MEANWHT and MEDWHT keywords to drizzle products.  These keyword computations are currently working
and tested for SVM Total and Filter drizzle products where they are resident in the WHT extension.