### PR TITLE
use canonical filename of RTD configuration and enable `nitpicky`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: doc/source/conf.py
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - htmlzip
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,0 @@
-type: sphinx
-python:
-    version: 3
-    setup_py_install: true
-conda:
-    file: doc/.rtd-environment.yml

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -316,3 +316,6 @@ latex_documents = [
 # latex_use_modindex = True
 
 latex_elements = { 'pointsize' : '11pt' }
+
+# Enable nitpicky mode - which ensures that all references in the docs resolve.
+nitpicky = True


### PR DESCRIPTION
change `.readthedocs.yml` -> `.readthedocs.yaml`, enable `nitpicky` mode to validate intra-doc links