### PR TITLE
Ensure tweakwcs >= 0.8.2 is in use 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'stsci.skypac>=1.0.9',
     'stsci.stimage',
     'stwcs>=1.5.3',
-    'tweakwcs>=0.8.0',
+    'tweakwcs>=0.8.2',
     'stregion>=1.1.7',
     'requests',
     'scikit-learn>=0.20',


### PR DESCRIPTION
A change in the bounding polygon computation in tweakwcs v0.8.2,imalign.align_wcs(), has improved the runtime processing of some SVM datasets from literally days to tens of minutes.  The algorithm formerly used an "exact" method as the default, but now
an approximate method of computing of the bounding polygon is used by default.
Example dataset: acs_8y2_02