### PR TITLE
Fix command line interface for runastrodriz

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1986,7 +1986,7 @@ def main():
     import getopt
 
     try:
-        optlist, args = getopt.getopt(sys.argv[1:], 'bdahfginv:')
+        optlist, args = getopt.getopt(sys.argv[1:], 'bdahfgin:v:')
     except getopt.error as e:
         print(str(e))
         print(__doc__)


### PR DESCRIPTION
This simple change fixes the command line interface to `runastrodriz` in order to once again interpret the `-n` parameter input correctly. 