### PR TITLE
revert astropy prerelease wheel spec and use nightly Scipy wheel index

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 git+https://github.com/astropy/photutils.git#egg=photutils
 git+https://github.com/spacetelescope/stsci.tools.git#egg=stsci.tools
-astropy>=0.0.dev0
+git+https://github.com/astropy/astropy.git#egg=astropy
 git+https://github.com/spacetelescope/stwcs.git#egg=stwcs
 git+https://github.com/astropy/astroquery.git#egg=astroquery
 numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -47,13 +47,15 @@ description =
     cov: with coverage
     xdist: using parallel processing
 package = editable
+set_env =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 deps =
     pytest
     ci_watson
     xdist: pytest-xdist
     cov: pytest-cov
-    devdeps: -rrequirements-dev.txt
 commands_pre =
+    devdeps: pip install -r requirements-dev.txt -U --upgrade-strategy eager
     pip freeze
 commands =
     pytest -s --basetemp=test_outputs tests \


### PR DESCRIPTION
This PR addresses @WilliamJamieson's comments in https://github.com/spacetelescope/romancal/pull/695#discussion_r1189078751; the Astropy dev spec from #1502 should be a Git repo instead, and `numpy` wheels are hosted at a different index URL
