### PR TITLE
Protect against using compute_sregion for no valid images

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.6.1 (Unreleased)
 ==================
 
+- Protect against writing the S_REGION keyword in intentionally empty DRZ/DRC
+  files in ``processinput.process`` to avoid messy crash. [#1547]
+
 - Fix a bug in ``processinput.buildFileListOrig`` due to which astrodrizzle
   might crash when ``updatewcs`` is set to ``True``. [#1549]
 

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -952,6 +952,11 @@ def buildEmptyDRZ(input, output):
     pipeline can handle the Multidrizzle zero expossure time exception
     where all data has been excluded from processing.
 
+    Notes
+    -----
+    The existance of the DRZ file is also necessary to satisfy the interface
+    expectations of the archive.  Do NOT delete this file.
+
     Parameters
     ----------
     input : str
@@ -983,7 +988,7 @@ def buildEmptyDRZ(input, output):
         if '_drz' not in output:
             output = fileutil.buildNewRootname(output, extn='_drz.fits')
 
-    print('Building emtpy DRZ file with output name: %s' % output)
+    print('Building empty DRZ file with output name: %s' % output)
 
     # Open the first image (of the excludedFileList?) to use as a template to build
     # the DRZ file.
@@ -1023,7 +1028,6 @@ def buildEmptyDRZ(input, output):
                                   "DRZ product because**")
     fitsobj[0].header.add_history("** all input images were excluded from "
                                   "processing.**")
-
 
     # Change the filename in the primary header to reflect the name of the output
     # filename.

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -698,8 +698,10 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 drz_output = drz_product
             # keep track of output files
             manifest_list.append(drz_output)
-            # update s_region header keyword
-            processing_utils.compute_sregion(drz_product)
+            # update s_region header keyword only if the drz_product
+            # contains actual data, not just header information.
+            if asn_dicts is not None:
+                processing_utils.compute_sregion(drz_product)
 
     else:
         # Create default trailer file messages when astrodrizzle is not

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -698,10 +698,10 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 drz_output = drz_product
             # keep track of output files
             manifest_list.append(drz_output)
-            # update s_region header keyword only if the drz_product
+            # update s_region header keyword only if the drz_output
             # contains actual data, not just header information.
             if asn_dicts is not None:
-                processing_utils.compute_sregion(drz_product)
+                processing_utils.compute_sregion(drz_output)
 
     else:
         # Create default trailer file messages when astrodrizzle is not


### PR DESCRIPTION
Ensure runastrodriz.py does not execute compute_sregion() if no valid images are found for processing and AstroDrizzle is exiting.  In the case of associations, a drizzled image file is created (e.g., ibvz01010_drz.fits), but the file only contains header information and no actual data component.