### PR TITLE
Revise Jenkins tests to pass

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -26,7 +26,7 @@ bc1.conda_packages = ['python=3.8']
 bc1.build_cmds = ["pip install numpy astropy codecov pytest-cov",
 		 "pip install --upgrade -e '.[test]'",
                  "pip freeze"]
-bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --bigdata",
+bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml results.xml --bigdata",
                 "codecov"]
 bc1.test_configs = [data_config]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ norecursedirs = [
     'doc/build',
     'doc/exts'
 ]
-junit_family = 'xunit2'
+junit_family = 'legacy'
 inputs_root = 'drizzlepac'
 results_root = 'drizzlepac-results'
 


### PR DESCRIPTION
These changes are intended to make the configuration of the CI testing more consistent with other packages while also passing all  steps implemented for testing.  