### PR TITLE
Backout incorrect update to RTD build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,4 +24,3 @@ python:
       path: .
       extra_requirements:
         - docs
-        - -e


### PR DESCRIPTION
This backs out the incorrect update to the RTD build configuration.