### PR TITLE
Fixed the S_REGION bug - ensure the polygon is closed

### DIFF
--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -312,6 +312,9 @@ def compute_sregion(image, extname='SCI'):
             footprint = extwcs.calc_footprint(center=True)
             for corner in footprint:
                 sregion_str += '{} {} '.format(corner[0], corner[1])
+            # Close the polygon
+            sregion_str += '{} {} '.format(footprint[0][0], footprint[0][1])
+            print(f"sregion {sregion_str}")
         else:
             if hdu[(extname, extnum)].data.min() == 0 and hdu[(extname, extnum)].data.max() == 0:
                 continue


### PR DESCRIPTION
I fixed the bug where the S_REGION string which is setup for the pipeline FLT/FLC image is not a closed polygon.  The fix was to add the first set of coordinates to the end of the output string.