### PR TITLE
Fixed skycell size in pixels as quoted in the documentation.

### DIFF
--- a/doc/source/multivisit.rst
+++ b/doc/source/multivisit.rst
@@ -91,7 +91,7 @@ Defining each SkyCell
 ----------------------
 Each ProjectionCell is split into a grid of 21 x 21 'sky cells' which serves as the most basic MVM product generated
 during MVM processing.  Sky cells, as defined as the SkyCell object in the code and referred to as **SkyCell**,
-are approximately 0.2° x 0.2° in size (~21500 x ~21500 pixels) and
+are approximately 0.2° x 0.2° in size (~18000 x ~18000 pixels) and
 they have the same WCS as the ProjectionCell.  Each SkyCell gets identified by its position within the ProjectionCell
 as shown in this figure:
 


### PR DESCRIPTION
A simple fix to documentation was done.  SkyCells are 0.2 x 0.2 degrees on a side.  For 0.04" pixels, the SkyCells are 18000 x 18000 pixels and **not** 21500 x 21500 pixels.