### PR TITLE
HLA-1029: Fix projection cell identification in overlapping regions

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -994,8 +994,8 @@ class ProjectionCell(object):
         print("SkyCell Ranges: {}, {}".format(mosaic_xr, mosaic_yr))
         # for each suspected sky cell or neighbor, look for any pixel by pixel
         #    overlap with input mosaic footprint
-        for xi in range(mosaic_xr[0], mosaic_xr[1]):
-            for yi in range(mosaic_yr[0], mosaic_yr[1]):
+        for xi in range(mosaic_xr[0], mosaic_xr[1]+1):
+            for yi in range(mosaic_yr[0], mosaic_yr[1]+1):
                 skycell = SkyCell(x=xi, y=yi, projection_cell=self)
 
                 if self.diagnostic_mode:


### PR DESCRIPTION
I've added a +1 to the upper range so that the code appropriately indexes skycells. Previously a range(20:21) was being used to loop through cell 21, but this range yielded just [20] so skycells with y=21 were not being looped through. 

The code now identifies program iczge2* as being in skycell-p2111x08y04 and skycell-p2111x09y04, and now, skycell-p2036x01y21 and skycell-p2037x17y21 as well. 