### PR TITLE
Revert sky matching upon any error

### DIFF
--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -348,7 +348,7 @@ def _skymatch(imageList, paramDict, in_memory, clean, logfile):
                  verbose     = True,
                  flog        = MultiFileLog(console = True, enableBold = False),
                  _taskname4history = 'AstroDrizzle')
-    except AssertionError:
+    except Exception:
         if 'match' in paramDict['skymethod']:  # This catches 'match' and 'globalmin+match'
             new_method = 'globalmin' if 'globalmin' in paramDict['skymethod'] else 'localmin'
 


### PR DESCRIPTION
Super simple update to the sky matching code in AstroDrizzle to always revert to a less complex sky matching algorithm if the full matching algorithm fails.  