### PR TITLE
Avoid running runastrodriz on calibration data

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -432,51 +432,50 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     for f in _calfiles+_calfiles_flc:
         processing_utils.compute_sregion(f)
 
-    # Run updatewcs on each list of images to define pipeline default WCS
-    # based on latest distortion models
-    # Always apply latest distortion to replace pipeline-default OPUS WCS
-    # for successful creation of updated headerlets for the cases where
-    # all inputs having EXPTIME==0 (for example) or guiding is bad.
-    updatewcs.updatewcs(_calfiles, use_db=False, checkfiles=False)
-    if _calfiles_flc:
-        updatewcs.updatewcs(_calfiles_flc, use_db=False, checkfiles=False)
-
-    # Check to see whether or not guide star failure affected these observations
-    # They would show up as images all sources streaked as if taken in SCAN mode or with a GRISM
-    # 
-    # Note: This functionality is intentionally turned off for pipeline processing at this time.
-    # However, a user may wish to invoke this functionality which is controlled by the
-    # parameter "do_verify_guiding".
-    if do_verify_guiding:
-        for fltimg in _calfiles:
-            flcimg = fltimg.replace('_flt.fits', '_flc.fits')
-            guide_img = flcimg if os.path.exists(flcimg) else fltimg
-            # We want to use the FLC image, if possible, to avoid any
-            # possible detection of CTE tails as false guide-star trailing lines
-            bad_guiding = analyze.verify_guiding(guide_img)
-            if bad_guiding:
-                # If the user did not specify they wanted a drizzle product no matter what...
-                if not force:
-                    # Remove the affected image(s) from further processing
-                    # except when user specifies they want to make a product no matter what (force=True)
-                    _calfiles.remove(fltimg)
-                    if os.path.exists(flcimg):
-                        _calfiles_flc.remove(flcimg)
-                    # If ANY input exposure has bad guiding, none of the data can be
-                    # trusted.  However, only allow alignment if the user forces the alignment.
-                if not force_alignment:
-                    # Turn off any alignment to GAIA
-                    # After all, if one exposure has bad guiding,
-                    # none of the WCS information can be trusted.
-                    align_to_gaia = False
-                    align_with_apriori = False
-
     # If we no longer have any valid images to process due to guiding problems,
     # set drizcorr to OMIT and finish processing gracefully.
     if len(_calfiles) == 0:
         dcorr = 'OMIT'
 
     if dcorr == 'PERFORM':
+        # Run updatewcs on each list of images to define pipeline default WCS
+        # based on latest distortion models
+        # Always apply latest distortion to replace pipeline-default OPUS WCS
+        # for successful creation of updated headerlets for the cases where
+        # all inputs having EXPTIME==0 (for example) or guiding is bad.
+        updatewcs.updatewcs(_calfiles, use_db=False, checkfiles=False)
+        if _calfiles_flc:
+            updatewcs.updatewcs(_calfiles_flc, use_db=False, checkfiles=False)
+
+        # Check to see whether or not guide star failure affected these observations
+        # They would show up as images all sources streaked as if taken in SCAN mode or with a GRISM
+        #
+        # Note: This functionality is intentionally turned off for pipeline processing at this time.
+        # However, a user may wish to invoke this functionality which is controlled by the
+        # parameter "do_verify_guiding".
+        if do_verify_guiding:
+            for fltimg in _calfiles:
+                flcimg = fltimg.replace('_flt.fits', '_flc.fits')
+                guide_img = flcimg if os.path.exists(flcimg) else fltimg
+                # We want to use the FLC image, if possible, to avoid any
+                # possible detection of CTE tails as false guide-star trailing lines
+                bad_guiding = analyze.verify_guiding(guide_img)
+                if bad_guiding:
+                    # If the user did not specify they wanted a drizzle product no matter what...
+                    if not force:
+                        # Remove the affected image(s) from further processing
+                        # except when user specifies they want to make a product no matter what (force=True)
+                        _calfiles.remove(fltimg)
+                        if os.path.exists(flcimg):
+                            _calfiles_flc.remove(flcimg)
+                        # If ANY input exposure has bad guiding, none of the data can be
+                        # trusted.  However, only allow alignment if the user forces the alignment.
+                    if not force_alignment:
+                        # Turn off any alignment to GAIA
+                        # After all, if one exposure has bad guiding,
+                        # none of the WCS information can be trusted.
+                        align_to_gaia = False
+                        align_with_apriori = False
 
         """
         Start updating the data and verifying that the new alignment is valid.


### PR DESCRIPTION
Only observations with the DRIZCORR header keyword value set to PERFORM should have 'updatewcs.updatewcs()' run on them, as the calibration files do not provide support for calibration or engineering modes.  This change fixes the problems caused by #1443 by moving that update and subsequent analysis of guiding inside the if statement for DRIZCORR.   
These changes were confirmed using data from visit 'u23v02'.