### PR TITLE
Ensure version of Matplotlib <= 3.6.3 for now

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,30 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
-3.6.0rc1 (10-May-2023)
+3.6.1rc0 (15-Jun-2023)
 ======================
+
+- Force the version of matplotlib to be <= 3.6.3 as the newer versions of
+  the library cause problems with the calcloud preview generation.  This
+  is a temporary restriction.
+
+3.6.0 (12-Jun-2023)
+======================
+
+- Modified the pyproject.toml file to ensure the tweakwcs version is greater
+  than 0.8.2 as the issue of taking a very long time to compute the bounding 
+  polygon now defaults to an approximate method which is significantly faster.
+  [#1565]
+
+- Modified Projection Cell 0 declination coordinate of the center to be
+  -89.999999999997 and the Projection Cell 2643 declination coordinate to
+  be 89.999999999997 to shift the WCS CRVAL position slightly off the pole.
+  [#1560]
+
+- Modified the criteria for the rejection of catalogs based upon the cosmic
+  ray criterion.  An empty catalog (n_sources=0) should not be rejected by the
+  CR contamination.  Also, if a catalog is empty, it should not trigger the
+  rejection of the other "type" of catalog (type=point vs segment). [#1559]
 
 - For WFPC2 datasets which turn out to have no viable data to process and
   a manifest file has been requested, force an empty manifest file to be
@@ -29,9 +51,6 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Fix a bug in ``processinput.buildFileListOrig`` due to which astrodrizzle
   might crash when ``updatewcs`` is set to ``True``. [#1549]
-
-3.6.0rc0 (28-Apr-2023)
-======================
 
 - Turn off use of ``verify_guiding()`` for WFPC2 images only as its use
   incorrectly recognizes diffraction spikes from saturated stars as evidence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     'astropy>=5.0.4',
     'fitsblender>=0.4.2',
     'scipy',
-    'matplotlib',
+    'matplotlib<=3.6.3',
     'stsci.tools>=4.0',
     'stsci.image>=2.3.4',
     'stsci.imagestats',


### PR DESCRIPTION
The matplotlib version 3.7.x caused a problem for the spec-plots preview code as discovered by B. Hayden in the latest build (Drizzlepac 3.6.0 and HSTDP-2023.1.0 ==> not installed in OPS yet).  He found the code seems to work for matplotlib 3.6.3, but not 3.7.1. While the group that handles the preview code has been contacted, it seems I should force a requirement on the matplotlib version temporarily.  The matplotlib version 3.6.3 has been a part of the packaging of Drizzlepac in previous releases so no issues with Drizzlepac are anticipated.