### PR TITLE
Add the missing CHANGELOG comment for PR#1450

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,11 +23,14 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Turn on use of ``verify_guiding()`` to ignore exposures where guide star
   lock was lost and the stars are trailed. [#1443]
 
+- Ensure when no sources are found and the variable thresh is zero, the 
+  ``verify_crthesh()`` properly indicates the catalog failed the CR threshold.
+  [#1450]
+
 - Added informational text when the catalog service fails (e.g., service cannot
   be reached or the request was somehow malformed) to make the default response
   more helpful. The request specification is also sent to the log, so the user
   can see what was actually requested. [#1451]
-
 
 3.5.0 (31-Aug-2022)
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   more helpful. The request specification is also sent to the log, so the user
   can see what was actually requested. [#1451]
 
+
 3.5.0 (31-Aug-2022)
 ====================
 


### PR DESCRIPTION
Added the missing CHANGELOG comment for the update in PR#1450 as it addresses a bug.  The fix ensures if no sources are found and the threshold is zero, the code properly evaluates to indicating the catalog failed the CR threshold criterion.