### PR TITLE
Only allow "verify_guiding" check for MVM processing

### DIFF
--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -174,8 +174,10 @@ def analyze_wrapper(input_file_list, log_level=logutil.logging.DEBUG, use_sbchrc
     filtered_table = filtered_table[mask]
 
     # Further reduce table to only the data which is NOT affected by bad guiding
-    guide_mask = [not verify_guiding(f) for f in filtered_table["imageName"]]
-    filtered_table = filtered_table[guide_mask]
+    # This check is only to be done for MVM processing
+    if type.upper() == "MVM":
+        guide_mask = [not verify_guiding(f) for f in filtered_table["imageName"]]
+        filtered_table = filtered_table[guide_mask]
 
     good_table = None
     good_rows = []
@@ -523,6 +525,11 @@ def verify_guiding(filename, min_length=33):
         Boolean specifying whether or not the image was detected as
         being affected by guiding problems.  Value is True if image
         was affected.
+
+    Note: This function will only be called from analyze_wrapper if the processing
+          type is "MVM".  It is deliberately False for other processing (e.g., SVM and
+          pipeline).  However, this routine can be invoked directly for pipeline
+          processing from runastrodriz.py with the appropriate parameter setting.
     """
     log.info(f"Verifying that {filename} was not affected by guiding problems.")
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1928,7 +1928,7 @@ def main():
         if opt == "-d":
             debug = True
         if opt == "-a":
-            force_alignment = False
+            force_alignment = True
         if opt == "-h":
             help = 1
         if opt == "-f":

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -182,7 +182,7 @@ wcs_preference = ['IDC_?????????-FIT_REL_GAIA*', 'IDC_?????????-FIT_IMG_GAIA*', 
 
 # Primary user interface
 def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
-            headerlets=True, align_to_gaia=True, force_alignment=False, debug=False):
+            headerlets=True, align_to_gaia=True, force_alignment=False, do_verify_guiding=False, debug=False):
     """ Run astrodrizzle on input file/ASN table
         using default values for astrodrizzle parameters.
     """
@@ -407,19 +407,23 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
 
     # Check to see whether or not guide star failure affected these observations
     # They would show up as images all sources streaked as if taken in SCAN mode or with a GRISM
-    for fltimg in _calfiles:
-        flcimg = f.replace('_flt.fits', '_flc.fits')
-        if os.path.exists(flcimg):
-            fltimg = flcimg
-        # We want to use the FLC image, if possible, to avoid any
-        # possible detection of CTE tails as false guide-star trailing lines
-        bad_guiding = analyze.verify_guiding(fltimg)
-        if bad_guiding:
-            # Remove the affected image(s) from further processing
-            _calfiles.remove(fltimg)
+    # 
+    # Note: This functionality is intentionally turned off for pipeline processing at this time.
+    # However, a user may wish to invoke this functionality which is controlled by the
+    # parameter "do_verify_guiding".
+    if do_verify_guiding:
+        for fltimg in _calfiles:
+            flcimg = f.replace('_flt.fits', '_flc.fits')
             if os.path.exists(flcimg):
-                _calfiles_flc.remove(flcimg)
-
+                fltimg = flcimg
+            # We want to use the FLC image, if possible, to avoid any
+            # possible detection of CTE tails as false guide-star trailing lines
+            bad_guiding = analyze.verify_guiding(fltimg)
+            if bad_guiding:
+                # Remove the affected image(s) from further processing
+                _calfiles.remove(fltimg)
+                if os.path.exists(flcimg):
+                    _calfiles_flc.remove(flcimg)
 
     if dcorr == 'PERFORM':
 
@@ -1899,7 +1903,7 @@ def main():
     import getopt
 
     try:
-        optlist, args = getopt.getopt(sys.argv[1:], 'bdahfgin:')
+        optlist, args = getopt.getopt(sys.argv[1:], 'bdahfginv:')
     except getopt.error as e:
         print(str(e))
         print(__doc__)
@@ -1915,6 +1919,7 @@ def main():
     align_to_gaia = True
     debug = False
     force_alignment = False
+    do_verify_guiding = False
 
     # read options
     for opt, value in optlist:
@@ -1930,6 +1935,8 @@ def main():
             force = True
         if opt == "-i":
             inmemory = True
+        if opt == "-v":
+            do_verify_guiding = True
         if opt == '-n':
             if not value.isdigit():
                 print('ERROR: num_cores value must be an integer!')
@@ -1939,7 +1946,7 @@ def main():
             # turn off writing headerlets
             headerlets = False
     if len(args) < 1:
-        print("syntax: runastrodriz.py [-fhibng] inputFilename [newpath]")
+        print("syntax: runastrodriz.py [-bdahfginv] inputFilename [newpath]")
         sys.exit()
     if len(args) > 1:
         newdir = args[-1]
@@ -1950,7 +1957,8 @@ def main():
         try:
             process(args[0], force=force, newpath=newdir, num_cores=num_cores,
                     inmemory=inmemory, headerlets=headerlets,
-                    align_to_gaia=align_to_gaia, force_alignment=force_alignment, debug=debug)
+                    align_to_gaia=align_to_gaia, force_alignment=force_alignment,
+                    do_verify_guiding=do_verify_guiding, debug=debug)
 
         except Exception as errorobj:
             print(str(errorobj))


### PR DESCRIPTION
Added protection around the function call, verify_guiding, from the analyze_wrapper routine.  The function will only be called if the processing type is "MVM".  Also added a new parameter, do_verify_guiding, to the process function in runastrodriz.py.  This new parameter will allow a user to turn on verify_guiding for pipeline processing.  Organized the order of the parameter switches for the process function.  Added explanatory comments in the code for these changes.