### PR TITLE
Fix default HLET filename

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -765,7 +765,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 try:
                     wcsname = fits.getval(fname, 'wcsname', ext=1)
                     wcstype = updatehdr.interpret_wcsname_type(wcsname)
-                    hdrname = "{}_{}_hlet.fits".format(fname.replace('.fits', ''), wcsname)
+                    hdrname = "{}_hlet.fits".format(fname.replace('.fits', ''))
                     headerlet.write_headerlet(fname, hdrname, output='flt',
                                               wcskey='PRIMARY',
                                               author="OPUS",
@@ -2065,6 +2065,7 @@ def handle_remove_readonly(func, path, exc):
         func(path)
     else:
         raise
+
 
 def _analyze_exposure(filename):
     """Evaluate whether or not this exposure should be processed at all."""


### PR DESCRIPTION
The filename used to write out the HLET file for the WCS solution used for the final runastrodriz product had been adding the WCSNAME to the filename without using the hash-tag when it should simply have been named using '_flt_hlet.fits'.  This corrects that mistake so that the simpler name gets used consistent with what gets written out to the manifest file.  

This change was tested using data from visit `u2311s`.