### PR TITLE
Removed XFAIL marker as tests are xpassing

### DIFF
--- a/tests/acs/test_acs_tweak.py
+++ b/tests/acs/test_acs_tweak.py
@@ -12,7 +12,7 @@ from ..resources import BaseACS
 
 class TestAcsTweak(BaseACS):
 
-    @pytest.mark.xfail
+    #@pytest.mark.xfail
     def test_tweak(self):
         """ This test confirms that image alignment performed by tweakreg
         works to find the correct alignment solution and that the solution
@@ -79,7 +79,7 @@ class TestAcsTweak(BaseACS):
             self.ignore_keywords += ['D00{}DATA'.format(i), 'D00{}MASK'.format(i)]
         self.compare_outputs(outputs)
 
-    @pytest.mark.xfail
+    #@pytest.mark.xfail
     def test_pixsky1(self):
         """This test verifies that the coordinate transformation tasks
         'pixtopix', 'pixtosky', and 'skytopix' still work as expected.

--- a/tests/acs/test_unit.py
+++ b/tests/acs/test_unit.py
@@ -494,7 +494,7 @@ class TestBlot(BaseUnit):
         assert(med_diff < 1.0e-6)
         assert(max_diff < 1.0e-5)
 
-    @pytest.mark.xfail(reason='Input with different distortion')
+    #@pytest.mark.xfail(reason='Input with different distortion')
     def test_blot_with_image(self):
         """
         Test do_blot with full image


### PR DESCRIPTION
Tests marked as **xfail** are actually passing (**xpass**), so removed the **xfail** marker.