### PR TITLE
Adjust RTD build paths

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,15 +36,14 @@ def setup(app):
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../'))
-sys.path.insert(0, os.path.abspath('../../'))
+# sys.path.insert(0, os.path.abspath('../'))
+# sys.path.insert(0, os.path.abspath('../../'))
 sys.path.insert(0, os.path.abspath('../../.eggs'))
 sys.path.insert(0, os.path.abspath('../../src/'))
 
 # sys.path.insert(0, os.path.abspath('../'))
 # sys.path.insert(0, os.path.abspath('packagename/'))
 # sys.path.insert(0, os.path.abspath('exts/'))
-
 
 # If your documentation needs a minimal Sphinx version, state it here.
 needs_sphinx = '1.3'


### PR DESCRIPTION
Another attempt to modify the RTD configuration to once again work.  This time by not adding the repo directory to the sys.path, since pip install will only install to the site-packages dir now.  