### PR TITLE
Revise what HLET files get added to manifest file

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -765,7 +765,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 try:
                     wcsname = fits.getval(fname, 'wcsname', ext=1)
                     wcstype = updatehdr.interpret_wcsname_type(wcsname)
-                    hdrname = "{}_{}-hlet.fits".format(fname.replace('.fits', ''), wcsname)
+                    hdrname = "{}_{}_hlet.fits".format(fname.replace('.fits', ''), wcsname)
                     headerlet.write_headerlet(fname, hdrname, output='flt',
                                               wcskey='PRIMARY',
                                               author="OPUS",
@@ -778,10 +778,26 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 except ValueError:
                     hlet_msg += _timestamp("SKIPPED: Headerlet not created for %s \n" % fname)
                     # update trailer file to log creation of headerlet files
+
         hlet_msg += _timestamp("Writing Headerlets completed")
         ftrl = open(_trlfile, 'a')
         ftrl.write(hlet_msg)
         ftrl.close()
+
+    # Keep track of headerlet files written out to disk.
+    # Those headerlets would have been written out by 'updatewcs.updatewcs()'
+    # using a SHA256 hash for the WCSNAME portion of the headerlet filename.
+    # The headerlets written out with that naming convention are the only ones
+    # which need to be added to the manifest, since they represent the only WCS
+    # solutions which are new for the exposure and, thus, the ones which need to
+    # be saved in the astrometry database during pipeline processing.
+    for fname in _calfiles:
+        # Look for HLET files new to astrometry database written out by STWCS
+        updatewcs_hdrlets = sorted(glob.glob(f'{fname.replace(".fits", "")}_??????_hlet.fits'))
+        manifest_list.extend(updatewcs_hdrlets)
+        # Look for HLET representing the WCS used in the updated FLT/FLC file.
+        final_hdrlet = glob.glob(f'{fname.replace(".fits", "")}_hlet.fits')
+        manifest_list.extend(final_hdrlet)
 
     # add trailer file to list of output products
     manifest_list.append(_trlfile)


### PR DESCRIPTION
Some headerlet files get written out by STWCS when they represent WCS solutions which are not present in the astrometry database, yet the filenames for those headerlets do not get passed along to the standard pipeline processing code `runastrodriz` to be included in the manifest file.  These changes look for those files and adds them to the manifest file along with the name of the headerlet file that was written out to represent the final WCS applied to the FLT/FLC file.  

These changes were tested against exposures from visit `u2l901` and resulted in 3 headerlet files being added to the manifest file that were not there before.  