### PR TITLE
WFPC2 json file error due to trailing comma

### DIFF
--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2_wfpc2_index.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2_wfpc2_index.json
@@ -9,7 +9,7 @@
         "total_basic": "wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_total.json",
         "wfpc2_wfpc2_any_n2":"wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n2.json",
         "wfpc2_wfpc2_any_n3":"wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n3.json",
-        "wfpc2_wfpc2_any_n4":"wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n4.json",
+        "wfpc2_wfpc2_any_n4":"wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n4.json"
     },
     "catalog generation": {
         "all": "wfpc2/wfpc2/wfpc2_wfpc2_catalog_generation_all.json"


### PR DESCRIPTION
An unwanted trailing comma in the WFPC2 json index file is the likely culprit for a failure of the WFPC2 HAP processing. This fix was confirmed by doing the WFPC2 processing locally (make_wfpc2.py) on the data from visit "ua0t02". 