### PR TITLE
SVM: Fix logic for catalogs and cosmic ray checking

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -687,7 +687,7 @@ class HAPCatalogs:
                 all_sources = len(source_cat)
                 log.info("{} catalog with {} good sources out of {} total sources :  CR threshold = {}".format(cat_type, n_sources, all_sources, thresh))
                 # n_sources == 0 should never get here, but just to cover the past case of 0 < 0.0
-                if n_sources == 0 or n_sources < thresh:
+                if n_sources < thresh or n_sources == 0:
                     reject_catalogs = True
                     log.info("{} catalog FAILED CR threshold.  Rejecting both catalogs...".format(cat_type))
                     break

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -686,7 +686,8 @@ class HAPCatalogs:
                 n_sources = source_cat.sources_num_good  # len(source_cat)
                 all_sources = len(source_cat)
                 log.info("{} catalog with {} good sources out of {} total sources :  CR threshold = {}".format(cat_type, n_sources, all_sources, thresh))
-                if n_sources < thresh:
+                # n_sources == 0 should never get here, but just to cover the past case of 0 < 0.0
+                if n_sources == 0 or n_sources < thresh:
                     reject_catalogs = True
                     log.info("{} catalog FAILED CR threshold.  Rejecting both catalogs...".format(cat_type))
                     break


### PR DESCRIPTION
The datasets quoted in this ticket which indicate they are good for testing a fix no longer even execute the apparent troublesome portion of the code.  The entirety of the drizzlepac code has changed a great deal in two years.  Since this has not been noted to have been an issue and no longer fails for the datasets suggested, I will make a modest change in the code which covers the case of zero sources. Note that zero sources should not be able to reach this portion of the code any longer.