### PR TITLE
Fix typo in ACS MVM header rules file

### DIFF
--- a/drizzlepac/pars/acs_mvm_header_hap.rules
+++ b/drizzlepac/pars/acs_mvm_header_hap.rules
@@ -418,7 +418,7 @@ MTFLAG    MTFLAG    first
 <delete>  QUALCOM2
 <delete>  QUALCOM3
 <delete>  / CALIBRATION REFERENCE FILES
-<delete>  / CALIBRATION SWITCHES: PERFORM, OMIT, COMPLETE, SKIPPED
+<delete>  / CALIBRATION SWITCHES: PERFORM, OMIT, COMPLETE
 <delete>  / PATTERN KEYWORDS
 ################################################################################
 #


### PR DESCRIPTION
Simple fix to correct a typo in the ACS MVM header rules file that was partially responsible for corrupting the output MVM products.  
This fix works in concert with the [fitsblender PR #33](https://github.com/spacetelescope/fitsblender/pull/33).