### PR TITLE
Update to fully support numpy v1.23

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -916,7 +916,7 @@ def match_relative_fit(imglist, reference_catalog, **fit_pars):
             image.meta["group_id"] = 1234567
         # 2: Perform absolute alignment
         matched_cat = align_wcs(imglist, reference_catalog, match=match,
-                                inobj=common_pars['minobj'][fitgeom],
+                                minobj=common_pars['minobj'][fitgeom],
                                 fitgeom=fitgeom, nclip=nclip)
         # Insure the expanded reference catalog has all the information needed
         # to complete processing.

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -337,8 +337,8 @@ class SkyFootprint(object):
                 meta_x = np.clip(meta_x, 0, self.meta_wcs.array_shape[1] - 1)
 
                 # define subarray spanned by this chip on the SkyCell
-                scell_slice = [slice(meta_y.min(), meta_y.max()),
-                               slice(meta_x.min(), meta_x.max())]
+                scell_slice = (slice(meta_y.min(), meta_y.max()),
+                               slice(meta_x.min(), meta_x.max()))
                 scell_ltm = [meta_x.min(), meta_y.min()]
                 # Reset range of pixels to be relative to starting pixel position in SkyCell
                 meta_x -= scell_ltm[0]


### PR DESCRIPTION
These changes fix the last remaining instance where numpy v1.23 support was overlooked earlier when resolving numpy deprecation warnings.  This affected the use of the cell_utils module only.  In addition, a typo was also cleaned up in a function within the align_utils module which would have affected what exposures could be aligned to an astrometric catalog. 

These changes were tested against data from visits 'j8ph01' and 'ie3501' with standard pipeline processing of an ASN with ``runastrodriz``, single-visit mosaic processing, and also sky cell determination for an exposure (where the numpy problem was originally identified).  