### PR TITLE
Enable user specified CRDS URL for WFPC2 processing

### DIFF
--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -19,6 +19,9 @@ from stsci.tools import fileutil, readgeis
 from .imageObject import imageObject
 from . import buildmask
 
+# Define default public CRDS server URL to use in case user does not specify one in `os.environ`
+PUBLIC_CRDS_SERVER_URL = "https://hst-crds.stsci.edu"
+
 # Translation table for any image that does not use the DQ extension of the MEF
 # for the DQ array.
 DQ_EXTNS = {'c0h': 'sdq', 'c0f': 'sci', 'c0m': 'sci'}
@@ -550,7 +553,7 @@ def apply_bestrefs(filename=None, dirname=None,
 
     # Now that we have confirmed we have images to update...
     # configure CRDS for use in updating the WFPC2 data
-    os.environ['CRDS_SERVER_URL'] = "https://hst-crds.stsci.edu"
+    os.environ['CRDS_SERVER_URL'] = orig_crds['CRDS_SERVER_URL'] if orig_crds['CRDS_SERVER_URL'] else PUBLIC_CRDS_SERVER_URL
     os.environ['CRDS_OBSERVATORY'] = "hst"
     os.environ['CRDS_PATH'] = crds_cache
     os.environ['uref'] = crds_uref_path


### PR DESCRIPTION
This changes the code to use any user-specified CRDS_SERVER_URL from os.environ when applying bestrefs to WFPC2 data.  This will support use of test CRDS servers rather than always forcing the use of the public server.   In addition, the logic has been revised to also trigger a sync of the reference files to the local cache (or not) based on the 'CRDS_READONLY_CACHE' environment variable in order to support pipeline use of that variable. 

This code allows the CRDS code to crash with a status=-1 completely crashing out of any Python environment it was running in if the CRDS reference file cache or uref is not configured correctly BY THE USER if sync is turned off.   