### PR TITLE
Handle empty images more gracefully

### DIFF
--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -617,9 +617,10 @@ def verify_guiding(filename, min_length=33):
     # Trying to ignore small sources (<= 4x4 pixels in size, or npixels < 17)
     #   which are either noise peaks or head-on CRs.
     segm = detect_sources(imgarr, 0, npixels=17)
-    log.debug(f'Detected {segm.nlabels} raw sources in {filename}')
-    if segm.nlabels < 2:
+    if segm is None or segm.nlabels < 2:
+        log.debug(f'Did NOT detect enough raw sources in {filename} for guiding verification.')
         return False
+    log.debug(f'Detected {segm.nlabels} raw sources in {filename} for guiding verification.')
 
     src_cat = SourceCatalog(imgarr, segm)
     # Remove likely cosmic-rays based on central_moments classification

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -165,6 +165,10 @@ valid_alignment_modes = ['apriori', 'aposteriori', 'default-pipeline']
 gsc240_date = '2017-10-01'
 apriori_priority = ['HSC', 'GSC', '']
 
+FILTER_NAMES = {'WFPC2': ['FILTNAM1', 'FILTNAM2'],
+                'ACS': ['FILTER1', 'FILTER2'],
+                'WFC3': ['FILTER']}
+
 
 # default marker for trailer files
 __trlmarker__ = '*** astrodrizzle Processing Version ' + __version__ + '***\n'
@@ -256,7 +260,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             print("ERROR: Input file - %s - does not exist." % inFilename)
             return
     except TypeError:
-        print("ERROR: Inappropriate input file.")
+        print("ERROR: Appropriate input file could not be found.")
         return
 
     # If newpath was specified, move all files to that directory for processing
@@ -2043,11 +2047,20 @@ def _analyze_exposure(filename):
 
     fhdu = fits.getheader(filename)
     targname = fhdu['targname']
+    filts = fhdu['filt*']
+    instrument = fhdu['instrume']
+
+    filters = [filts[filtname].strip() for filtname in FILTER_NAMES[instrument]]
 
     if any(x in targname for x in ['DARK', 'TUNG', 'BIAS', 'FLAT', 'DEUT', 'EARTH-CAL']):
+        print(f"ERROR: Inappropriate target with name {targname}")
+        process_exposure = False
+    if all(filter == '' for filter in filters):
+        print(f"ERROR: Inappropriate filter for exposure of {filters}")
         process_exposure = False
 
     return process_exposure
+
 
 # Functions to support execution from the shell.
 def main():


### PR DESCRIPTION
A couple of issues with empty images can still cause runastrodriz to crash.  

The first affects exposures where both filter names are empty (not listed as "BLANK") as found for '**u23v020nt**'.  The exposure was not able to get the full readout from the telescope resulting in an incomplete exposure with missing header information.  This causes `updatewcs.updatewcs()` to throw an Exception for an unsupported filter name. 

The second issue results from an empty image not returning any identified source segments when trying to verify whether or not the guiding was correct in `verify_guiding()` as triggered for data from visit '**u23105**'.  This resulted in an Exception reporting problems with " **'NoneType' object has not attribute 'nlabels'** ".  

These datasets were used to confirm the problem as well as the fact that these changes fix both problems.  