### PR TITLE
Fix command line interface for runastrodriz (#1444)

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1986,7 +1986,7 @@ def main():
     import getopt
 
     try:
-        optlist, args = getopt.getopt(sys.argv[1:], 'bdahfginv:')
+        optlist, args = getopt.getopt(sys.argv[1:], 'bdahfgin:v:')
     except getopt.error as e:
         print(str(e))
         print(__doc__)


### PR DESCRIPTION
Update 3.5.0rc1 to include fix for runastrodriz command-line interface (#1444).