### PR TITLE
Fix Numpy 1.24 str deprecation

### DIFF
--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -933,7 +933,7 @@ def build_poller_table(input, log_level, all_mvm_exposures=[], poller_type='svm'
         poller_dtype = POLLER_DTYPE
 
     datasets = []
-    obs_converters = {'col4': [ascii.convert_numpy(np.str)]}
+    obs_converters = {'col4': [ascii.convert_numpy(np.str_)]}
     if isinstance(input, str):
         input_table = ascii.read(input, format='no_header', converters=obs_converters)
         if len(input_table.columns) == len(poller_colnames):
@@ -943,7 +943,7 @@ def build_poller_table(input, log_level, all_mvm_exposures=[], poller_type='svm'
                 input_table.columns[i].name = colname
 
             # Convert to a string column, instead of int64
-            input_table['obset_id'] = input_table['obset_id'].astype(np.str)
+            input_table['obset_id'] = input_table['obset_id'].astype(np.str_)
             # Convert string column into a Bool column
             # The input poller file reports True if it has been reprocessed.
             # This code interprets that as False since it is NOT new, so the code

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -271,7 +271,7 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
         # define new column with HAP expname and ensure the column
         # will accommodate a string of at least 51 characters which handles an ACS image
         max_len = max(max([len(name) for name in name_col]), 51)
-        hapcol = Column(array=np.array(name_col, dtype=np.str), name=HAPCOLNAME, format='{}A'.format(max_len))
+        hapcol = Column(array=np.array(name_col, dtype=np.str_), name=HAPCOLNAME, format='{}A'.format(max_len))
         newcol = fits.ColDefs([hapcol])
         hdrtab_cols += newcol
 


### PR DESCRIPTION
These simple changes (as suggested by Numpy 1.20 Release Notes) should fix the problems with the pytests now that Numpy 1.24 has been released since Numpy 1.24 completely removed the deprecated use of 'np.str' in favor of 'np.str_'.  