### PR TITLE
Implement update of WFPC2 header for best references in runastrodriz

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -276,14 +276,16 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         raw_suffix = '_raw.fits'
         goodpix_name = 'NGOODPIX'
     else:
-        # Update header of WFPC2 data to use latest reference
-        # files from CRDS
-        wfpc2Data.apply_bestrefs(inFilename)
         # Convert input c0m file into compatible flt file
         if 'd0m' in inFilename:
             inFilename = inFilename.replace('d0m', 'c0m')
         # This returns the name of the _flt.fits file that was created
         inFilename = wfpc2Data.wfpc2_to_flt(inFilename)
+        # Update header of WFPC2 data to use latest reference
+        # files from CRDS
+        print(f"Updating distortion reference files for: {inFilename}")
+        wfpc2Data.apply_bestrefs(inFilename)
+
         raw_suffix = '_d0m.fits'
         goodpix_name = 'GPIXELS'
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -276,6 +276,9 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         raw_suffix = '_raw.fits'
         goodpix_name = 'NGOODPIX'
     else:
+        # Update header of WFPC2 data to use latest reference
+        # files from CRDS
+        wfpc2Data.apply_bestrefs(inFilename)
         # Convert input c0m file into compatible flt file
         if 'd0m' in inFilename:
             inFilename = inFilename.replace('d0m', 'c0m')

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -429,3 +429,28 @@ def wfpc2_to_flt(imgname):
         in_dq.close()
 
     return flt_filename
+
+
+# -----------------------------
+# Optional code for updating headers to latest
+# reference files from CRDS
+# -----------------------------
+def apply_bestrefs(uref_dir, dirname=None):
+
+    os.environ['CRDS_SERVER_URL'] = "https://hst-crds.stsci.edu"
+    os.environ['CRDS_PATH'] = "D:\data\crds_cache"
+    os.environ['CRDS_OBSERVATORY'] = "hst"
+    os.environ['uref'] = uref_dir
+#    os.environ['uref'] = "D:\\data\\crds_cache\\references\\hst\\"
+
+    import crds
+    import glob
+
+    if dirname:
+        os.chdir(dirname)
+
+    c0m = sorted(glob.glob("*c0m.fits"))
+    d0m = sorted(glob.glob("*d0m.fits"))
+    crds.assign_bestrefs(c0m, sync_references=True)
+    crds.assign_bestrefs(d0m, sync_references=True)
+

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -472,7 +472,6 @@ def apply_bestrefs(raw_filename=None, dirname=None, uref_path=None, crds_path=No
 
     """
     starting_dir = os.getcwd()
-    import glob
 
     wfpc2_dir = dirname if dirname else os.getcwd()
     os.chdir(wfpc2_dir)

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -432,16 +432,17 @@ def wfpc2_to_flt(imgname):
     return flt_filename
 
 
-# -----------------------------
-# Optional code for updating headers to latest
+# ------------------------------------------------------
+# Function for updating headers to latest
 # reference files from CRDS
-# -----------------------------
+# ------------------------------------------------------
 def apply_bestrefs(raw_filename=None, dirname=None, uref_path=None, crds_path=None):
     """Update WFPC2 data to use the latest reference files from CRDS
 
     .. note::
-        See https://hst-crds.stsci.edu/docs/cmdline_bestrefs/ for details
-        on how to configure CRDS for your local system and for definitions
+        See `https://hst-crds.stsci.edu/docs/cmdline_bestrefs/
+        <https://hst-crds.stsci.edu/docs/cmdline_bestrefs/>`_
+        for details on how to configure CRDS for your local system and for definitions
         of all the environment variables used by CRDS.
 
     Parameters
@@ -450,6 +451,9 @@ def apply_bestrefs(raw_filename=None, dirname=None, uref_path=None, crds_path=No
         Filename of RAW (*d0m.fits) input file to be updated
         The corresponding calibrated (*c0m.fits) file also needs to be
         present in the directory to be updated as well.
+        If not specified, **all RAW and calibrated files** from the
+        current directory, or ``dirname`` directory if given, will
+        be updated.
 
     dirname : str, optional
         Name of directory containing WFPC2 data to be updated.


### PR DESCRIPTION
These changes include:

- a new function `wfpc2Data.apply_bestrefs()`
- update to `runastrodriz.process()` to always call `wfpc2Data.apply_bestrefs()` for all WFPC2 input files
- only FLT files will be updated by `runastrodriz.process()` 
- only the distortion reference files will be updated by `runastrodriz.process()`

The new function uses CRDS to update the headers with the best reference files currently available for processing according to CRDS.  If a local CRDS cache is already defined, it will use that, otherwise it will create one in the current working directory then delete it when finished.

The code was tested using data from visit **u2lx05**.