### PR TITLE
Add Python 3.11 to Jenkins tests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -46,8 +46,12 @@ bc3.test_cmds = ["pytest --cov=./ --basetemp=tests_output --bigdata",
                 "codecov"]
 bc3.test_configs = [data_config]
 
+bc4 = utils.copy(bc3)
+bc4.name = '3.11-dev'
+bc4.conda_packages = ['python=3.11']
+
 
 // Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host (or workdir) for each combination and run in parallel.
 // Also apply the job configuration defined in `jobconfig` above.
-utils.run([bc1, bc3, jobconfig])
+utils.run([bc1, bc3, bc4, jobconfig])


### PR DESCRIPTION
This simply adds a Python 3.11 environment to the suite of Jenkins tests for nightly builds.