### PR TITLE
Pass along default WCSNAME

### DIFF
--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -721,6 +721,7 @@ def getTemplates(fnames, blend=True, rules_file=None):
 
     return newhdrs, newtab
 
+
 def addWCSKeywords(wcs, hdr, blot=False, single=False, after=None):
     """ Update input header 'hdr' with WCS keywords.
     """
@@ -729,8 +730,9 @@ def addWCSKeywords(wcs, hdr, blot=False, single=False, after=None):
 
     # Update WCS Keywords based on PyDrizzle product's value
     # since 'drizzle' itself doesn't update that keyword.
-    hdr['WCSNAME'] = wname
-    hdr['WCSTYPE'] = wtype
+    if wname != '':
+        hdr['WCSNAME'] = wname
+        hdr['WCSTYPE'] = wtype
     hdr.set('VAFACTOR', value=1.0, after=after)
     hdr.set('ORIENTAT', value=wcs.orientat, after=after)
 

--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -730,7 +730,12 @@ def addWCSKeywords(wcs, hdr, blot=False, single=False, after=None):
 
     # Update WCS Keywords based on PyDrizzle product's value
     # since 'drizzle' itself doesn't update that keyword.
+    # If output wcs does not have a name (wcs.name), then
+    # the value from the input hdr will remain as the name
+    # for this WCS solution.
     if wname != '':
+        # Replace input WCSNAME value with name from user-specified WCS
+        # since it was defined.
         hdr['WCSNAME'] = wname
         hdr['WCSTYPE'] = wtype
     hdr.set('VAFACTOR', value=1.0, after=after)


### PR DESCRIPTION
This simple change makes sure that the WCSNAME and WCSTYPE keywords do not get populated by blank strings if the output WCS used for drizzling did not have a `wcs.name` attribute to use in creating the WCSNAME keyword value.  This situation can happen if an output WCS gets defined and passed in to AstroDrizzle for the final drizzle step, leading to the blank string overwriting the default value  from the input images during MVM processing.   