### PR TITLE
Delete WFPC2 CAL FLT files

### DIFF
--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -70,6 +70,10 @@ DEFAULT_KEYS = {'OBSKEY': 'OBSTYPE', 'MTKEY':' MTFLAG', 'SCNKEY': 'SCAN_TYP',
                 'TYPEKEY': 'IMAGETYP'}
 HEADER_KEYS = {'WFPC2': WFPC2_KEYS, 'DEFAULT':DEFAULT_KEYS}
 
+CAL_TARGETS = {'WFPC2': ['INTFLAT', 'UVFLAT', 'VISFLAT', 'KSPOTS',
+                         'DARK', 'BIAS', 'EARTH-CALIB'],
+               'DEFAULT': ['DARK', 'TUNG', 'BIAS', 'FLAT', 'DEUT', 'EARTH-CAL']
+               }
 
 # These definitions are for ACS and WFC3
 BAD_DQ_FLAGS = [256,  # full-well saturated pixel
@@ -439,13 +443,13 @@ def analyze_data(input_file_list, log_level=logutil.logging.DEBUG, type=""):
             no_proc_value = scan_typ
 
         # Calibration target
-        elif any(x in targname for x in ['DARK', 'TUNG', 'BIAS', 'FLAT', 'DEUT', 'EARTH-CAL'])\
+        elif any(x in targname for x in CAL_TARGETS['DEFAULT'])\
                 and instrume != 'WFPC2':
             no_proc_key = hdr_keys['TARKEY']
             no_proc_value = targname
 
         # WFPC2 sets the imagetyp keyword correctly(?) as something other than EXT for cal observations
-        elif any(x in targname for x in ['DARK', 'TUNG', 'BIAS', 'FLAT', 'DEUT', 'EARTH-CAL'])\
+        elif any(x in targname for x in CAL_TARGETS['WFPC2'])\
                 and instrume == 'WFPC2' and imagetype != 'EXT':
             no_proc_key = hdr_keys['TARKEY']
             no_proc_value = targname

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -308,9 +308,10 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             raw_suffix = '_d0m.fits'
             goodpix_name = 'GPIXELS'
         else:
-            print("ERROR: Inappropriate input file.")
+            # Remove FLT file created here, since the calibration file can NOT be aligned or drizzled
+            os.remove(inFilename)
+            print("ERROR: Inappropriate input file.  Deleting converted WFPC2 FLT file.")
             return
-
 
     infile_det = fits.getval(inFilename, 'detector')
     cal_ext = None
@@ -983,6 +984,7 @@ def run_driz(inlist, trlfile, calfiles, mode='default-pipeline', verify_alignmen
             [os.remove(file) for file in glob.glob(ftype)]
 
     return drz_products, focus_dicts, diff_dicts
+
 
 def reset_mdriztab_nocr(pipeline_pars, good_bits, skysub):
     # Need to turn off MDRIZTAB if any other parameters are to be set


### PR DESCRIPTION
These changes look for and remove any WFPC2 calibration exposures that can not be aligned or processed during standard pipeline alignment and drizzling.  This required updating the list of recognized calibration target names for WFPC2 and using that to identify those exposures to be skipped and deleted after converting the D0M images into FLT images.

The data from WFPC2 visit 'u2311s' include KSPOT and DARK exposures as well as 2 SCI exposures, and was used to confirm that these changes work as expected.  