### PR TITLE
Prevent astroquery code from throwing an Exception for SVM requests

### DIFF
--- a/drizzlepac/haputils/astroquery_utils.py
+++ b/drizzlepac/haputils/astroquery_utils.py
@@ -138,6 +138,8 @@ def retrieve_observation(obsid, suffix=['FLC'], archive=False, clobber=False,
                 download_dir = os.path.dirname(os.path.abspath(file))
             # Move or copy downloaded file to current directory
             local_file = os.path.abspath(os.path.basename(file))
+            if not os.path.exists(file):
+                continue
             if archive:
                 shutil.copy(file, local_file)
             else:


### PR DESCRIPTION
Some requests for SVM data using `astroquery_utils.retrieve_observation` will result in an Exception being thrown due to an attempt to try to move a file which has already been moved.  This simple change avoids that problem and allows the request to succeed normally. 