### PR TITLE
Fixed bug in calculation of the measurements for each detected source

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -174,6 +174,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
                 if cat_type == "segment":
                     sources_dict['segment']['kernel'] = total_product_catalogs.catalogs['segment'].kernel
                     sources_dict['segment']['source_cat'] = total_product_catalogs.catalogs['segment'].source_cat
+                    sources_dict['segment']['total_source_cat'] = total_product_catalogs.catalogs['segment'].total_source_cat
 
             # Get parameter from config files for CR rejection of catalogs
             cr_residual = total_product_obj.configobj_pars.get_pars('catalog generation')['cr_residual']


### PR DESCRIPTION
The detection_cat parameter of SourceCatalog (Photoutils) is now set to the source catalog object computed for the total detection image. This ensures the source centroid and morphological properties computed based upon the total detection image are used to perform the aperture photometry in the filter images.  Removed check for old versions (<1.1.0) of Photoutils as the pyproject.toml enforces the use of newer versions. Updated the call to the SourceCatalog constructor to remove the deprecated kernel parameter.

This PR addresses Jira HLA-1044.