### PR TITLE
Verify astrometry headerlets and remove bad ones

### DIFF
--- a/drizzlepac/outputimage.py
+++ b/drizzlepac/outputimage.py
@@ -745,9 +745,9 @@ def addWCSKeywords(wcs, hdr, blot=False, single=False, after=None):
     if after in WCS_KEYWORDS:
         after = None
 
-    if 'CTYPE1' not in hdr:
-        hdr.set('CTYPE2', value=wcs.wcs.ctype[1], after=after)
-        hdr.set('CTYPE1', value=wcs.wcs.ctype[0], after=after)
+    # if 'CTYPE1' not in hdr:
+    hdr.set('CTYPE2', value=wcs.wcs.ctype[1], after=after)
+    hdr.set('CTYPE1', value=wcs.wcs.ctype[0], after=after)
     hdr.set('CRPIX2', value=wcs.wcs.crpix[1], after=after)
     hdr.set('CRPIX1', value=wcs.wcs.crpix[0], after=after)
     hdr.set('CRVAL2', value=wcs.wcs.crval[1], after=after)


### PR DESCRIPTION
Some _a posteriori_ headerlet solutions retrieved from the astrometry database do not have the full distortion model solution attached as they should have which results in the omission of the distortion model when drizzling the affected exposure(s).  These changes look at all the headerlet solutions provided by the astrometry database to verify that those with WCSNAME containing '-FIT' also have a full distortion model and the corresponding CTYPE values.  This check gets performed before those solutions are used for alignment, so if any are found with problems, they are simply deleted from the input exposure so that the alignment can proceed from scratch.  

This allows the resulting image to be aligned correctly while also generating a properly distortion-corrected drizzled image and was tested on data from visit 'ie3501' where exposures from ASN `ie3501020` had incorrect GAIAeDR3 headerlets in the database.  

In addition, some Flake8 updates were also made to the affected modules as well.  