### PR TITLE
Skip processing GSFAIL WFPC2 exposures

### DIFF
--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -573,7 +573,7 @@ def verify_guiding(filename, min_length=33):
     gs_quality = hdu[0].header.get('quality', default="").lower()
     if 'gsfail' in gs_quality or 'tdf-down' in gs_quality:
         hdu.close()
-        log.warning(f"Image {filename}'s GUIDING detected as: BAD.")
+        log.warning(f"Image {filename}'s QUALITY keywords report GUIDING: BAD.")
         return True  # Yes, there was bad guiding...
 
     # No guide star problems indicated in header, so let's check the

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -2066,6 +2066,7 @@ def handle_remove_readonly(func, path, exc):
     else:
         raise
 
+
 def _analyze_exposure(filename):
     """Evaluate whether or not this exposure should be processed at all."""
 
@@ -2078,9 +2079,20 @@ def _analyze_exposure(filename):
 
     filters = [filts[filtname].strip() for filtname in FILTER_NAMES[instrument]]
 
-    if any(x in targname for x in ['DARK', 'TUNG', 'BIAS', 'FLAT', 'DEUT', 'EARTH-CAL']):
-        print(f"ERROR: Inappropriate target with name {targname}")
+    # Let's start by checking whether the header indicates any problems with
+    # the guide stars or tracking.
+    # Using .get() insures that this check gets done even if keyword is missing.
+    gs_quality = fhdu.get('quality', default="")
+    if 'gsfail' in gs_quality.lower() or 'tdf-down' in gs_quality.lower():
+        print(f"ERROR: Image {filename}'s QUALITY keywords: '{gs_quality}'")
+        print("        GUIDING == BAD.  Skipping processing ")
+        process_exposure = False  # Yes, there was bad guiding...
+
+    badtab = analyze.analyze_data([filename])
+    if badtab['doProcess'][0] == 0:
         process_exposure = False
+
+    # Also check to see whether this observation was taken with a blank filter name.
     if all(filter == '' for filter in filters):
         print(f"ERROR: Inappropriate filter for exposure of {filters}")
         process_exposure = False


### PR DESCRIPTION
The logic used for checking whether WFPC2 observations should be processed took place after already starting to perform DRIZCORR processing.  This removed exposures from the list of inputs leaving no exposures to process, yet the next step was to get the exposures times which failed.  These changes update the logic for checking what exposures to process to not only fully reuse code from `haputils.analyze`, but also includes the check for GSFAIL as well, all before DRIZCORR processing starts.  

In addition, the message in `haputils.analyze.verify_guiding()` reporting on GSFAIL has been clarified so that the fact that the QUALITY keywords triggered the image to be flagged as 'BAD' gets properly reported in the output processing log (trailer file). 
 
The problem was originally identified in data from visit `ubaf06`, and these changes now cleanly skip those affected observations instead of throwing an Exception.  