### PR TITLE
Updates to the SVM quality analysis to accommodate WFPC2

### DIFF
--- a/drizzlepac/haputils/diagnostic_utils.py
+++ b/drizzlepac/haputils/diagnostic_utils.py
@@ -127,6 +127,9 @@ class HapDiagnostic(object):
             header_items_to_remove.append('FILTER2')
         if self.header['INSTRUME'] == 'WFC3':
             header_items_to_remove.append('FILTER')
+        if self.header['INSTRUME'] == 'WFPC2':
+            header_items_to_remove.append('FILTNAM1')
+            header_items_to_remove.append('FILTNAM2')
 
         header_patterns_to_remove = ["D\d+VER",
                                      "D\d+GEOM",
@@ -178,7 +181,10 @@ class HapDiagnostic(object):
         self.out_dict['general information']['visit'] = extract_visit_from_header(self.header)
 
         # determine filter...
-        filter_names = ';'.join([self.header[f] for f in self.header['filter*']])
+        if self.header['INSTRUME'] == 'WFPC2':
+            filter_names = ';'.join([self.header[f] for f in self.header['filtnam*']])
+        else:
+            filter_names = ';'.join([self.header[f] for f in self.header['filter*']])
         self.out_dict['general information']['filter'] = poller_utils.determine_filter_name(filter_names)
 
         rootname = self.header['rootname'].split('_')
@@ -254,6 +260,8 @@ class HapDiagnostic(object):
                 self.filter = poller_utils.determine_filter_name("{};{}".format(self.header['FILTER1'], self.header['FILTER2']))
             elif self.header['INSTRUME'].lower() == "wfc3":
                 self.filter = poller_utils.determine_filter_name(self.header['FILTER'])
+            elif self.header['INSTRUME'].lower() == "wfpc2":
+                self.filter = poller_utils.determine_filter_name("{};{}".format(self.header['FILTNAM1'], self.header['FILTNAM2']))
             else:
                 errmsg = "Invalid instrument."
                 log.error(errmsg)
@@ -314,6 +322,8 @@ class HapDiagnostic(object):
                     "{};{}".format(self.header['FILTER1'], self.header['FILTER2']))
             elif self.header['INSTRUME'].lower() == "wfc3":
                 self.filter = poller_utils.determine_filter_name(self.header['FILTER'])
+            elif self.header['INSTRUME'].lower() == "wfpc2":
+                self.filter = poller_utils.determine_filter_name("{};{}".format(self.header['FILTNAM1'], self.header['FILTNAM2']))
             else:
                 errmsg = "Invalid instrument."
                 log.error(errmsg)

--- a/drizzlepac/haputils/graph_utils.py
+++ b/drizzlepac/haputils/graph_utils.py
@@ -261,6 +261,11 @@ class HAPFigure:
         if 'legend_label' in data_dict:
             self.legend_label = data_dict.get('legend_label')
 
+        if 'view' in data_dict:
+            self.view = data_dict.get('view')
+        else:
+            self.view = None
+
         # Dictionary of supported "shape" glyphs.  These are really references to
         # the associated method names.
         # TODO: Note that there should be some internal re-write to use scatter() instead.
@@ -287,6 +292,7 @@ class HAPFigure:
                             size=self.size,
                             color=self.color,
                             legend_group=self.legend_group,
+                            view=self.view,
                             fill_alpha=self.fill_alpha,
                             line_alpha=self.line_alpha,
                             hover_color='#2F4F4F',
@@ -298,6 +304,7 @@ class HAPFigure:
                             size=self.size,
                             color=self.color,
                             legend_label=self.legend_label,
+                            view=self.view,
                             fill_alpha=self.fill_alpha,
                             line_alpha=self.line_alpha,
                             hover_color='#2F4F4F',

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_total.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_total.json
@@ -117,4 +117,5 @@
         "driz_sep_dec": null,
         "driz_sep_crpix1": null,
         "driz_sep_crpix2": null
-    },
+    }
+}

--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -396,6 +396,7 @@ def wfpc2_to_flt(imgname):
     num_sci = fileutil.countExtn(imgname)
     det_name = 'WFPC2'
     in_sci[0].header['DETECTOR'] = det_name
+    in_sci[0].header['PRIMESI'] = det_name
 
     if is_dq:
         # Read in existing input DQ file


### PR DESCRIPTION
Modified diagnostic_utils.py module to accommodate WFPC2, in particular for its filter keywords which are FILTNAM[1|2] vs FILTER[ |1|2] for ACS and WFC3, respectively.  Addeded keyword PRIMESI to the PHDU for WFPC2 data, and fixed a typo in a configuration JSON file. Finally, made graph_utils.py a bit more flexible as the interface now accommodates a "view" request.