### PR TITLE
Avoid trying to delete non-existent readonly cache flag from environment

### DIFF
--- a/drizzlepac/wfpc2Data.py
+++ b/drizzlepac/wfpc2Data.py
@@ -523,12 +523,11 @@ def apply_bestrefs(filename=None, dirname=None,
     orig_crds = {'CRDS_PATH': os.environ.get('CRDS_PATH'),
                  'uref': os.environ.get('uref'),
                  'CRDS_SERVER_URL': os.environ.get('CRDS_SERVER_URL'),
-                 'CRDS_OBSERVATORY': os.environ.get('CRDS_OBSERVATORY'),
-                 'CRDS_READONLY_CACHE': os.environ.get('CRDS_READONLY_CACHE')}
+                 'CRDS_OBSERVATORY': os.environ.get('CRDS_OBSERVATORY')}
 
     # Now, define what CRDS directories will be used for this update...
     remove_local_cache = False
-    sync_refs = False if orig_crds['CRDS_READONLY_CACHE'] == '1' else True
+    sync_refs = False if os.environ.get('CRDS_READONLY_CACHE') == '1' else True
     if not orig_crds['CRDS_PATH']:
         # User has not set up any local CRDS cache, so
         # we need to define one under the current working directory


### PR DESCRIPTION
This change avoids treating the environment variable `CRDS_READONLY_CACHE` as a writable variable, since the code only needs to read it once.  Removing this from the list of variables read keeps this variable out of the list of variables that need to be restored to the original state so the code does not try to delete the non-existent variable.  