### PR TITLE
Add error handling/improved messages to CatalogSearch functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,11 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Turn on use of ``verify_guiding()`` to ignore exposures where guide star
   lock was lost and the stars are trailed. [#1443]
 
+- Added informational text when the catalog service fails (e.g., service cannot
+  be reached or the request was somehow malformed) to make the default response
+  more helpful. The request specification is also sent to the log, so the user
+  can see what was actually requested. [#1451]
+
 
 3.5.0 (31-Aug-2022)
 ====================

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -473,7 +473,6 @@ def get_catalog(ra, dec, sr=0.1, epoch=None, catalog='GSC241'):
         # More information is still needed for the user. Regardless of the
         # portion of the the specification which is incorrect, the returned
         # error is still "Cannot find table 0".
-        out_string = spec.replace("&", " ")
         log.warning("Check request for bad specification, unsupported catalog, or "
                     "service may be unavailable.")
         log.warning("Request: {}".format(spec.replace("&", " ")))
@@ -545,7 +544,6 @@ def get_catalog_from_footprint(footprint, epoch=None, catalog='GSC241'):
         # More information is still needed for the user. Regardless of the
         # portion of the the specification which is incorrect, the returned
         # error is still "Cannot find table 0".
-        out_string = spec.replace("&", " ")
         log.warning("Check request for bad specification, unsupported catalog, or "
                     "service may be unavailable.")
         log.warning("Request: {}".format(spec.replace("&", " ")))

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -467,7 +467,16 @@ def get_catalog(ra, dec, sr=0.1, epoch=None, catalog='GSC241'):
 
     # If we still have an error returned by the web-service, report the exact error
     if rstr[0].startswith('Error'):
-        log.warning("Astrometric catalog generation FAILED with: \n{}".format(rstr))
+        log.warning("Astrometric catalog generation FAILED with: \n{}." 
+                    " No output table has been generated.".format(rstr))
+         
+        # More information is still needed for the user. Regardless of the
+        # portion of the the specification which is incorrect, the returned
+        # error is still "Cannot find table 0".
+        out_string = spec.replace("&", " ")
+        log.warning("Check request for bad specification, unsupported catalog, or "
+                    "service may be unavailable.")
+        log.warning("Request: {}".format(spec.replace("&", " ")))
 
     del rstr[0]
     r_csv = Table.read(rstr, format='ascii.csv')
@@ -532,6 +541,14 @@ def get_catalog_from_footprint(footprint, epoch=None, catalog='GSC241'):
     # If we still have an error returned by the web-service, report the exact error
     if rstr[0].startswith('Error'):
         log.warning("Astrometric catalog generation FAILED with: \n{}".format(rstr))
+
+        # More information is still needed for the user. Regardless of the
+        # portion of the the specification which is incorrect, the returned
+        # error is still "Cannot find table 0".
+        out_string = spec.replace("&", " ")
+        log.warning("Check request for bad specification, unsupported catalog, or "
+                    "service may be unavailable.")
+        log.warning("Request: {}".format(spec.replace("&", " ")))
 
     # remove initial line describing the number of sources returned
     # CRITICAL to proper interpretation of CSV data


### PR DESCRIPTION
Added informational text in the form of a log WARNING when the catalog service fails (e.g., service cannot be reached or the request was somehow malformed) in an effort to make the default response more useful.  The request specification is also sent to the log, so the user can see what was actually requested.

The routine that is making the function call may decide this issue is or is not a problem.