### PR TITLE
Add doc build dependency for install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
     'sphinx',
     'stsci_rtd_theme',
     'packaging',
+    'tomli',
 ]
 test = [
     'ci_watson',


### PR DESCRIPTION
This change simply adds the 'tomli' package as a dependency that needs to be installed when building the docs, since it is called by 'conf.py' when building the RTD pages.