### PR TITLE
update `stregion` to include Python 3.11 build patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     'stsci.stimage',
     'stwcs>=1.5.3',
     'tweakwcs>=0.8.0',
-    'stregion',
+    'stregion>=1.1.7',
     'requests',
     'scikit-learn>=0.20',
     'bokeh',


### PR DESCRIPTION
This PR updates the `stregion` version from `1.1.6` to `1.1.7`, to include the fix for building in CPython 3.11