### PR TITLE
Fix an incompatibility with np 1.25 in minmed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,14 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
+
+3.6.1 (unreleased)
+==================
+
+- Fixed an incompatibility in the ``minmed`` code for cosmic ray rejection
+  with the ``numpy`` version ``>=1.25``. [#1573]
+
+
 3.6.1rc0 (15-Jun-2023)
 ======================
 
@@ -28,7 +36,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 ======================
 
 - Modified the pyproject.toml file to ensure the tweakwcs version is greater
-  than 0.8.2 as the issue of taking a very long time to compute the bounding 
+  than 0.8.2 as the issue of taking a very long time to compute the bounding
   polygon now defaults to an approximate method which is significantly faster.
   [#1565]
 

--- a/drizzlepac/minmed.py
+++ b/drizzlepac/minmed.py
@@ -421,7 +421,7 @@ def min_med(images, weight_images, readnoise_list, exptime_list,
     images = np.asarray(images)
     weight_images = np.asarray(weight_images)
 
-    if weight_masks == [] or weight_masks is None:
+    if weight_masks is None or np.size(weight_masks) == 0:
         weight_masks = None
         mask_sum = np.zeros(images.shape[1:], dtype=np.int16)
         all_bad_idx = np.array([], dtype=int)


### PR DESCRIPTION
Fixes a crash in minmed code due to incompatibility with numpy 1.25 dropping support for comparisons of arrays of different lengths. This PR fixes this.