### PR TITLE
Ensure DATE-* keywords conform to the FITS standard (ISO-8601) for "DATE"

### DIFF
--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -161,8 +161,8 @@ def refine_product_headers(product, total_obj_list):
     phdu['numexp'] = len(input_exposures)
 
     # Convert dates to ISO format
-    phdu['date-beg'] = (Time(phdu['expstart'], format='mjd').iso, "Starting Date and Time")
-    phdu['date-end'] = (Time(phdu['expend'], format='mjd').iso, "Ending Date and Time")
+    phdu['date-beg'] = (Time(phdu['expstart'], format='mjd').iso.replace(' ', 'T'), "Starting Date and Time")
+    phdu['date-end'] = (Time(phdu['expend'], format='mjd').iso.replace(' ', 'T'), "Ending Date and Time")
 
     phdu['equinox'] = hdu[('sci', 1)].header['equinox'] if 'equinox' in hdu[('sci', 1)].header else 2000.0
 


### PR DESCRIPTION
Small fix that replaces the space between the date and time with a "T" using "string".replace(' ', 'T'). 