### PR TITLE
Essentially remove restriction on PhotUtils package version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     pandas
     spherical_geometry>=1.2.22
     astroquery>=0.4
-    photutils<1.4.0
+    photutils>1.2.0
     lxml
     PyPDF2
     scikit-image>=0.14.2


### PR DESCRIPTION
Essentially remove restriction on PhotUtils package version, except to avoid old versions where there were many changes (avoid <= 1.2.0).