### PR TITLE
runastrodriz: Report the name of the file being process on exception

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -2161,7 +2161,7 @@ def main():
 
         except Exception as errorobj:
             print(str(errorobj))
-            print("ERROR: Cannot run astrodrizzle on %s." % sys.argv[1])
+            print("ERROR: Cannot run astrodrizzle on %s." % " ".join(sys.argv))
             raise Exception(str(errorobj))
 
     sys.exit()


### PR DESCRIPTION
An exception error now reports the name of the file being processed (e.g., ERROR: Cannot run astrodrizzle on runastrodriz -m -i u482c701r_d0m.fits).