### PR TITLE
Remove the last RTD warnings for v3.5.1

### DIFF
--- a/doc/source/catalog_generation.rst
+++ b/doc/source/catalog_generation.rst
@@ -380,7 +380,7 @@ these values. Specific flag values are defined below in table 2:
     scientifically dubious are filtered out and not written to the final source catalogs. For all detectors, sources
     with a flag value greater than 5 are filtered out. Users can adjust this value using a custom input parameter file
     and changing the "flag_trim_value" parameter. For more details on how to create a custom parameter file, please
-    refer to the `~drizzlepac.haputils.generate_custom_svm_param_file` documentation page.
+    refer to the `~drizzlepac.haputils.generate_custom_svm_mvm_param_file` documentation page.
 
 2.4.2.1: Assignment of Flag Values 0 (Point Source), 1 (Extended Source), and 16 (Hot Pixels)
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,6 +74,9 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.org/', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
+    'tweakwcs': ('https://tweakwcs.readthedocs.io/en/latest/', None),
+    'stsci.skypac': ('https://stsci-skypac.readthedocs.io/en/latest/', None),
+    'stwcs': ('https://stwcs.readthedocs.io/en/latest/', None),
 }
 
 if sys.version_info[0] == 2:
@@ -180,9 +183,6 @@ exclude_patterns = ['_build']
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 default_role = 'obj'
-
-
-
 
 # Don't show summaries of the members in each class along with the
 # class' docstring

--- a/doc/source/multivisit_api.rst
+++ b/doc/source/multivisit_api.rst
@@ -31,6 +31,8 @@ Module for defining ProjectionCells and SkyCells for a set of exposures.
 .. autoclass:: drizzlepac.haputils.cell_utils.SkyCell
 
 
+.. _make_poller_files:
+
 haputils.make_poller_files
 ---------------------------
 Module for creating CSV-formatted input 'poller' files for MVM processing.
@@ -38,24 +40,29 @@ Module for creating CSV-formatted input 'poller' files for MVM processing.
 .. automodule:: drizzlepac.haputils.make_poller_files
 .. autofunction:: drizzlepac.haputils.make_poller_files.generate_poller_file
 
+
 haputils.poller_utils
 ---------------------
 Module for interpreting input 'poller' files for MVM processing.
 
-.. automodule:: drizzlepac.haputils.poller_utils
 .. autofunction:: drizzlepac.haputils.poller_utils.interpret_mvm_input
-.. autofunction:: drizzlepac.haputils.poller_utils.build_poller_table
 
 
 haputils.product
 -----------------
 Module for defining classes for MVM processing.
 
-.. automodule:: drizzlepac.haputils.product
-.. autofunction:: drizzlepac.haputils.product.HAPProduct
-.. autofunction:: drizzlepac.haputils.product.FilterProduct
 .. autofunction:: drizzlepac.haputils.product.SkyCellExposure
 .. autofunction:: drizzlepac.haputils.product.SkyCellProduct
 
+
+.. _generate_custom_svm_mvm_param_file:
+
+haputils.generate_custom_svm_mvm_param_file
+---------------------------------------------
+Module for defining custom sets of parameters for SVM and MVM processing.
+
+.. automodule:: drizzlepac.haputils.generate_custom_svm_mvm_param_file
+.. autofunction:: drizzlepac.haputils.generate_custom_svm_mvm_param_file.make_svm_input_file
 
 

--- a/doc/source/nicmosobjects.rst
+++ b/doc/source/nicmosobjects.rst
@@ -29,3 +29,7 @@ NICMOS ImageObjects
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. autoclass:: darkobject
+   :members:
+   :undoc-members:

--- a/doc/source/runastrodriz.rst
+++ b/doc/source/runastrodriz.rst
@@ -78,7 +78,7 @@ the input exposures taking into account the best available distortion model
 for the input exposures.  Being able to compare the combined image to other exposures
 taken of the same field at other times, or even with other telescopes, requires
 that the WCS be defined to come as close to the GAIA frame as possible.  The
-processing done by `~drizzlepac.runastrodriz` attempts to not only apply the most current
+processing done by ``drizzlepac.runastrodriz`` attempts to not only apply the most current
 distortion model, but also the best available pre-computed GAIA-based WCS
 solutions while proceeding to determine it's own solution to the available GAIA
 reference stars for the field-of-view.  It also performs numerous checks to see
@@ -94,7 +94,7 @@ drizzle products for the set of exposures being processed.
 
 Overview
 --------
-The overall logic implemented by `~drizzlepac.runastrodriz` to generate the final set of
+The overall logic implemented by ``drizzlepac.runastrodriz`` to generate the final set of
 drizzle products involves creating multiple sets of drizzle products and ultimately
 selecting one as the 'best'.  The basic steps are outlined here, with following
 sections providing additional detail on each step.
@@ -167,7 +167,7 @@ By default, all the processing steps are turned **on** during pipeline processin
 
 Input Data
 ^^^^^^^^^^^
-The processing code needs to be told what data to process, and for `~drizzlepac.runastrodriz`, a single input filename is all that **can** be provided.  This single input will be either:
+The processing code needs to be told what data to process, and for ``drizzlepac.runastrodriz``, a single input filename is all that **can** be provided.  This single input will be either:
 
   * the name of an association table for a whole set of input exposures with a filename that looks like **'<rootname>_asn.fits'**, where <rootname> is the designation for the association, such as *'ie6d07030_asn.fits'*.
   * the name of a single (uncalibrated) exposure with a filename that looks like **'<rootname>_raw.fits'**.
@@ -219,7 +219,9 @@ for the distortion model to the WCS.  This operation gets performed using the
 
 where ``calfiles_flc`` is the list of CTE-corrected FLC files or in the case there are
 no CTE-corrected files, the list of calibrated FLT files.  Crucially, the use
-of ``use_db=False`` forces ``updatewcs()`` from `~stwcs.updatewcs` to only apply the distortion model to the
+of ``use_db=False`` forces ``updatewcs()`` from
+`stwcs.updatewcs <https://stwcs.readthedocs.io/en/latest/updatewcs.html>`_
+to only apply the distortion model to the
 default WCS to create what is referred to as the **pipeline-default WCS**.  This
 WCS has a ``WCSNAME`` associated with it that has the format ``IDC_<rootname>`` where
 ``<rootname>`` is the rootname of the ``IDCTAB`` reference files applied to the WCS.
@@ -433,7 +435,13 @@ based on the ``IDCTAB`` reference file in use when the database was first establ
 If the ``IDCTAB`` specified in
 the image is not found in any of the WCSs in the database, the *a priori* WCS based on that ``IDCTAB`` get
 determined by the ``stwcs.updatewcs.updatewcs()``. It starts by querying the guide-star web
-interface to retrieve the corrections from the original guide star coordinates using the `stwcs.updatewcs.astrometry_utils.find_gsc_offset function <https://stwcs.readthedocs.io/en/latest/astrometry_utils.html>`_.  These offsets can also evolve as new GAIA catalogs are released to provide more accurate coordinates for the guide stars.  These offsets are then used to correct the reference point of the pipeline-default WCS based on the new ``IDCTAB`` using the ``apply_new_apriori`` method in the `AstrometryDB class <https://stwcs.readthedocs.io/en/latest/astrometry_utils.html#stwcs.updatewcs.astrometry_utils.AstrometryDB.apply_new_apriori>`_.
+interface to retrieve the corrections from the original guide star coordinates using the
+`stwcs.updatewcs.astrometry_utils.find_gsc_offset function <https://stwcs.readthedocs.io/en/latest/astrometry_utils.html>`_.
+These offsets can also evolve as new GAIA catalogs are released to provide more accurate coordinates for the guide
+stars.  These offsets are then used to correct the reference point of the pipeline-default WCS based on the new
+``IDCTAB`` using the ``apply_new_apriori`` method in the
+`AstrometryDB class
+<https://stwcs.readthedocs.io/en/latest/astrometry_utils.html#stwcs.updatewcs.astrometry_utils.AstrometryDB.apply_new_apriori>`_.
 This method uses the same lines of code used to populate the astrometry database with the original set
 of *a priori* WCS solutions. This not only insures that there is
 always a GAIA-based WCS available for all exposures, but it does it using the best available information.
@@ -619,8 +627,11 @@ an attempt to perform an *a posteriori* fit to GAIA:
     * Compute a 2D background for all the observations using ``photutils``
     * Determine a PSF kernel from the detectable sources in the image, if possible.
     * Segments the image after applying the 2D background to identify as many
-      sources as possible above a threshold using `~photutils.segmentation`
-    * Performs source centering using `~photutils.detection.DAOStarFinder`
+      sources as possible above a threshold using
+      `photutils.segmentation <https://photutils.readthedocs.io/en/stable/segmentation.html>`_
+    * Performs source centering using
+      `photutils.detection.DAOStarFinder
+      <https://photutils.readthedocs.io/en/stable/api/photutils.detection.DAOStarFinder.html>`_
     * Keeps the position of the single brightest source nearest the center of
       the segment as the catalog position for each segment's object.
     * Checks whether there are enough sources to potentially get a viable linear
@@ -656,7 +667,8 @@ an attempt to perform an *a posteriori* fit to GAIA:
 
     * Evaluate the success/failure state of the fit and the quality of any
       successful fit.
-    * Repeat the fit with :py:func:`~drizzlepac.tweakwcs.imalign.align_wcs` with other GAIA catalogs;
+    * Repeat the fit with `~tweakwcs.imalign.align_wcs`
+      with other GAIA catalogs;
       including GAIA DR1 or any others specified for use in ``runastrodriz`` itself.
     * Select the fit to the GAIA catalog which results in the lowest RMS.
 

--- a/doc/source/runmultihap.rst
+++ b/doc/source/runmultihap.rst
@@ -20,15 +20,6 @@ Associated Helper Code
 ======================
 These modules and functions assist with some of the logistics associated with multi-visit processing.
 
-
-.. _make_poller_files:
-
-drizzlepac.haputils.make_poller_files
--------------------------------------
-.. automodule:: drizzlepac.haputils.make_poller_files
-.. autofunction:: drizzlepac.haputils.make_poller_files.generate_poller_file
-
-
 .. _which_skycell:
 
 drizzlepac.haputils.which_skycell

--- a/doc/source/runsinglehap.rst
+++ b/doc/source/runsinglehap.rst
@@ -15,17 +15,14 @@ from a single-visit into a uniform set of images.
 
 .. automodule:: drizzlepac.hapsequencer
 .. autofunction:: drizzlepac.hapsequencer.run_hap_processing
+.. autofunction:: drizzlepac.hapsequencer.create_catalog_products
+.. autofunction:: drizzlepac.hapsequencer.create_drizzle_products
 
 
 Supporting code
 ===============
 These modules and functions provide the core functionality for the single-visit
 processing.
-
-.. automodule:: drizzlepac.hapsequencer
-.. autofunction:: drizzlepac.hapsequencer.create_catalog_products
-.. autofunction:: drizzlepac.hapsequencer.create_drizzle_products
-
 
 .. _product_api:
 
@@ -73,6 +70,10 @@ drizzlepac.haputils.photometry_tools
 .. autofunction:: drizzlepac.haputils.photometry_tools.convert_flux_to_abmag
 
 
+Associated Helper Code
+======================
+These modules and functions assist with some of the logistics associated with single-visit processing.
+
 
 .. _processing_utils_api:
 
@@ -83,20 +84,5 @@ drizzlepac.haputils.processing_utils
 .. autofunction:: drizzlepac.haputils.processing_utils.compute_sregion
 
 
-Associated Helper Code
-======================
-These modules and functions assist with some of the logistics associated with single-visit processing.
 
-.. _generate_custom_svm_mvm_param_file:
 
-drizzlepac.haputils.generate_custom_svm_mvm_param_file
--------------------------------------------------------
-.. automodule:: drizzlepac.haputils.generate_custom_svm_mvm_param_file
-.. autofunction:: drizzlepac.haputils.generate_custom_svm_mvm_param_file.make_svm_input_file
-
-.. _make_poller_files:
-
-drizzlepac.haputils.make_poller_files
--------------------------------------
-.. automodule:: drizzlepac.haputils.make_poller_files
-.. autofunction:: drizzlepac.haputils.make_poller_files.generate_poller_file

--- a/doc/source/singlevisit.rst
+++ b/doc/source/singlevisit.rst
@@ -395,7 +395,7 @@ would result in the definition of these output products:
   * a point-source catalog for the total product
   * a segmentation-based catalog for the total product
 
-The function ``haputils.poller_utils.interpret_obset_input`` serves as the sole
+The function :py:func:`drizzlepac.haputils.poller_utils.interpret_obset_input` serves as the sole
 interface for interpreting either the input **poller** file which contains exposure
 information for a visit or a file which contains dataset names, one per line.
 A basic tree is created (as a dictionary of dictionaries) by this function where the
@@ -539,9 +539,9 @@ simply requires defining a common WCS which can be used to define the output for
 all the **filter products** from the visit.
 
 The common WCS, or **metawcs**, gets defined by reading in all the WCS definitions
-as :py:class:`stwcs.wcsutil.HSTWCS` objects
+as `stwcs.wcsutil.HSTWCS <https://stwcs.readthedocs.io/en/latest/hstwcs.html#stwcs.wcsutil.hstwcs.HSTWCS>`_ objects
 for all the input exposures taken with the same **instrument** in the visit.  This
-list of **HSTWCS** objects then gets fed to :py:func:`stwcs.distortion.utils.output_wcs`,
+list of **HSTWCS** objects then gets fed to ``stwcs.distortion.utils.output_wcs``,
 the same function used by ``AstroDrizzle`` to define the default output WCS when
 the user does not specify one before-hand.  This results in the definition of a
 WCS which spans the entire field-of-view for all the input exposures with the same

--- a/doc/source/tweakback.rst
+++ b/doc/source/tweakback.rst
@@ -9,8 +9,9 @@ Tweakback
 .. automodule:: drizzlepac.tweakback
    :members:
    :undoc-members:
-   :exclude-members: getHelpAsString
+   :exclude-members: getHelpAsString, tweakback
+   :noindex:
 
-.. autofunction:: help
-.. autofunction:: tweakback
+.. autofunction:: drizzlepac.tweakback.help
+.. autofunction:: drizzlepac.tweakback.apply_tweak
 

--- a/drizzlepac/mapreg.help
+++ b/drizzlepac/mapreg.help
@@ -163,7 +163,8 @@ include/exclude region file ``input_reg.reg``. Now we can save the regions using
 coordinates, DS9 will use the WCS info from the image onto which the region file
 was loaded. The :py:func:`~drizzlepac.mapreg.MapReg` task tries to automate this process.
 
-**NOTE 2:** :py:func:`~drizzlepac.mapreg.MapReg` relies on the :py:class:`~stregion` package for region file
+**NOTE 2:** :py:func:`~drizzlepac.mapreg.MapReg` relies on the
+`stregion <https://github.com/spacetelescope/stregion>`_ package for region file
 parsing and coordinate transformation. Unfortunately, as of writing,
 **stregion** does not consider distortion corrections when performing coordinate
 transformations. Therefore, there might be a slight discrepancy between the

--- a/drizzlepac/pixtopix.help
+++ b/drizzlepac/pixtopix.help
@@ -18,7 +18,7 @@ Parameters
     should be provided if output is a multi-extension ``FITS`` file.
     If no image gets specified, the input image will be used to
     generate a default output WCS
-    using :py:func:`~stwcs.distortion.util.output_wcs`.
+    using ``stwcs.distortion.util.output_wcs()``.
 
   direction : str
     Direction of transform (forward or backward). The 'forward' transform

--- a/drizzlepac/sky.help
+++ b/drizzlepac/sky.help
@@ -318,7 +318,7 @@ Second, two new methods have been introduced: ``'globalmin'`` and
   is defined by specifying extensions to be used with input images
   (see parameter ``input``\ ).
 
-  See help for :py:func:`~skypac.parseat.parse_at_line` for details
+  See help for :py:func:`~stsci.skypac.parseat.parse_at_line` for details
   on how to specify image extensions.
 
   **Footprint** -- the outline (edge) of the projection of a chip or
@@ -327,14 +327,16 @@ Second, two new methods have been introduced: ``'globalmin'`` and
   .. note::
 
     * Footprints are managed by the
-      :py:class:`~spherical_geometry.polygon.SphericalPolygon` class.
+      `spherical_geometry.polygon.SphericalPolygon
+      <https://spacetelescope.github.io/spherical_geometry/api/spherical_geometry.polygon.SphericalPolygon.html>`_
+      class.
 
     * Both footprints *and* associated exposures (image data, WCS
       information, and other header information) are managed by the
-      :py:class:`~skypac.skyline.SkyLine` class.
+      :py:class:`~stsci.skypac.skyline.SkyLine` class.
 
-    * Each :py:class:`~skypac.skyline.SkyLine` object contains one or more
-      :py:class:`~skypac.skyline.SkyLineMember` objects that manage
+    * Each :py:class:`~stsci.skypac.skyline.SkyLine` object contains one or more
+      :py:class:`~stsci.skypac.skyline.SkyLineMember` objects that manage
       both footprints *and* associated *chip* data that form an exposure.
 
 **Remarks:**


### PR DESCRIPTION
The last(?) of the warnings/errors for the RTD build for version 3.5.1 should have been fixed with these changes.  The changes involved removing duplicate references in the automodule and autofunction listings, as well as cleaning up some last cross-references problems and fixing the name of the `generate_custom_svm_mvm_param_file` as used in the docs.  Some additional entries needed to be made to `conf.rst` for the intersphinx configuration to tell Sphinx where to look for references to modules, functions and classes from external packages like stsci.skypac.  