### PR TITLE
WFPC2: Issue a specific error code and create an empty manifest file for bad data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.6.1 (Unreleased)
 ==================
 
+- For WFPC2 datasets which turn out to have no viable data to process and
+  a manifest file has been requested, force an empty manifest file to be
+  generated and issue the exit code NO_VIABLE_DATA. [#1550]
+
 - Protect against writing the S_REGION keyword in intentionally empty DRZ/DRC
   files in ``processinput.process`` to avoid messy crash. [#1547]
 


### PR DESCRIPTION
If analysis of a WFPC2 exposure determines the data cannot be processed for some reason, the converted WFPC2 FLT file is currently deleted.  The process will now exit with the return code of NO_VIABLE_DATA (65), and an empty manifest file will be created. Also, fixed the option string, added a little documentation, and added a BaseException to handle the sys.exit().