### PR TITLE
Update pyproject.toml astropy min version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0",
             "setuptools_scm[toml]>=3.4",
             "wheel",
             "oldest-supported-numpy",
-            "astropy>=4.3",
+            "astropy>=5.0.4",
             "markupsafe<=2.0.1"]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=42.0",
             "setuptools_scm[toml]>=3.4",
             "wheel",
-            "oldest-supported-numpy",
+            "numpy>=1.18",
             "astropy>=5.0.4",
             "markupsafe<=2.0.1"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
As [noted](https://github.com/spacetelescope/drizzlepac/pull/1335#issuecomment-1099237782) by @nden in PR #1335, the astropy version in `pyproject.toml` needs to be updated. This PR does that too.