### PR TITLE
Added an upper limit to NumPy version temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ runmultihap = 'drizzlepac.runmultihap:main'
 requires = ["setuptools>=61",
             "setuptools_scm[toml]>=3.4",
             "wheel",
-            "numpy>=1.18",
+            "numpy>=1.18, <=1.24",
             "astropy>=5.0.4",
             "markupsafe<=2.0.1"]
 build-backend = "setuptools.build_meta"

--- a/tests/hap/test_pipeline.py
+++ b/tests/hap/test_pipeline.py
@@ -126,9 +126,9 @@ class TestSingleton(BaseWFC3Pipeline):
         """ Tests pipeline-style processing of a singleton exposure using runastrodriz.
         """
         # Get sample data through astroquery
-        flcfile = aqutils.retrieve_observation(dataset_names, suffix=['FLC'])[0]
-        fltfile = aqutils.retrieve_observation(dataset_names, suffix=['FLT'])[0]
-        rawfile = aqutils.retrieve_observation(dataset_names, suffix=['RAW'])[0]
+        flcfile = aqutils.retrieve_observation(dataset_names, suffix=['FLC'], product_type="pipeline")
+        fltfile = aqutils.retrieve_observation(dataset_names, suffix=['FLT'], product_type="pipeline")
+        rawfile = aqutils.retrieve_observation(dataset_names, suffix=['RAW'], product_type="pipeline")
 
         # Retrieve reference files for these as well
         self.get_input_file('', fltfile, docopy=False)


### PR DESCRIPTION
Temporary change to pyproject.toml to add an upper limit to the NumPy version until deprecated functionality can be updated.