### PR TITLE
Use verify_guiding correctly for pipeline and SVM processing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
+3.5.1 (unreleased)
+==================
+
+- Turn on use of ``verify_guiding()`` to ignore exposures where guide star
+  lock was lost and the stars are trailed. [#1443]
+
 
 3.5.0 (31-Aug-2022)
 ====================


### PR DESCRIPTION
These changes turn on the use of the `verify_guiding()` function from `haputils/analyze.py` in order to not try to align any exposure which appears (according to the algorithm) to have lost lock resulting in trailed stars.  The function was also upgraded to check the `QUALITY` keyword and ignore any exposure which has been marked with either 'GSFAIL' or 'TDF-DOWN'.  In addition, the logic for using this function was updated considerably in `runastrodriz` so that alignment is turned off when any exposure has been flagged as `BAD` by this function, and to not create any drizzle products if all exposures are found to be 'BAD'.  The logic, though, still allows the user to override these behaviors with the use of the `force` and `force_alignment` parameters. 

These changes were tested using data from ASN `jdtg08010` and from the singleton `j94rd3b0q`.   The ASN includes a single exposure which is trailed and flagged as `BAD` while the remaining exposures in the ASN have EXPTIME=0 due to the shutter remaining closed. 