### PR TITLE
Update to use photutils catalog wcs correctly

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2937,7 +2937,10 @@ def enforce_icrs_compatibility(catalog):
     # header keyword REFFRAME can be populated with anything specified by the user in the original
     # proposal.
     """
-    if catalog._wcs.wcs.radesys.upper() not in RADESYS_OPTIONS:
-        catalog._wcs.wcs.radesys = 'ICRS'
-        log.warning(f"Assuming input coordinates are ICRS, instead of {catalog._wcs.wcs.radesys}")
+    # We need to check whether or not the catalog was generated with photutils<1.6.0 or not
+    # since photutils=1.6.0 (apparently) renamed the 'catalog._wcs' to 'catalog.wcs'.
+    cat_wcs = catalog.wcs if hasattr(catalog, 'wcs') else catalog._wcs
+    if cat_wcs.wcs.radesys.upper() not in RADESYS_OPTIONS:
+        cat_wcs.wcs.radesys = 'ICRS'
+        log.warning(f"Assuming input coordinates are ICRS, instead of {cat_wcs.wcs.radesys}")
         log.warning(f"Sky coordinates of source objects may not be accurate.")

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -94,6 +94,7 @@ except ImportError:
 # THIRD-PARTY
 import numpy as np
 from astropy.io import fits
+import photutils
 
 import stwcs
 from stwcs import wcsutil
@@ -196,10 +197,12 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     init_time = time.time()
     trlmsg = "{}: Calibration pipeline processing of {} started.\n".format(init_time, inFile)
     trlmsg += __trlmarker__
-    trlmsg += "    drizzlepac version {}".format(drizzlepac.__version__)
-    trlmsg += "    tweakwcs version {}".format(tweakwcs.__version__)
-    trlmsg += "    stwcs version {}".format(stwcs.__version__)
-    trlmsg += "    numpy version {}".format(np.__version__)
+    trlmsg += "    drizzlepac version {}\n".format(drizzlepac.__version__)
+    trlmsg += "    tweakwcs version {}\n".format(tweakwcs.__version__)
+    trlmsg += "    stwcs version {}\n".format(stwcs.__version__)
+    trlmsg += "    numpy version {}\n".format(np.__version__)
+    trlmsg += "    photutils version {}\n".format(photutils.__version__)
+
     pipeline_pars = PIPELINE_PARS.copy()
     _verify = True  # Switch to control whether to verify alignment or not
     manifest_list = []

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -258,7 +258,7 @@ def print_pkg_versions(packages=None, git=False, svn=False, log=None):
         def output(msg):
             print(msg)
 
-    pkgs = ['numpy', 'astropy', 'stwcs']
+    pkgs = ['numpy', 'astropy', 'stwcs', 'photutils']
     if packages is not None:
         if not isinstance(packages, list):
             packages = [packages]


### PR DESCRIPTION
Photutils renamed the '_wcs' attribute for SourceCatalogs to simply 'wcs' as of photutils==1.6.0.  These changes not only look for that and use the correct attribute under 1.6.0, but also uses the old attribute name generated by 1.5.0 as well when creating the source catalogs for SVM products. 

In addition, the version of photutils being used for processing now gets reported along with the versions of numpy, stwcs and astropy since photutils is a major dependency for this package. 

These changes were tested using data from visit 'j8ep06' under photutils=1.5.0 and photutils=1.6.0.  