### PR TITLE
Removed version restriction on Matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     'astropy>=5.0.4',
     'fitsblender>=0.4.2',
     'scipy',
-    'matplotlib<=3.6.3',
+    'matplotlib',
     'stsci.tools>=4.0',
     'stsci.image>=2.3.4',
     'stsci.imagestats',


### PR DESCRIPTION
The appropriate fixes have been made in the downstream systems so the plotting now works with more current versions of Matplotlib.