### PR TITLE
Support additional RADESYS options for input files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ number of the code change for that issue.  These PRs can be viewed at:
   ``tweakback()``. ``apply_tweak()`` preserves the functionality of ``tweakback``
   with a re-designed API. Existing ``tweakback`` was deprecated. [#1372]
 
+- Updated segmentation source catalog generation to use ICRS as input RADESYS
+  when input images have an unsupported REFFRAME value (like OTHER or B1950). [#1423]
+
 
 3.4.1 (5-Apr-2022)
 ==================

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1827,17 +1827,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
                                                     kernel=self.kernel, wcs=self.image.imgwcs,
                                                     kron_params=[self._kron_scaling_radius, self._kron_minimum_radius])
 
-            # Guard against a non-standard coordinate system being defined in the input image headers
-            # If something non-standard is found, set the value to 'ICRS' to insure that the
-            # table conversion works.  Checking against the set of valid options recognized by WCSLIB and
-            # documented in http://ds9.si.edu/doc/ref/region.html#RegionFileFormat is necessary since the
-            # header keyword REFFRAME can be populated with anything specified by the user in the original
-            # proposal.
-            if self.source_cat._wcs.wcs.radesys.upper() not in RADESYS_OPTIONS:
-                self.source_cat._wcs.wcs.radesys = 'ICRS'
-                log.warning(f"Assuming input coordinates are ICRS, instead of {self.source_cat._wcs.wcs.radesys}")
-                log.warning(f"Sky coordinates of source objects may not be accurate.")
 
+            enforce_icrs_compatibility(self.source_cat)
             # Convert source_cat which is a SourceCatalog to an Astropy Table - need the data in tabular
             # form to filter out bad rows and correspondingly bad segments before the filter images are processed.
             total_measurements_table = Table(self.source_cat.to_table(columns=['label', 'xcentroid', 'ycentroid', 'sky_centroid_icrs']))
@@ -2188,16 +2179,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             self.source_cat = SourceCatalog(imgarr_bkgsub, self.sources, background=self.image.bkg_background_ra,
                                                 error=total_error, kernel=self.kernel, wcs=self.image.imgwcs)
 
-        # Guard against a non-standard coordinate system being defined in the input image headers
-        # If something non-standard is found, set the value to 'ICRS' to insure that the
-        # table conversion works.  Checking against the set of valid options recognized by WCSLIB and
-        # documented in http://ds9.si.edu/doc/ref/region.html#RegionFileFormat is necessary since the
-        # header keyword REFFRAME can be populated with anything specified by the user in the original
-        # proposal.
-        if self.source_cat._wcs.wcs.radesys.upper() not in RADESYS_OPTIONS:
-            self.source_cat._wcs.wcs.radesys = 'ICRS'
-            log.warning(f"Assuming input coordinates are ICRS, instead of {self.source_cat._wcs.wcs.radesys}")
-            log.warning(f"Sky coordinates of source objects may not be accurate.")
+        enforce_icrs_compatibility(self.source_cat)
 
         filter_measurements_table = Table(self.source_cat.to_table(columns=include_filter_cols))
 
@@ -2938,3 +2920,19 @@ def fill_nans_maskvalues(catalog, fill_value=constants.FLAG):
         np.nan_to_num(col, copy=False, nan=fill_value)
 
     return catalog
+
+
+def enforce_icrs_compatibility(catalog):
+    """This function insures that the source catalog can return ICRS sky coordinates.
+
+    # This function guards against a non-standard coordinate system being defined in the input image headers
+    # If something non-standard is found, set the value to 'ICRS' to insure that the
+    # table conversion works.  Checking against the set of valid options recognized by WCSLIB and
+    # documented in http://ds9.si.edu/doc/ref/region.html#RegionFileFormat is necessary since the
+    # header keyword REFFRAME can be populated with anything specified by the user in the original
+    # proposal.
+    """
+    if catalog._wcs.wcs.radesys.upper() not in RADESYS_OPTIONS:
+        catalog._wcs.wcs.radesys = 'ICRS'
+        log.warning(f"Assuming input coordinates are ICRS, instead of {catalog._wcs.wcs.radesys}")
+        log.warning(f"Sky coordinates of source objects may not be accurate.")


### PR DESCRIPTION
Some input data includes names of the coordinate system for the WCS from the REFFRAME keyword that are not supported by the FITS WCSLIB transformations.  These changes watch for any incompatible REFFRAME/RADESYS values and replaces it blindly with a value of 'ICRS' for the purposes of generating the sky coordinates of the segmentation catalog sources only.  Log messages are then generated to warn the user that such a change to the computation of the sky coordinates was made and that the output sky coordinates may not be entirely accurate.  