### PR TITLE
Reset crder units

### DIFF
--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -1063,6 +1063,13 @@ def generate_astrometric_catalog(imglist, **pars):
     imglist : list
         List of one or more calibrated fits images that will be used for catalog generation.
 
+    output : str, optional
+        If specified as part of input pars dict, it provides the name of the output catalog file
+
+    overwrite : bool, optional
+        If specified as part of the input pars dict, it specifies whether or not to overwrite any
+        catalog file already present with the same path/filename as specified in `output`.
+
     Returns
     =======
     ref_table : object
@@ -1075,12 +1082,15 @@ def generate_astrometric_catalog(imglist, **pars):
         pars['output'] = 'ref_cat.ecsv'
     else:
         pars['output'] = None
+
+    overwrite = pars.get('clobber', True)
+
     out_catalog = amutils.create_astrometric_catalog(imglist, **pars)
     pars = temp_pars.copy()
     # if the catalog has contents, write the catalog to ascii text file
     if len(out_catalog) > 0 and pars['output']:
         catalog_filename = "refcatalog.cat"
-        out_catalog.write(catalog_filename, format="ascii.fast_commented_header")
+        out_catalog.write(catalog_filename, format="ascii.fast_commented_header", overwrite=overwrite)
         log.info("Wrote reference catalog {}.".format(catalog_filename))
 
     return(out_catalog)

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -1320,12 +1320,16 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
         updatehdr.update_wcs(hdulist, sci_extn, item.wcs, wcsname=wcs_name, reusename=True)
         info = item.meta['fit_info']
         if info['catalog'] and info['catalog'] != '':
-            rms_ra_val = info['RMS_RA'].value if info['RMS_RA'] is not None else -1.0
-            rms_dec_val = info['RMS_DEC'].value if info['RMS_DEC'] is not None else -1.0
+            # Explicitly report the RMS values in units of mas.
+            rms_ra_val = info['RMS_RA'].mas if info['RMS_RA'] is not None else -1.0
+            rms_dec_val = info['RMS_DEC'].mas if info['RMS_DEC'] is not None else -1.0
             hdulist[sci_extn].header['RMS_RA'] = (rms_ra_val, RMS_RA_COMMENT)
             hdulist[sci_extn].header['RMS_DEC'] = (rms_dec_val, RMS_DEC_COMMENT)
-            hdulist[sci_extn].header['CRDER1'] = info['RMS_RA'].value/3600. if info['RMS_RA'] is not None else -1.0
-            hdulist[sci_extn].header['CRDER2'] = info['RMS_DEC'].value/3600. if info['RMS_DEC'] is not None else -1.0
+            # convert RMS values from units of mas to deg in order to be consistent
+            # with CUNIT keyword value, as per FITS Paper I standard.
+            # https://www.aanda.org/articles/aa/full/2002/45/aah3859/aah3859.right.html Section 2.6
+            hdulist[sci_extn].header['CRDER1'] = info['RMS_RA'].deg if info['RMS_RA'] is not None else -1.0
+            hdulist[sci_extn].header['CRDER2'] = info['RMS_DEC'].deg if info['RMS_DEC'] is not None else -1.0
             hdulist[sci_extn].header['NMATCHES'] = len(info['ref_mag']) if info['ref_mag'] is not None else 0
             hdulist[sci_extn].header['FITGEOM'] = info['fitgeom'] if info['fitgeom'] is not None else 'N/A'
         else:

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -1328,8 +1328,10 @@ def update_image_wcs_info(tweakwcs_output, headerlet_filenames=None, fit_label=N
             # convert RMS values from units of mas to deg in order to be consistent
             # with CUNIT keyword value, as per FITS Paper I standard.
             # https://www.aanda.org/articles/aa/full/2002/45/aah3859/aah3859.right.html Section 2.6
-            hdulist[sci_extn].header['CRDER1'] = info['RMS_RA'].deg if info['RMS_RA'] is not None else -1.0
-            hdulist[sci_extn].header['CRDER2'] = info['RMS_DEC'].deg if info['RMS_DEC'] is not None else -1.0
+            cr1_comment = RMS_RA_COMMENT.replace('mas', 'deg')
+            cr2_comment = RMS_DEC_COMMENT.replace('mas', 'deg')
+            hdulist[sci_extn].header['CRDER1'] = (info['RMS_RA'].deg, cr1_comment) if info['RMS_RA'] is not None else -1.0
+            hdulist[sci_extn].header['CRDER2'] = (info['RMS_DEC'].deg, cr2_comment) if info['RMS_DEC'] is not None else -1.0
             hdulist[sci_extn].header['NMATCHES'] = len(info['ref_mag']) if info['ref_mag'] is not None else 0
             hdulist[sci_extn].header['FITGEOM'] = info['fitgeom'] if info['fitgeom'] is not None else 'N/A'
         else:


### PR DESCRIPTION
These changes report the correct units for the CRDER* keywords now, using the astropy units already defined for them instead of trying to convert them manually.  Comments were also added to the keyword cards to specify the units of the term.  The units used for this keyword are now fully correct and consistent with the FITS Paper 1 standard and with the CUNIT* header keyword value.  