### PR TITLE
Let photeq fail without crashing pipeline

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -288,7 +288,11 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             # files from CRDS
             print(f"Updating distortion reference files for: {inFilename}")
             wfpc2Data.apply_bestrefs(inFilename)
-            photeq.photeq(files=inFilename, ref_phot_ext=3, readonly=False)
+            try:
+                photeq.photeq(files=inFilename, ref_phot_ext=3, readonly=False)
+            except Exception as err:
+                print(err)
+                print(f"WARNING: PHOTEQ was unable to run on {inFilename}")
 
             raw_suffix = '_d0m.fits'
             goodpix_name = 'GPIXELS'


### PR DESCRIPTION
Some WFPC2 exposures do not have their photometry properly calibrated causing the `photeq.photeq()` function to fail due to `PHOTFLAM` having a reported value of 0.0.  An example of such an exposure would be `u2l90105t` which uses an unusual polarizer filter, whereas other exposures in the visit using other filters process successfully.  These changes simply  trap the Exception from `photeq`, report the error in the log, then proceeds to process the image.   This should only affect the photometry of exposures taken with unsupported modes and will not affect the alignment or subsequent HAP processing of the data.  