### PR TITLE
Modified the docstring which defines the HAPLEVEL and its associated meaning

### DIFF
--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -7,8 +7,9 @@
     'HAPLEVEL' keyword.  The 'HAPLEVEL' values are:
 
       * 1 : calibrated (FLT/FLC) input images and exposure level drizzle products with improved astrometry
-      * 2 : filter and total products combined using the improved astrometry, consistent pixel scale, and oriented to North.
-      * 3 : (future) multi-visit mosaics aligned to common tangent plane
+      * 2 : filter and total products combined using the improved astrometry, consistent pixel scale, and oriented to North
+      * 3 : unused
+      * 4 : multi-visit mosaics aligned to a common tangent plane
 """
 import copy
 import logging


### PR DESCRIPTION
The changes are that Level 3 is unused and Level 4 indicates the multi-visit mosaics.  The full documentation is now:

      1 : calibrated (FLT/FLC) input images and exposure level drizzle products with improved astrometry
      2 : filter and total products combined using the improved astrometry, consistent pixel scale, and oriented to North
      3 : unused
      4 : multi-visit mosaics aligned to a common tangent plane