### PR TITLE
Fix WFPC2 config file typos

### DIFF
--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n6.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n6.json
@@ -117,4 +117,5 @@
         "driz_sep_dec": null,
         "driz_sep_crpix1": null,
         "driz_sep_crpix2": null
-    },
+    }
+}


### PR DESCRIPTION
These are simple changes to fix the syntax of a couple of WFPC2 config files based on errors reported during WFPC2 SVM testing.