### PR TITLE
use latest versions of linux and macos runners

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: spacetelescope/action-publish_to_pypi/build-wheel@master


### PR DESCRIPTION
update the runners used in the PyPI publish workflow