### PR TITLE
Add numpydoc as RTD build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ docs = [
     'stsci_rtd_theme',
     'packaging',
     'tomli',
+    'numpydoc',
 ]
 test = [
     'ci_watson',


### PR DESCRIPTION
This adds the `numpydoc` package as a dependency to the installation for use with building the sphinx (RTD) documentation.