### PR TITLE
Implement photometric equalization for WFPC2 pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Protect against inability to find a FWHM due to a fitting problem. [#1467]
 
+- Implement photometric equalization for standard pipeline processing
+  (runastrodriz) of WFPC2 data. [#1471]
 
 3.5.0 (10-Oct-2022)
 ====================

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -121,6 +121,7 @@ from drizzlepac import wcs_functions
 # for WFPC2 support
 from drizzlepac.haputils import config_utils
 from drizzlepac import wfpc2Data
+from drizzlepac import photeq
 
 from . import __version__
 
@@ -287,6 +288,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         # files from CRDS
         print(f"Updating distortion reference files for: {inFilename}")
         wfpc2Data.apply_bestrefs(inFilename)
+        photeq.photeq(files=inFilename, ref_phot_ext=3, readonly=False)
 
         raw_suffix = '_d0m.fits'
         goodpix_name = 'GPIXELS'


### PR DESCRIPTION
This simple change applies photometric equalization using `drizzlepac.photeq` to all WFPC2 exposures during standard pipeline processing with `runastrodriz`.  