### PR TITLE
Update SVM to support WFPC2 subarray exposures

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -92,7 +92,8 @@ envvar_cat_svm = {"SVM_CATALOG_SBC": 'on',
                   "SVM_CATALOG_WFC": 'on',
                   "SVM_CATALOG_UVIS": 'on',
                   "SVM_CATALOG_IR": 'on',
-                  "SVM_CATALOG_PC": 'on'}
+                  "SVM_CATALOG_PC": 'on',
+                  "SVM_CATALOG_WF": 'on'}
 envvar_cat_str = "SVM_CATALOG_{}"
 
 # --------------------------------------------------------------------------------------------------------------

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -34,20 +34,18 @@ Dependencies
 * ci_table.py
 """
 import glob
-import json
 import math
 import os
 import sys
 import time
 
 from astropy.io import fits as fits
-from astropy.table import Table
 import numpy
 import scipy
 import scipy.ndimage
 
-from drizzlepac.haputils import ci_table
 from stsci.tools import logutil
+from stsci.tools import fileutil
 from stwcs import wcsutil
 
 
@@ -324,6 +322,7 @@ def hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, p
     """
     image_split = drizzled_image.split('/')[-1]
     channel = drizzled_image.split("_")[4].upper()
+    instrume = drizzled_image.split("_")[3].upper()
 
     if channel == 'IR':  # TODO: Test and IR case just to make sure that IR shouldn't be skipped
         return catalog_data
@@ -354,11 +353,11 @@ def hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, p
         if channel.lower() in ['sbc', 'hrc']:
             image_ext_list = ["[sci,1]"]
         dq_sat_bit = 256
-    if channel.lower() == 'wfpc2':
-        image_ext_list = ["[sci,1]", "[sci,2]", "[sci,3]", "[sci,4]"]
-        dq_sat_bit = 8
-    if channel.lower() == 'pc':
-        image_ext_list = ["[sci,1]"]
+
+    if instrume.lower() == 'wfpc2':
+        numext = fileutil.countExtn(flt_list[0], extname='SCI')
+        # This accounts for readouts of only some detectors instead of all 4
+        image_ext_list = [f"[sci,{i+1}]" for i in range(numext)]
         dq_sat_bit = 8
 
     # build list of arrays

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -347,6 +347,10 @@ def hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, p
     # EXTRACT DQ DATA FROM FLT IMAGE AND CREATE A LIST
     # OF "ALL" PIXEL COORDINATES WITH A FLAG VALUE OF 256
     # ----------------------------------------------------
+    # instrume: name of instrument from INSTRUME keyword used in filename
+    # Channel: detector or chip ID from instrument used for exposure
+    #          WFPC2 does not define this in the image headers,
+    #          so default values 'PC' and 'WF' are used
     if ((channel.lower() != 'wfpc2') and (channel.lower() != 'pc')):
         if channel.lower() in ['wfc', 'uvis']:
             image_ext_list = ["[sci,1]", "[sci,2]"]

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -157,7 +157,9 @@ focus_pars = {"WFC3/IR": {'sigma': 2.0, 'good_bits': 512},
               "ACS/WFC": {'sigma': 1.5, 'good_bits': 1360},
               "ACS/SBC": {'sigma': 2.0, 'good_bits': 0},
               "ACS/HRC": {'sigma': 1.5, 'good_bits': 1360},
-              "WFPC2/PC": {'sigma': 1.5, 'good_bits': 1360}}
+              "WFPC2/PC": {'sigma': 1.5, 'good_bits': 1360},
+              "WFPC2/WF": {'sigma': 1.5, 'good_bits': 1360}}
+
 sub_dirs = ['OrIg_files', 'pipeline-default']
 valid_alignment_modes = ['apriori', 'aposteriori', 'default-pipeline']
 gsc240_date = '2017-10-01'

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -384,7 +384,7 @@ def wfpc2_to_flt(imgname):
 
     # Add keywords to be more compatible with ACS and WFC3 data
     num_sci = fileutil.countExtn(imgname)
-    det_name = 'PC' if num_sci == 4 else 'WF'
+    det_name = 'PC' if in_sci[('sci',1)].header['detector'] == 1 else 'WF'
     in_sci[0].header['DETECTOR'] = det_name
 
     if is_dq:


### PR DESCRIPTION
These updates revise the SVM processing code to support not only full 4-chip readout mode WFPC2 exposures, but also 'subarray' readout exposures where only some of the detectors are read out.  This adds a new 'detector' mode for WFPC2 data, 'wf', to compliment the default 'pc' which gets defined for 4-chip exposures.  

These changes were tested using data from "visit" **u2310k** which actually has a mix of readout modes for the exposures in the visit.