### PR TITLE
Carry over IDCSCALE keyword when updating WCS to match Grism WCS

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -1183,6 +1183,9 @@ def update_active_wcs(filename, wcsname):
 
     hdu = fits.open(filename)
 
+    # Get original value of IDCSCALE keyword
+    idcscale = hdu['SCI', 1].header['idcscale']
+
     # Check if the desired WCS solution is already the active solution
     # whereupon there is nothing to do
     key = wcsutil.altwcs.getKeyFromName(hdu['SCI', 1].header, wcsname)
@@ -1219,6 +1222,8 @@ def update_active_wcs(filename, wcsname):
             for sciext in range(1, num_sci_ext+1):
                 nm = fhdu[extensions[0]].header['nmatch'] if 'nmatch' in fhdu[extensions[0]].header else 0
                 fhdu[(extname, sciext)].header['nmatches'] = nm
+                if 'idcscale' not in fhdu[(extname, sciext)].header:
+                    fhdu[(extname, sciext)].header['idcscale'] = idcscale  # Restore this if it was overwritten/deleted
             fhdu.close()
         except:
             _, _, tb = sys.exc_info()


### PR DESCRIPTION
These simple changes insure that the IDCSCALE keyword does not get deleted when the WCS gets updated to an a priori WCS to match the Grism exposures WCS.  The keyword gets deleted by STWCS when restoring the WCS from the headerlet.  The code now just records the original value and restores it at the same time it restores the NMATCHES keyword.  

This change was tested against data from **icwz06** which was originally used to demonstrate the problem.  