### PR TITLE
Ignore layers with no overlapping exposures

### DIFF
--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -207,6 +207,10 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
     # create the drizzle-combined filtered image, the drizzled exposure (aka single) images,
     # and finally the drizzle-combined total detection image.
     for filt_obj in total_obj_list:
+        if not filt_obj.valid_product:
+            # If this object has 'valid_product' set to False,
+            # skip processing this object
+            continue
         filt_obj.rules_file = proc_utils.get_rules_file(filt_obj.edp_list[0].full_filename,
                                                         rules_type='MVM',
                                                         rules_root=filt_obj.drizzle_filename)
@@ -249,7 +253,8 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
 
     # Add primary header information to all objects
     for filt_obj in total_obj_list:
-        filt_obj = poller_utils.add_primary_fits_header_as_attr(filt_obj)
+        if filt_obj.valid_product:
+            filt_obj = poller_utils.add_primary_fits_header_as_attr(filt_obj)
 
     # Return product list for creation of pipeline manifest file
     return product_list
@@ -373,7 +378,10 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
             # Compute mask keywords early in processing for use in determining what
             # parameters need to be used for processing.
             filter_item.generate_footprint_mask(save_mask=False)
-
+            if not filter_item.mask_computed:
+                log.warning(f"Ignoring {filter_item.info} as no input exposures overlap that layer.")
+                filter_item.valid_product = False
+                continue
             # Optionally rename output products
             if output_file_prefix or custom_limits:
                 filter_item = rename_output_products(filter_item, output_file_prefix=output_file_prefix)

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -378,9 +378,8 @@ def run_mvm_processing(input_filename, skip_gaia_alignment=True, diagnostic_mode
             # Compute mask keywords early in processing for use in determining what
             # parameters need to be used for processing.
             filter_item.generate_footprint_mask(save_mask=False)
-            if not filter_item.mask_computed:
+            if not filter_item.valid_product:
                 log.warning(f"Ignoring {filter_item.info} as no input exposures overlap that layer.")
-                filter_item.valid_product = False
                 continue
             # Optionally rename output products
             if output_file_prefix or custom_limits:

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -579,7 +579,7 @@ def verify_guiding(filename, min_length=33):
     num_sources = len(src_cat)
 
     # trim edges from image to avoid spurious sources
-    trim_slice=[slice(2, -2), slice(2, -2)]
+    trim_slice=(slice(2, -2), slice(2, -2))
 
     # Now determine whether this image was affected by guiding problems
     bad_guiding = lines_in_image(imgarr[trim_slice], num_sources,

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -88,6 +88,11 @@ class HAPProduct:
         self.mask_whtkws = copy.deepcopy(MASK_WHTKWS)
         self.mask_computed = False
 
+        # attribute to use for identifying whether or not this product is valid
+        # can be set depending on any number of conditions, such as no member
+        # overlapping the WCS.
+        self.valid_product = True
+
     # def print_info(self):
         # """ Generic print at this time to indicate the information used in the
         #     construction of the object for debug purposes.
@@ -103,6 +108,11 @@ class HAPProduct:
         footprint = cell_utils.SkyFootprint(self.meta_wcs)
         exposure_names = [element.full_filename for element in self.edp_list]
         footprint.build(exposure_names, scale=True)
+        if footprint.bounded_wcs is None:
+            log.warning(f"These exposures do not overlap this WCS:\n{exposure_names}\n{self.meta_wcs}")
+            self.valid_product = False
+            del footprint
+            return
 
         # This mask actually represents the number of chips per pixel, not True/False.
         # To have the True/False mask it should be self.mask = footprint.footprint.


### PR DESCRIPTION
This implements several changes (fixes?) to how exposures are associated with SkyCells and how the processing will respond when an unexpectedly non-overlapping exposure is specified for a given SkyCell.  The specific changes include:

- adding an attribute to the SkyCellProduct class to indicate whether or not there are overlapping exposures for that product
- adding logic to check whether or not any exposure overlaps a SkyCellProduct footprint
- checking whether or not this attribute is True when running `hapmultisequencer.run_mvm_processing`
- treating all edge pixels and corner pixels as lists of numpy arrays (addresses #1358 and #1359)
- checking each exposure separately to see what SkyCell(s) it overlaps when running `cell_utils.get_sky_cells`

These changes were all tested against exposures from visit `icvz15` and all other exposures identified for `skycell-p2489x15y02`.  It turned out that the IR exposures from visit `icvz15` do not actually overlap this SkyCell, and these changes no longer identifies them as members of that SkyCell.  