### PR TITLE
Turn off Pytest XML output

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -26,7 +26,7 @@ bc1.conda_packages = ['python=3.8']
 bc1.build_cmds = ["pip install numpy astropy codecov pytest-cov",
 		 "pip install --upgrade -e '.[test]'",
                  "pip freeze"]
-bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml results.xml --bigdata",
+bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --bigdata",
                 "codecov"]
 bc1.test_configs = [data_config]
 
@@ -44,7 +44,7 @@ bc3.conda_packages = ['python=3.10']
 bc3.build_cmds = ["pip install numpy astropy codecov pytest-cov",
 		 "pip install -r requirements-dev.txt --upgrade -e '.[test]'",
                  "pip freeze"]
-bc3.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml results.xml --bigdata",
+bc3.test_cmds = ["pytest --cov=./ --basetemp=tests_output --bigdata",
                 "codecov"]
 bc3.test_configs = [data_config]
 


### PR DESCRIPTION
This change turns off generation of the XML output from pytest to see whether the regression tests will complete successfully. 