### PR TITLE
Try to set readthedocs to use an editable pip install

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,3 +24,4 @@ python:
       path: .
       extra_requirements:
         - docs
+        - -e


### PR DESCRIPTION
Need a PR just to try to debug the RTD build with this one trying to force it to use an editable install so that the C extension gets installed for use by the RTD build process.