### PR TITLE
replace astropy VCS checkout with link to wheel URL

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 git+https://github.com/astropy/photutils.git#egg=photutils
 git+https://github.com/spacetelescope/stsci.tools.git#egg=stsci.tools
-git+https://github.com/astropy/astropy.git#egg=astropy
 git+https://github.com/spacetelescope/stwcs.git#egg=stwcs
 git+https://github.com/astropy/astroquery.git#egg=astroquery
+--extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
 numpy>=0.0.dev0


### PR DESCRIPTION
This matches the corresponding solution in `romancal`'s `requirements-dev.txt`