### PR TITLE
Protect against there being no sources left to measure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,11 @@ number of the code change for that issue.  These PRs can be viewed at:
   more helpful. The request specification is also sent to the log, so the user
   can see what was actually requested. [#1451]
 
+- Protect against there being no sources left to measure
+  the properties after cleaning cosmic rays from the input
+  in ``verify_guiding()``.
+  [#1466]
+
 
 3.5.0 (31-Aug-2022)
 ====================

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -627,6 +627,11 @@ def verify_guiding(filename, min_length=33):
     # Get the label IDs for sources flagged as CRs, IDs are 1-based not 0-based
     pt_srcs = np.where(bad_srcs == 0)[0] + 1
     segm.remove_labels(pt_srcs)
+    # If there are no sources left, this is akin to the check above where number
+    # of sources < 2, so just return False
+    if segm.nlabels == 0:
+        log.warning("After removal of suspected cosmic rays, there are no sources remaining in the image.")
+        return False
     src_cat = SourceCatalog(imgarr, segm)  # clean up source catalog now...
     num_sources = len(src_cat)
 


### PR DESCRIPTION
Protect against there being no sources left to measure after cleaning cosmic rays from the input image in ``verify_guiding()``.  If there are no sources left, this is akin to the check in the code where the number of sources < 2.  The value of False is being returned in both cases indicating the guiding is good.  This fix avoids the _ValueError: segment_img must have at least one non-zero label._