### PR TITLE
Insure source columns are not masked

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1111,7 +1111,9 @@ class HAPPointCatalog(HAPCatalogBase):
 
             log.info("Measured {} sources in {}".format(len(sources), self.image.imgname))
             log.info("   colnames: {}".format(sources.colnames))
-
+            # insure centroid columns are not masked
+            sources['xcentroid'] = Column(sources['xcentroid'])
+            sources['ycentroid'] = Column(sources['ycentroid'])
             # calculate and add RA and DEC columns to table
             ra, dec = self.transform_list_xy_to_ra_dec(sources["xcentroid"], sources["ycentroid"], self.imgname)
             ra_col = Column(name="RA", data=ra, dtype=np.float64)


### PR DESCRIPTION
Source position columns in the source catalogs come back as MaskedColumns, yet the masking can actually cause problems in some cases when the '_mask' attribute goes missing during processing.  Since we never use the mask attributes for any of our processing, we can avoid these problems by simply insuring that the source catalog never contains a MaskedColumn.  These changes convert all point source catalog columns to simple unmasked columns.  

The data from visit `idw101` originally had problems since some of the images were empty causing those catalogs to be MaskedColumns unnecessarily.  These changes were tested against that data to confirm that this allows that data to complete SVM processing.