### PR TITLE
Fix another typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = """
     to remove cosmic rays, and
     generally to improve the fidelity of data in the final image.
     """
-readme = { file = 'README.md', content-type = 'test/x-rst' }
+readme = { file = 'README.md', content-type = 'text/x-rst' }
 requires-python = '>=3.8'
 license = { file = "LICENSE.txt" }
 authors = [{ name = 'Megan Sosey' }, { name = 'Warren Hack' }, { name = 'Christopher Hanley' }, { name = 'Chris Sontag' }, { name = 'Mihai Cara' }]


### PR DESCRIPTION
Fix test/x-rst ==> text/x-rst.