### PR TITLE
Cleanup SCI header (FLT/C, DRZ/C) keywords remaining from an 'a aposteriori' active WCS solution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,12 @@ number of the code change for that issue.  These PRs can be viewed at:
   more helpful. The request specification is also sent to the log, so the user
   can see what was actually requested. [#1451]
 
+- Check the SCI extension(s) of the output FLT/FLC and DRZ/DRC files.  If the active
+  WCS solution is 'a priori', there should not be any valid values for NMATCHES,
+  RMS_RA/RMS_DEC, FITGEOM, and CRDER1/CRDER2 as these keywords are associated with 
+  'a posteriori' solutions.  Ensure the WCSTYPE is based upon the active WCSNAME.
+  [#1465]
+
 - Protect against there being no sources left to measure
   the properties after cleaning cosmic rays from the input
   in ``verify_guiding()``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,16 +32,17 @@ number of the code change for that issue.  These PRs can be viewed at:
   more helpful. The request specification is also sent to the log, so the user
   can see what was actually requested. [#1451]
 
-- Check the SCI extension(s) of the output FLT/FLC and DRZ/DRC files.  If the active
-  WCS solution is 'a priori', there should not be any valid values for NMATCHES,
-  RMS_RA/RMS_DEC, FITGEOM, and CRDER1/CRDER2 as these keywords are associated with 
-  'a posteriori' solutions.  Ensure the WCSTYPE is based upon the active WCSNAME.
-  [#1465]
-
 - Protect against there being no sources left to measure
   the properties after cleaning cosmic rays from the input
   in ``verify_guiding()``.
   [#1466]
+
+- Check the SCI extension(s) of the output FLT/FLC and DRZ/DRC files.  If the active
+  WCS solution is 'a priori', delete the following keywords if they are associated
+  with the active WCS as they are residue from a previous 'a posteriori' solution:
+  NMATCHES, RMS_RA/RMS_DEC, FITGEOM, and CRDER1/CRDER2. Ensure the WCSTYPE is based
+  upon the active WCSNAME to clean up any confusion.
+  [#1465]
 
 
 3.5.0 (31-Aug-2022)

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -1473,13 +1473,8 @@ def reset_keywords_apriori(filename):
 
             # Loop over the keys_to_delete list
             for key in keys_to_delete:
-                try:
-                    if key in hdu[ext].header:
-                        del hdu[ext].header[key]
-
-                # Log a problem, but keep going as this is just a bit of cleanup
-                except KeyError:
-                    log.warning(f'Could not delete the {key} keyword from the active WCS solution.')
+                if key in hdu[ext].header:
+                    del hdu[ext].header[key]
 
     hdu.flush()
     hdu.close()


### PR DESCRIPTION
Check the SCI extension(s) of the output FLT/FLC and DRZ/DRC files.  If the active
WCS solution is 'a priori', there should not be any valid values for NMATCHES, RMS_RA/RMS_DEC, FITGEOM, and CRDER1/CRDER2 as these keywords are associated with 'a posteriori' solutions.  Ensure the WCSTYPE is based upon the active WCSNAME. Clarify some comments.