### PR TITLE
Update MacOS runner for publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
 
     steps:
       - uses: spacetelescope/action-publish_to_pypi/build-wheel@master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,23 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
-3.6.0rc1 (10-May-2023)
+3.6.0 (12-Jun-2023)
 ======================
+
+- Modified the pyproject.toml file to ensure the tweakwcs version is greater
+  than 0.8.2 as the issue of taking a very long time to compute the bounding 
+  polygon now defaults to an approximate method which is significantly faster.
+  [#1565]
+
+- Modified Projection Cell 0 declination coordinate of the center to be
+  -89.999999999997 and the Projection Cell 2643 declination coordinate to
+  be 89.999999999997 to shift the WCS CRVAL position slightly off the pole.
+  [#1560]
+
+- Modified the criteria for the rejection of catalogs based upon the cosmic
+  ray criterion.  An empty catalog (n_sources=0) should not be rejected by the
+  CR contamination.  Also, if a catalog is empty, it should not trigger the
+  rejection of the other "type" of catalog (type=point vs segment). [#1559]
 
 - For WFPC2 datasets which turn out to have no viable data to process and
   a manifest file has been requested, force an empty manifest file to be
@@ -29,9 +44,6 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Fix a bug in ``processinput.buildFileListOrig`` due to which astrodrizzle
   might crash when ``updatewcs`` is set to ``True``. [#1549]
-
-3.6.0rc0 (28-Apr-2023)
-======================
 
 - Turn off use of ``verify_guiding()`` for WFPC2 images only as its use
   incorrectly recognizes diffraction spikes from saturated stars as evidence


### PR DESCRIPTION
The MacOS runner for the publish to PyPI was out-of-date, so the runner was never activated.