### PR TITLE
Find neighbor pcells

### DIFF
--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -34,7 +34,7 @@ if util.can_parallel:
 __all__ = ['drizzle', 'run', 'drizSeparate', 'drizFinal', 'mergeDQarray',
            'updateInputDQArray', 'buildDrizParamDict', 'interpret_maskval',
            'run_driz', 'run_driz_img', 'run_driz_chip', 'do_driz',
-           'get_data', 'create_output', 'help', 'getHelpAsString']
+           'get_data', 'create_output']
 
 
 __taskname__ = "adrizzle"
@@ -921,7 +921,8 @@ def run_driz_chip(img, chip, output_wcs, outwcs, template, paramDict, single,
             del pimg
             log.info('Writing out mask file: %s' % _outmaskname)
 
-    time_pre = time.time() - epoch; epoch = time.time()
+    time_pre = time.time() - epoch
+    epoch = time.time()
     # New interface to performing the drizzle operation on a single chip/image
     _vers = do_driz(_insci, chip.wcs, _inwht, outwcs, _outsci, _outwht, _outctx,
                 _expin, _in_units, chip._wtscl,
@@ -929,7 +930,8 @@ def run_driz_chip(img, chip, output_wcs, outwcs, template, paramDict, single,
                 pixfrac=paramDict['pixfrac'], kernel=paramDict['kernel'],
                 fillval=paramDict['fillval'], stepsize=paramDict['stepsize'],
                 wcsmap=wcsmap)
-    time_driz = time.time() - epoch; epoch = time.time()
+    time_driz = time.time() - epoch
+    epoch = time.time()
 
     # Set up information for generating output FITS image
     # ### Check to see what names need to be included here for use in _hdrlist
@@ -949,7 +951,8 @@ def run_driz_chip(img, chip, output_wcs, outwcs, template, paramDict, single,
     outputvals['wt_scl_val'] = chip._wtscl
 
     _hdrlist.append(outputvals)
-    time_post = time.time() - epoch; epoch = time.time()
+    time_post = time.time() - epoch
+    epoch = time.time()
 
     if doWrite:
         ###########################
@@ -1003,7 +1006,7 @@ def run_driz_chip(img, chip, output_wcs, outwcs, template, paramDict, single,
             img.saveVirtualOutputs(outimgs)
 
     # this is after the doWrite
-    time_write = time.time() - epoch; epoch = time.time()
+    time_write = time.time() - epoch
     if False and not single:  # turn off all this perf reporting for now
         time_pre_all.append(time_pre)
         time_driz_all.append(time_driz)
@@ -1132,10 +1135,12 @@ def get_data(filename):
         data = None
     return data
 
-def create_output(filename):
+
+def create_output(filename, arr):
     fileroot, extn = fileutil.parseFilename(filename)
     extname = fileutil.parseExtn(extn)
-    if extname[0] == '': extname = "PRIMARY"
+    if extname[0] == '':
+        extname = "PRIMARY"
 
     if not os.path.exists(fileroot):
         # We need to create the new file

--- a/drizzlepac/findobj.py
+++ b/drizzlepac/findobj.py
@@ -357,13 +357,13 @@ def precompute_sharp_round(nxk, nyk, xc, yc):
     """
 
     # Create arrays for the two- and four-fold symmetry computations:
-    s4m = np.ones((nyk,nxk),dtype=np.int16)
+    s4m = np.ones((nyk, nxk), dtype=np.int16)
     s4m[yc, xc] = 0
 
-    s2m = np.ones((nyk,nxk),dtype=np.int16)
+    s2m = np.ones((nyk, nxk), dtype=np.int16)
     s2m[yc, xc] = 0
-    s2m[yc:nyk, 0:xc]     = -1;
-    s2m[0:yc+1, xc+1:nxk] = -1;
+    s2m[yc:nyk, 0:xc] = -1
+    s2m[0:yc+1, xc+1:nxk] = -1
 
     return s2m, s4m
 

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -599,7 +599,7 @@ class SkyFootprint(object):
             if member not in self.exp_masks:
                 raise ValueError("Member {} not added to footprint".format(member))
             ordered_xy = [self.exp_masks[member]['xy_corners']]
-            sky_corners = [self.meta_wcs.all_pix2world(xy_corners, 0)]
+            sky_corners = [self.meta_wcs.all_pix2world(ordered_xy, 0)]
 
         self.edge_pixels = ordered_edges
         self.xy_corners = ordered_xy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ ignore = [
     'E401', # Multiple imports not allowed on single line
     'E402', # Module level import not at top of file
     'E501', # Line too long
+    'E701', # Multiple-statements on one line (colon) NEEDS TO BE FIXED
     'E711', # Comparison to `None` should be `cond is None`
     'E712', # Comparison to `True` should be `cond is True`
     'E713', # Test for membership should be `not in`


### PR DESCRIPTION
The logic for identifying what ProjectionCells (pcells) overlap a set of input exposures ended up only identifying the pcell that had the exposures closest to the center in the X direction (along the ring, or declination band of pcells).  These changes revise that logic to look in the central pcell as well as the ones on either side (-1 and +1).  This logic of looking on either side gets applied to finding the pcell in each overlapping declination band, looking in a total of 6 (or 9?) pcells for any overlap with the input exposures.  Doing so allows SkyCells near the edges of the pcells (with X=1,2, 20 or 21) to be identified as output products as well.

These changes were tested to identify overlap with missing X=2 SkyCells for data from visits `idlx09`, `j8fncm`, and `jd5h17`.  