### PR TITLE
Re-design tweakback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,14 @@ number of the code change for that issue.  These PRs can be viewed at:
     https://github.com/spacetelescope/drizzlepac/pulls
 
 
+3.5.0 (unreleased)
+==================
+
+- Introduced a new ``apply_tweak()`` function as a replacement to the
+  ``tweakback()``. ``apply_tweak()`` preserves the functionality of ``tweakback``
+  with a re-designed API. Existing ``tweakback`` was deprecated. [#1372]
+
+
 3.4.1 (5-Apr-2022)
 ==================
 This release addresses issues found in v3.4.0.  The most significant

--- a/drizzlepac/tweakback.py
+++ b/drizzlepac/tweakback.py
@@ -15,13 +15,19 @@ the "aligned" (to the new drizzled WCS) image coordinates.
 
 """
 import os
+import string
+from datetime import date
 
 import numpy as np
 from astropy.io import fits
+from astropy.utils.decorators import deprecated
 
 from stwcs import wcsutil
+from stwcs.wcsutil import altwcs
 from stsci.tools import parseinput, logutil
 from stsci.skypac.utils import get_ext_list, ext2str
+from stsci.skypac.parseat import parse_cs_line
+
 
 from . import updatehdr
 from . import linearfit
@@ -42,10 +48,505 @@ else:
     ndfloat128 = np.float64
 
 
-#### Primary function
+def _wcs_key_name(wcs_key, wcs_name, fi, ext, default_key, param_name):
+    wnames = altwcs.wcsnames(fi.image.hdu, ext=ext)
+    if wcs_key is None:
+        if wcs_name is None:
+            wcs_key = sorted(wnames)[default_key]
+            wcs_name = wnames[wcs_key]
+            # report our guess:
+            print(f"Using WCS with WCSNAME '{wcs_name}' (WCS key '{wcs_key}') "
+                  f"for '{param_name}'")
+        else:
+            # find associated wcs_key
+            wcs_name_u = wcs_name.upper()
+            for k, name in wnames.items():
+                if name.upper() == wcs_name_u:
+                    wcs_key = k
+                    break
+            else:
+                fi.release_all_images()
+                raise KeyError(f"WCS with wcsname '{wcs_name}' not found.")
+    else:
+        wcs_name = wnames[wcs_key]
+
+    return wcs_key, wcs_name
+
+
+def _process_wcs_key_par(par_name, kwargs):
+    if par_name in kwargs:
+        wcs_key = kwargs[par_name]
+        if len(wcs_key) != 1 or wcs_key.upper().strip() not in string.ascii_uppercase:
+            raise ValueError(
+                f"Parameter '{par_name}' must be a character - "
+                "one of 'A'-'Z' or ' '."
+            )
+    else:
+        wcs_key = None
+    return wcs_key
+
+
+def apply_tweak(drz_file, orig_wcs_name, output_wcs_name=None, input_files=None,
+                default_extname='SCI', **kwargs):
+    """
+    Apply WCS solution recorded in drizzled file to distorted input images
+    (``_flt.fits`` files) used to create the drizzled file.
+
+    It is assumed that if input images given by ``input_files`` are drizzled
+    together, they would produce the drizzled image given by ``drz_file`` image
+    and with the "original" primary WCS. It is also assumed that drizzled image
+    was aligned using ``tweakreg`` either to another image or to an external
+    reference catalog. We will refer to the primary WCS in the drizzled image
+    _before_ ``tweakreg`` was run as the "original" WCS and the WCS _after_
+    ``tweakreg`` was run as "tweaked" WCS.
+
+    By comparing both "original" and "tweaked" WCS, ``apply_wcs`` computes
+    the correction that was applied by ``tweakreg`` to the "original" WCS
+    and converts this correction in the drizzled image frame into a correction
+    in the input image's (``input_files``) frame that will be applied to the
+    primary WCS of input images. If updated input images are now resampled
+    again, they would produce an image very close to ``drz_file`` but with
+    a primary WCS very similar to the "tweaked" WCS instead of the "original"
+    WCS.
+
+    Parameters
+    ----------
+    drz_file : str
+        File name of the drizzled image that contains both the "original" and
+        "tweaked" WCS. Even though wildcards are allowed in the file name,
+        their expansion must resolve to a single image file. By default,
+        ``apply_tweak`` looks for the first image-like HDU in the drizzled
+        image. To specify a particular extension from which to load WCS,
+        append extension specification after the file name, for example:
+            - ``'image_drz.fits[sci,1]'`` for first "sci" extension
+            - ``'image_drz.fits[1]'`` for the first extension
+            - ``'image_drz.fits[0]'`` for the primary HDU
+
+    orig_wcs_name : str
+        Name (provided by the ``WCSNAME?`` header keyword where ``?``
+        respesents a letter A-Z) of the "original" WCS. This is the WCS of
+        the resampled image (obtained by drizzling all input images)  _before_
+        this resampled image was aligned ("tweaked") to another image/catalog.
+
+        If ``orig_wcs_name`` is `None`, the the original WCS _must be
+        specified_ using ``orig_wcs_key``. When ``orig_wcs_key`` is provided,
+        ``orig_wcs_name`` is ignored altogether.
+
+    output_wcs_name : str, None
+        Value of ``WCSNAME`` to be used to label the updated solution in the
+        input (e.g., ``_flt.fits``) files.  If left blank or ``None``, it will
+        default to using either the current (primary) ``WCSNAME`` value from
+        the ``drz_file`` or from the alternate WCS given by the
+        ``tweaked_wcs_name`` or ``tweaked_wcs_key`` parameters.
+
+    input_files : str, None
+        Filenames of distorted images whose primary WCS is to be updated
+        with the same transformation as used in the "tweaked" drizzled image.
+        Default value of `None` indicates that input image filenames will be
+        derived from the ``D*DATA`` keywords written out by the ``AstroDrizzle``.
+        If they can not be found, the task will quit.
+
+        ``input_files`` string can contain one of the following:
+
+            * a comma-separated list of valid science image file names
+              (see note below) and (optionally) extension specifications,
+              e.g.: ``'j1234567q_flt.fits[1], j1234568q_flt.fits[sci,2]'``;
+
+            * an @-file name, e.g., ``'@files_to_match.txt'``.
+
+        .. note::
+            **Valid** **science** **image** **file** **names** are:
+
+            * file names of existing FITS, GEIS, or WAIVER FITS files;
+
+            * partial file names containing wildcard characters, e.g.,
+              ``'*_flt.fits'``;
+
+            * Association (ASN) tables (must have ``_asn``, or ``_asc``
+              suffix), e.g., ``'j12345670_asn.fits'``.
+
+        .. warning::
+            @-file names **MAY** **NOT** be followed by an extension
+            specification.
+
+        .. warning::
+            If an association table or a partial file name with wildcard
+            characters is followed by an extension specification, it will be
+            considered that this extension specification applies to **each**
+            file name in the association table or **each** file name
+            obtained after wildcard expansion of the partial file name.
+
+    default_extname : str
+        Extension name of extensions in input images whose primary WCS
+        should be updated. This value is used only when file names provided in
+        ``input_files`` do not contain extension specifications.
+
+    Other Parameters
+    ----------------
+    tweaked_wcs_name : str
+        Name of the "tweaked" WCS. This is the WCS of
+        the resampled image (obtained by drizzling all input images)  _after_
+        this resampled image was aligned ("tweaked") to another image/catalog.
+
+        When neither ``tweaked_wcs_name`` nor ````tweaked_wcs_key`` are not
+        provided, ``apply_tweak`` will take the current primary WCS in the
+        drizzled image as a "tweaked" WCS. ``tweaked_wcs_name`` is ignored
+        when ``tweaked_wcs_key`` is provided.
+
+    tweaked_wcs_key : {' ', 'A'-'Z'}
+        Same as ``tweaked_wcs_name`` except it specifies a WCS by key instead
+        of name. When provided, ``tweaked_wcs_name`` is ignored.
+
+    orig_wcs_key : {' ', 'A'-'Z'}
+        Same as ``orig_wcs_name`` except it specifies a WCS by key instead
+        of name. When provided, ``orig_wcs_name`` is ignored.
+
+    Notes
+    -----
+    The algorithm used by this function is based on linearization of
+    the exact compound operator that converts input image coordinates
+    to the coordinates (in the input image) that would result in
+    alignment with the new drizzled image WCS.
+
+    .. warning::
+        Parameters ``orig_wcs_name`` and ``tweaked_wcs_name`` (or their "key"
+        equivalents) allow computation of transformation between *any two
+        WCS* in the drizzled image and application of this transformation to the
+        primary WCS of the input images. This will produce an
+        expected result **only if** the WCS pointed to by ``orig_wcs_name`` was
+        obtained by drizzling input images with their current primary WCS.
+
+
+    EXAMPLES
+    --------
+    A drizzled image named ``acswfc_mos2_drz.fits`` was created from 4 images
+    using ``AstroDrizzle``. The primary WCS of this drizzled image was named
+    ``'INITIAL_GUESS'``. This drizzled image was then aligned to some other
+    image using ``TweakReg`` and the updated ("tweaked") primary WCS was named
+    ``'BEST_WCS'`` while the previous primary WCS - the WCS named
+    ``'INITIAL_GUESS'`` - was archived by ``TweakReg`` under WCS key ``'C'``.
+    We will refer to this archived WCS as the "original" WCS.
+    ``apply_tweak`` can now be used to compute the
+    transformation between the original and the tweaked WCS and apply this
+    transformation to the WCS of each of the input images that were
+    drizzle-combined to produce the resampled image ``acswfc_mos2_drz.fits``.
+
+    The simplest way to accomplish this would be to run ``apply_tweak()`` using
+    default parameters:
+
+    >>> from drizzlepac import tweakback
+    >>> tweakback.apply_tweak('acswfc_mos2_drz.fits', orig_wcs_name='INITIAL_GUESS')
+
+    or
+
+    >>> tweakback.apply_tweak('acswfc_mos2_drz.fits', orig_wcs_key='C')
+
+    If the same WCS should be applied to a specific set of images or
+    extensions in those images, then we can explicitly specify input files:
+
+    >>> tweakback.apply_tweak(
+    ...     'acswfc_mos2_drz.fits',
+    ...     input='img_mos2a_flt.fits,img_mos2c_flt.fits[1],img_mos2d_flt.fits[sci,1]'
+    ... )
+
+    In the examples above, current primary WCS of the input
+    ``'img_mos2?_flt.fits'`` files will be archived and the primary WCS will
+    be replaced with a "tweaked" WCS obtained by applying relevant
+    transformations to the current primary WCS. Because we did not specify
+    ``output_wcs_name``, the name of this tweaked primary WCS in the
+    input images will be set to ``'BEST_WCS'``.
+
+    See Also
+    --------
+    stwcs.wcsutil.altwcs: Alternate WCS implementation
+
+    """
+    print(f"\n*** 'apply_tweak' version {__version__:s} started "
+          f"at {util._ptime()[0]:s}: ***\n")
+
+    tweaked_wcs_name = kwargs.get('tweaked_wcs_name', None)
+    tweaked_wcs_key = kwargs.get('tweaked_wcs_key', None)
+    orig_wcs_key = kwargs.get('orig_wcs_key', None)
+
+    tweaked_wcs_key = _process_wcs_key_par('tweaked_wcs_key', kwargs)
+    orig_wcs_key = _process_wcs_key_par('orig_wcs_key', kwargs)
+
+    # load drizzled image and extract input file names (if needed) and
+    # load specified WCS:
+
+    fis = parse_cs_line(
+        drz_file, default_ext='*', fnamesOnly=False, doNotOpenDQ=True,
+        im_fmode="readonly"
+    )
+    if len(fis) == 0:
+        raise FileNotFoundError(f"Drizzled file '{drz_file}' not found.")
+    elif len(fis) > 1:
+        for f in fis:
+            f.release_all_images()
+        raise ValueError("When expanded, 'drz_file' should correspond to a "
+                         "single file.")
+
+    fi = fis[0]
+    hdul = fi.image.hdu
+    if len(fi.fext) == 1:
+        drz_sciext = fi.fext[0]
+
+    elif fi.fext:
+        fi.release_all_images()
+        raise ValueError(
+            "Input drizzled image contains multiple image-like extensions. "
+            "Please explicitly specify a single extension containing desired "
+            "WCS."
+        )
+
+    else:
+        fi.release_all_images()
+        raise ValueError(
+            "Specified extension was not found in the input drizzled image."
+        )
+
+    # check that there are at least two WCS in the drizzled image header:
+    wkeys = altwcs.wcskeys(hdul, ext=drz_sciext)
+    if len(wkeys) < 2:
+        fi.release_all_images()
+        raise ValueError(f"'{fi.image}[{ext2str(drz_sciext)}]' must "
+                         "contain at least two valid WCS: original and "
+                         "updated by tweakreg.")
+
+    # load "tweaked" WCS
+    tweaked_wcs_key, tweaked_wcs_name = _wcs_key_name(
+        tweaked_wcs_key,
+        tweaked_wcs_name,
+        fi=fi,
+        ext=drz_sciext,
+        default_key=0,
+        param_name='tweaked_wcs_name'
+    )
+    tweaked_wcs = wcsutil.HSTWCS(hdul, ext=drz_sciext, wcskey=tweaked_wcs_key)
+
+    # load "original" WCS
+    if orig_wcs_key is None and orig_wcs_name is None:
+        fi.release_all_images()
+        raise ValueError("Either 'orig_wcs_name' or 'orig_wcs_key' must be specified.")
+
+    # default_key=-1 below is useless since we require that either
+    # orig_wcs_key or orig_wcs_name be specified. However, in the future,
+    # if we allow both to be None, we can use the last WCS key as the default
+    # for the "original" WCS (last WCS key in the list).
+    orig_wcs_key, orig_wcs_name = _wcs_key_name(
+        orig_wcs_key,
+        orig_wcs_name,
+        fi=fi,
+        ext=drz_sciext,
+        default_key=-1,
+        param_name='orig_wcs_name'
+    )
+    orig_wcs = wcsutil.HSTWCS(hdul, ext=drz_sciext, wcskey=orig_wcs_key)
+
+    # get RMS values reported for new solution
+    crderr1 = fi.image.hdu[drz_sciext].header.get('CRDER1' + orig_wcs_key, 0.0)
+    crderr2 = fi.image.hdu[drz_sciext].header.get('CRDER2' + orig_wcs_key, 0.0)
+
+    fi.release_all_images()  # done with the resampled image
+
+    # Process the list of input files:
+    if not isinstance(default_extname, str):
+        raise TypeError("Argument 'default_extname' must be a string")
+    default_extname = default_extname.strip()
+    if default_extname.upper() == 'PRIMARY':
+        ext2get = ('PRIMARY', 1)
+    else:
+        ext2get = (default_extname, '*')
+
+    if input_files is None:
+        # get input (FLT) file names from the drizzled image. This information
+        # is recorded in the primary header of the drizzled image.
+        input_files = ",".join(hdul[0].header["D???DATA"].values())
+
+    # Build a list of input files and extensions
+    fnames_ext = {}
+    fis = parse_cs_line(
+        input_files, default_ext=ext2get, fnamesOnly=False,
+        doNotOpenDQ=True, im_fmode="readonly"
+    )
+    for f in fis:
+        f.release_all_images()
+        if f.image in fnames_ext:
+            fnames_ext[f.image] |= set(f.fext)
+        else:
+            fnames_ext[f.image] = set(f.fext)
+
+    if output_wcs_name is None:
+        output_wcs_name = tweaked_wcs_name
+        print(f"\n* Setting 'output_wcs_name' to '{output_wcs_name}'")
+        auto_output_name = True
+    else:
+        auto_output_name = False
+
+    output_wcs_name_u = output_wcs_name.strip().upper()
+
+    # Compute tweakback transformation to each extension of each input file.
+    # This is the main part of this function.
+    # Before applying new WCS solution, make sure we can use the same
+    # output WCS name for the updated WCS in all input images.
+    # Also, this gives us opportunity to remove duplicate extensions, if any.
+
+    final_wcs_info = []
+
+    for fname, extlist in fnames_ext.items():
+        print(f"\n* Working on input image {fname:s} ...")
+
+        fis = parse_cs_line(
+            f"{fname}",
+            default_ext=ext2get, fnamesOnly=False,
+            doNotOpenDQ=True, im_fmode="readonly"
+        )
+        if len(fis) != 1:
+            fi.release_all_images()
+            raise AssertionError("The algorithm should not open more than one file.")
+        fi = fis[0]
+
+        if not fi.fext:
+            fi.release_all_images()
+            print(f"  No valid input image extension found. Skipping image {fname}.\n")
+            continue
+
+        current_wcs_info = {
+            'fname': fname,
+            'extlist': [],
+            'archived_wcs_name': [],
+            'updated_primary_wcs': []
+        }
+        final_wcs_info.append(current_wcs_info)
+
+        # Process extensions
+        hdu_list = []  # to avoid processing duplicate hdus
+        try:
+            for ext in extlist:
+                imhdulist = fi.image.hdu
+                hdu = imhdulist[ext]
+                if hdu in hdu_list:
+                    continue
+                hdu_list.append(hdu)
+
+                current_wcs_info['extlist'].append(ext)
+
+                # Find the name under which to archive current WCS:
+                all_wcs_names = [
+                    v.upper() for v in
+                    altwcs.wcsnames(imhdulist, ext, include_primary=False).values()
+                ]
+
+                if output_wcs_name_u in all_wcs_names:
+                    if auto_output_name:
+                        raise ValueError(
+                            "Current value of 'output_wcs_name' was set to "
+                            f"'{tweaked_wcs_name}' by default. However, this "
+                            f"WCS name value was already used in {fname:s}[{ext2str(ext)}]. "
+                            "Please re-run 'apply_tweak' again and explicitly "
+                            "provide a unique value for the output WCS name."
+                        )
+                    else:
+                        raise ValueError(
+                            "Provided value of 'output_wcs_name' - '{tweaked_wcs_name}' - "
+                            f"was already used in {fname:s}[{ext2str(ext)}]. "
+                            "Please re-run 'apply_tweak' again and explicitly "
+                            "provide a unique value for the output WCS name."
+                        )
+
+                if 'WCSNAME' in imhdulist[ext].header:
+                    pri_wcs_name = imhdulist[ext].header['WCSNAME'].strip()
+                else:
+                    pri_wcs_name = 'NONAME'
+
+                # add current output WCS name to the list so that archived
+                # primary WCS will be archived under a different name:
+                all_wcs_names.append(output_wcs_name)
+
+                archived_name = altwcs._auto_increment_wcsname(pri_wcs_name, all_wcs_names)
+                current_wcs_info['archived_wcs_name'].append(archived_name)
+
+                # compute updated WCS:
+                new_wcs = wcsutil.HSTWCS(imhdulist, ext=ext)
+
+                update_chip_wcs(new_wcs, orig_wcs, tweaked_wcs,
+                                xrms=crderr1, yrms=crderr2)
+                new_wcs.setOrient()
+                current_wcs_info['updated_primary_wcs'].append(new_wcs)
+
+                print(f"  - Computed new WCS solution for {fname:s}[{ext2str(ext)}]:")
+                repr_wcs = repr(new_wcs)
+                print('\n'.join(['      ' + l.strip() for l in repr_wcs.split('\n')]))
+
+        finally:
+            fi.release_all_images()
+
+    print("\n* Saving updated WCS to image headers:")
+
+    for fwi in final_wcs_info:
+        if not fwi['extlist']:
+            continue
+
+        fname = fwi['fname']
+
+        fis = parse_cs_line(
+            f"{fname}",
+            default_ext=ext2get, fnamesOnly=False,
+            doNotOpenDQ=True, im_fmode="update"
+        )
+        fi = fis[0]
+
+        # Process extensions
+        try:
+            for ext, archived_name, new_wcs in zip(fwi['extlist'],
+                                                   fwi['archived_wcs_name'],
+                                                   fwi['updated_primary_wcs']):
+                imhdulist = fi.image.hdu
+                hdu = imhdulist[ext]
+
+                hdu.header['HISTORY'] = (
+                    f"apply_tweak version: {__version__} ({date.today().isoformat():s})"
+                )
+
+                # Archive current primary WCS:
+                awcs_key, awcs_name = altwcs.archive_wcs(
+                    imhdulist, ext, wcsname=archived_name,
+                    mode=altwcs.ArchiveMode.NO_CONFLICT
+                )
+                hdu.header['HISTORY'] = (
+                    "apply_tweak: Archived Primary WCS under key "
+                    f"'{awcs_key}' on {date.today().isoformat():s}"
+                )
+                hdu.header['HISTORY'] = (
+                    f"apply_tweak: WCSNAME{awcs_key}='{awcs_name}'"
+                )
+
+                # Update primary WCS of this extension:
+                wcs_hdr = new_wcs.wcs2header(idc2hdr=new_wcs.idcscale is not None, relax=True)
+                wcs_hdr.set('WCSNAME', output_wcs_name, before=0)
+                wcs_hdr.set(
+                    'WCSTYPE',
+                    updatehdr.interpret_wcsname_type(output_wcs_name),
+                    after=0
+                )
+                wcs_hdr.set('ORIENTAT', new_wcs.orientat, after=len(wcs_hdr))
+                hdu.header.update(wcs_hdr)
+                hdu.header['HISTORY'] = (
+                    f"apply_tweak: Applied Primary WCS correction on {date.today().isoformat():s}"
+                )
+
+            str_extlist = '; '.join(map(ext2str, fwi['extlist']))
+            print(f"  - Updated '{fname:s}', extensions: {str_extlist}")
+
+        finally:
+            util.updateNEXTENDKw(imhdulist)
+            fi.release_all_images()
+
+
+@deprecated(since='3.4.2', name='tweakback', alternative='apply_tweak')
 def tweakback(drzfile, input=None,  origwcs = None,
-                newname = None, wcsname = None,
-                extname='SCI', force=False, verbose=False):
+              newname = None, wcsname = None,
+              extname='SCI', force=False, verbose=False):
     """
     Apply WCS solution recorded in drizzled file to distorted input images
     (``_flt.fits`` files) used to create the drizzled file.  This task relies on
@@ -60,7 +561,7 @@ def tweakback(drzfile, input=None,  origwcs = None,
 
     newname : str (Default = None)
         Value of ``WCSNAME`` to be used to label the updated solution in the
-        output (eq., ``_flt.fits``) files.  If left blank or None, it will
+        output (e.g., ``_flt.fits``) files.  If left blank or ``None``, it will
         default to using the current ``WCSNAME`` value from the input drzfile.
 
     input : str (Default = '')
@@ -106,6 +607,7 @@ def tweakback(drzfile, input=None,  origwcs = None,
     If no input distorted files are specified as input, this task will attempt
     to generate the list of filenames from the drizzled input file's own
     header.
+
 
     EXAMPLES
     --------
@@ -190,7 +692,7 @@ def tweakback(drzfile, input=None,  origwcs = None,
         else:
             raise ValueError(f"WCS with name '{origwcs}' not found in '{drzfile}'")
     else:
-         _, orig_wcskey = determine_orig_wcsname(scihdr, wnames, wkeys)
+        _, orig_wcskey = determine_orig_wcsname(scihdr, wnames, wkeys)
 
     orig_wcs = wcsutil.HSTWCS(drzfile, ext=sciext, wcskey=orig_wcskey)
 


### PR DESCRIPTION
Due to somewhat recent changes in the `stwcs` package and `altwcs` module specifically, `tweakback` function stopped working with default parameters. It has become clear that it is impossible to fix `tweakback` (or its documentation) in a consistent way given changes in the `stwcs`.

This PR proposes a new version of the `tweakback` function called here `apply_tweak` with a slightly different API consistent with `stwcs` changes that preserves main functionality of the `tweakback`. This is basically a replacement for `tweakback` which is deprecated in this PR.