### PR TITLE
Update wfpc2 shadow mask

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -234,7 +234,6 @@ class AlignmentTable:
         for img in self.haplist:
             img.close()
 
-
     def find_alignment_sources(self, output=True, crclean=None):
         """Find observable sources in each input exposure."""
         if crclean is None:
@@ -275,7 +274,6 @@ class AlignmentTable:
         for image in self.imglist:
             image.meta["group_id"] = self.group_id_dict["{}_{}".format(image.meta["rootname"], image.meta["chip"])]
             image.meta['num_ref_catalog'] = num_ref
-
 
     def configure_fit(self):
         # Convert input images to tweakwcs-compatible FITSWCSCorrector objects and

--- a/drizzlepac/haputils/deconvolve_utils.py
+++ b/drizzlepac/haputils/deconvolve_utils.py
@@ -512,6 +512,7 @@ def _create_input_psf(psf_name, calimg, total_flux):
 
     return psf_flt_name
 
+
 def get_cutouts(data, star_list, kernel, threshold_eff, exclude_border=False):
 
     coords = [(row[1], row[0]) for row in star_list]
@@ -990,6 +991,7 @@ def find_point_sources(drzname, data=None, mask=None,
     del peak_mask
 
     return peaks, psf_fwhm
+
 
 def determine_input_image(image):
     """Determine the name of an input exposure for the given drizzle product"""

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -69,8 +69,13 @@ class WFPC2InputImage (imageObject):
         # Look for additional file with DQ array, primarily for WFPC2 data
 
         indx = self._filename.find('.fits')
+        _flt_file = False
 
-        if indx > 3:
+        if self._filename.endswith('_flt.fits'):
+            dqfile = self._filename
+            _flt_file = True
+
+        elif indx > 3:
             suffix = self._filename[indx-4:indx]
             dqfile = self._filename.replace(suffix[:3],'_c1')
 
@@ -95,7 +100,10 @@ class WFPC2InputImage (imageObject):
                         "a FITS file nor a GEIS file.".format(self._filename))
 
         if os.path.exists(dqfile):
-            dq_suffix = fits.getval(dqfile, "EXTNAME", ext=1, memmap=False)
+            if _flt_file:
+                dq_suffix = 'DQ'
+            else:
+                dq_suffix = fits.getval(dqfile, "EXTNAME", ext=1, memmap=False)
         else:
             dq_suffix = "SCI"
 


### PR DESCRIPTION
The 'shadow mask' refers to the mask used to ignore those pixels from each chip which falls under the shadow of the WFPC2 pyramid.  This mask gets used when drizzling the data and can either be made from the DQ array or from a calibrated function that describes that shadowed region.  The changes in this code allow the code to properly work with the new ACS-style FLT format for the WFPC2 data as generated when updating the reference files early in astrodrizzle processing.  This allows the current logic to work correctly based on the DQ array as opposed to using the default functional form when the code was originally looking for the DQ array in the c0m file which was not provided as input to astrodrizzle.  

The logic was also updated to used the shadow mask defined by the calibrated functions to increase the overlap between chips by slightly shrinking the region flagged in the shadow mask region with DQ=2.  

The changes were tested using data from 'uba301', as well as several other visits.  