### PR TITLE
Ensure the SVM FLT/FLC files all contain a valid S_REGION

### DIFF
--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -314,7 +314,6 @@ def compute_sregion(image, extname='SCI'):
                 sregion_str += '{} {} '.format(corner[0], corner[1])
             # Close the polygon
             sregion_str += '{} {} '.format(footprint[0][0], footprint[0][1])
-            print(f"sregion {sregion_str}")
         else:
             if hdu[(extname, extnum)].data.min() == 0 and hdu[(extname, extnum)].data.max() == 0:
                 continue

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -30,6 +30,7 @@ from .. import wcs_functions
 from . import align_utils
 from . import astrometric_utils as amutils
 from . import cell_utils
+from . import processing_utils
 
 MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
@@ -802,6 +803,11 @@ class ExposureProduct(HAPProduct):
             edp_hdu[0].header['IPPPSSOO'] = edp_hdu[0].header['ROOTNAME']
             edp_hdu[0].header['FILENAME'] = edp_filename
 
+            # Ensure the S_REGION keyword is present in the SCI extension(s) and each
+            # polygon (POLYGON ICRS) in the S_REGION string is closed.  As an example,
+            # S_REGION can be missing for images on the "do not reprocess" list.  
+            processing_utils.compute_sregion(edp_hdu)
+
         return edp_filename
 
 
@@ -874,6 +880,11 @@ class GrismExposureProduct(HAPProduct):
             edp_hdu[0].header['HAPLEVEL'] = (1, 'Classification level of this product')
             edp_hdu[0].header['IPPPSSOO'] = edp_hdu[0].header['ROOTNAME']
             edp_hdu[0].header['FILENAME'] = edp_filename
+
+            # Ensure the S_REGION keyword is present in the SCI extension(s) and each
+            # polygon (POLYGON ICRS) in the S_REGION string is closed.  As an example,
+            # S_REGION can be missing for images on the "do not reprocess" list.  
+            processing_utils.compute_sregion(edp_hdu)
 
         return edp_filename
 


### PR DESCRIPTION
Implemented an update to ensure the SVM FLT/FLC files all contain the S_REGION keyword AND it has valid values (i.e., closed polygons). Removed a print statement (cruft) in the compute_region() function.