### PR TITLE
Exit immediately if no new MVM inputs

### DIFF
--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -939,7 +939,7 @@ def build_poller_table(input, log_level, all_mvm_exposures=[], poller_type='svm'
                 if len(rows_to_drop) == len(input_table):
                     err_msg = "All images have already been MVM processed. No new MVM processing is needed. Exiting..."
                     log.error(err_msg)
-                    raise Exception(err_msg)
+                    sys.exit(analyze.Ret_code.NO_VIABLE_DATA.value)
                 elif len(rows_to_drop) == 0:
                     log.info("None of the input images have previously been MVM processed. Proceeding with MVM processing of all input images... ")
                 else:


### PR DESCRIPTION
This simple change converts an Exception to an immediate system exit so that the calling code can better understand the reason for quitting processing at this point.  Specifically, if there are no new MVM inputs to process, it should simply quit with a pre-defined exit code of 65.