### PR TITLE
Update required to compute_2d_background() in astrometric_utils.py 

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -46,16 +46,14 @@ from astropy.time import Time
 from astropy.utils.decorators import deprecated
 
 import photutils  # needed to check version
+from photutils.segmentation import (detect_sources, SourceCatalog,
+                                    deblend_sources, SegmentationImage)
 if Version(photutils.__version__) < Version('1.5.0'):
     OLD_PHOTUTILS = True
-    from photutils.segmentation import (detect_sources, SourceCatalog,
-                                        deblend_sources, make_source_mask,
-                                        SegmentationImage)
+    from photutils.segmentation import make_source_mask
 else:
     OLD_PHOTUTILS = False
-    from photutils.segmentation import (detect_sources, SourceCatalog,
-                                        deblend_sources, detect_threshold,
-                                        SegmentationImage)
+    from photutils.segmentation import detect_threshold
     from photutils.utils import circular_footprint
     from astropy.stats import SigmaClip
 
@@ -1045,12 +1043,8 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
 
         segm.remove_labels(bad_srcs)
 
-    if OLD_PHOTUTILS:
-        flux_colname = 'source_sum'
-        ferr_colname = 'source_sum_err'
-    else:
-        flux_colname = 'segment_flux'
-        ferr_colname = 'segment_fluxerr'
+    flux_colname = 'segment_flux'
+    ferr_colname = 'segment_fluxerr'
 
     # convert segm to mask for daofind
     if centering_mode == 'starfind':
@@ -1115,23 +1109,15 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                 if (detection_img > detection_img.max() * 0.9).sum() > 3:
 
                     # Revert to segmentation photometry for sat. source posns
-                    if OLD_PHOTUTILS:
-                        segment_properties = SourceCatalog(detection_img, segment.data)
-                    else:
-                        segimg = SegmentationImage(segment.data)
-                        segment_properties = SourceCatalog(detection_img, segimg)
+                    segimg = SegmentationImage(segment.data)
+                    segment_properties = SourceCatalog(detection_img, segimg)
 
                     sat_table = segment_properties.to_table()
                     seg_table['flux'][max_row] = sat_table[flux_colname][0]
                     seg_table['peak'][max_row] = sat_table['max_value'][0]
-                    if OLD_PHOTUTILS:
-                        xcentroid = sat_table['xcentroid'][0].value
-                        ycentroid = sat_table['ycentroid'][0].value
-                        sky = sat_table['background_mean'][0].value
-                    else:
-                        xcentroid = sat_table['xcentroid'][0]
-                        ycentroid = sat_table['ycentroid'][0]
-                        sky = sat_table['local_background'][0]
+                    xcentroid = sat_table['xcentroid'][0]
+                    ycentroid = sat_table['ycentroid'][0]
+                    sky = sat_table['local_background'][0]
                     seg_table['xcentroid'][max_row] = xcentroid
                     seg_table['ycentroid'][max_row] = ycentroid
                     seg_table['npix'][max_row] = sat_table['area'][0].value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ extend-exclude = [
     '.tox',
 ]
 ignore = [
+    'E401', # Multiple imports not allowed on single line
     'E402', # Module level import not at top of file
     'E501', # Line too long
     'E711', # Comparison to `None` should be `cond is None`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     'pandas',
     'spherical_geometry>=1.2.22',
     'astroquery>=0.4',
-    'photutils>1.2.0',
+    'photutils>1.5.0',
     'lxml',
     'PyPDF2',
     'scikit-image>=0.14.2',

--- a/tests/hap/test_pipeline.py
+++ b/tests/hap/test_pipeline.py
@@ -119,7 +119,7 @@ class BaseWFC3Pipeline(BasePipeline):
 class TestSingleton(BaseWFC3Pipeline):
 
     @pytest.mark.parametrize(
-        'dataset_names', ['iaaua1n4q', 'iacs01t4q']
+        'dataset_names', ['iacs01n4q']
     )
 
     def test_astrometric_singleton(self, dataset_names):

--- a/tests/hap/test_pipeline.py
+++ b/tests/hap/test_pipeline.py
@@ -119,7 +119,7 @@ class BaseWFC3Pipeline(BasePipeline):
 class TestSingleton(BaseWFC3Pipeline):
 
     @pytest.mark.parametrize(
-        'dataset_names', ['iacs01n4q']
+        'dataset_names', ['iaaua1n4q']
     )
 
     def test_astrometric_singleton(self, dataset_names):


### PR DESCRIPTION
Modified compute_2d_background to accommodate API changes in PhotUtils while keeping this source code backwards compatible.  Modified the imports used in conjunction with OLD_PHOTUTILS.

Tested the "old" and "new" versions of compute_2d_background() by calling the function explicitly within a small test harness using hst_12572_52_wfc3_ir_total_ibug52_drz.fits as the input image.  The output images and float statistics were compared.  Note the specific portion of the code modified is invoked when the bkg = None and the resultant background and background_rms images are images of a single value.  The comparison between the "old" and "new" datasets is considered fine.

NEW
bkg_median: 0.5143258571624756   bkg_rms_median: 0.2762162387371063

OLD
bkg_median: 0.521289587020874   bkg_rms_median: 0.27636751532554626