### PR TITLE
Protect against inability to find a FWHM due to a fitting problem

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ number of the code change for that issue.  These PRs can be viewed at:
   upon the active WCSNAME to clean up any confusion.
   [#1465]
 
+- Protect against inability to find a FWHM due to a fitting problem.
+
 
 3.5.0 (31-Aug-2022)
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   upon the active WCSNAME to clean up any confusion.
   [#1465]
 
-- Protect against inability to find a FWHM due to a fitting problem.
+- Protect against inability to find a FWHM due to a fitting problem. [#1467]
 
 
 3.5.0 (31-Aug-2022)

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -861,14 +861,18 @@ def find_fwhm(psf, default_fwhm):
     sigma_psf = gaussian_fwhm_to_sigma * default_fwhm
     gaussian_prf = IntegratedGaussianPRF(sigma=sigma_psf)
     gaussian_prf.sigma.fixed = False
-    itr_phot_obj = IterativelySubtractedPSFPhotometry(finder=iraffind,
-                                                      group_maker=daogroup,
-                                                      bkg_estimator=mmm_bkg,
-                                                      psf_model=gaussian_prf,
-                                                      fitter=fitter,
-                                                      fitshape=(11, 11),
-                                                      niters=2)
-    phot_results = itr_phot_obj(psf)
+    try:
+        itr_phot_obj = IterativelySubtractedPSFPhotometry(finder=iraffind,
+                                                          group_maker=daogroup,
+                                                          bkg_estimator=mmm_bkg,
+                                                          psf_model=gaussian_prf,
+                                                          fitter=fitter,
+                                                          fitshape=(11, 11),
+                                                          niters=2)
+        phot_results = itr_phot_obj(psf)
+    except Exception:
+        log.error("The find_fwhm() failed due to problem with fitting.")
+        return None
     # Insure none of the fluxes determined by photutils is np.nan
     phot_results['flux_fit'] = np.nan_to_num(phot_results['flux_fit'].data, nan=0)
 


### PR DESCRIPTION
Excapsulate the code which creates an IterativelySubtractedPSFPhotometry object and then tries to fit a FWHM with the settings in a try/except.  Added a log message indicating inability to find a FWHM due to a fitting problem as the original Exception message could be misleading.