### PR TITLE
Insure correct filetype gets defined for filter and total products

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Refactored code to work with changes in ``tweakwcs`` version 0.8.0. [#1430]
 
+- Ignore non-CTE-corrected exposures when SVM or MVM products also include
+  CTE-corrected exposures as inputs. [#1433]
+
 
 3.4.3 (24-Aug-2022)
 ===================

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -4,7 +4,7 @@ jobs:
     ${{ if eq(parameters.os, 'windows') }}:
       vmImage: windows-latest
     ${{ if eq(parameters.os, 'macos') }}:
-      vmImage: macOS-10.15
+      vmImage: macOS-latest
     ${{ if eq(parameters.os, 'linux') }}:
       vmImage: ubuntu-latest
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -783,11 +783,11 @@ def select_common_filetype(filter_files):
     # Check whether or not all input files for this filter product have the same filetype (suffix)
     filetypes_flt = filetypes == 'flt'
     filetypes_flc = filetypes == 'flc'
-    num_flt = len(np.where(filetypes_flt)[0])
     num_flc = len(np.where(filetypes_flc)[0])
 
-    # determine which file type is the majority of the inputs
-    filter_type = 'flc' if num_flc >= num_flt else 'flt'
+    # determine whether we have FLC images in set or not
+    # and set the filter_type accordingly
+    filter_type = 'flc' if num_flc > 0 else 'flt'
 
     filter_members = filetypes_flc if filter_type == 'flc' else filetypes_flt
 


### PR DESCRIPTION
New logic has been implemented to determine the output product type (DRZ vs DRC) based on evaluating the filenames of all inputs.  If any FLC files are present for the filter product, any FLT images in the same filter product input list will be ignored and the product will be given the DRC product type (filename suffix).  A single exposure product will be created for any ignored product as a record that those exposures were taken, but they will not be included when creating any filter product, total product or even skycell layer.

This change serves as the interpretation of decisions made by the instrument teams on how to treat any mix of CTE and non-CTE corrected exposures when creating SVM and MVM products.  The changes were tested using the data from visit ``ibig07``, where the F814W exposures included 1 non-CTE-corrected image mixed in with 4 CTE-corrected images. 