### PR TITLE
Turn on CR classify in align for WFPC2

### DIFF
--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/pc/wfpc2_pc_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/pc/wfpc2_pc_alignment_all.json
@@ -29,7 +29,7 @@
         "num_sources": 250,
         "deblend": false,
         "fwhmpsf": 0.13,
-        "classify": false,
+        "classify": true,
         "threshold": -1.1
       },
     "generate_astrometric_catalog":

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wf/wfpc2_wf_alignment_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wf/wfpc2_wf_alignment_all.json
@@ -29,7 +29,7 @@
         "num_sources": 250,
         "deblend": false,
         "fwhmpsf": 0.13,
-        "classify": false,
+        "classify": true,
         "threshold": -1.1
       },
     "generate_astrometric_catalog":


### PR DESCRIPTION
These changes simply turn on the CR identification step within the alignment processing to ignore CRs when aligning WFPC2 data.   This corrects the problems with aligning WFPC2 data seen in testing, as confirmed by successfully aligning data from these visits:

- u2m301
- u27817
- u2lx05
- u55i03