### PR TITLE
HLA-1093: Updated WFPC2 params for SVM any_n1.json and any_n2.json

### DIFF
--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n1.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n1.json
@@ -73,7 +73,7 @@
         "driz_combine": true,
         "final_pixfrac": 1.0,
         "final_fillval": null,
-        "final_bits": "65535",
+        "final_bits": "65533",
         "final_maskval": null,
         "final_wht_type": "EXP",
         "final_kernel": "square",

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n2.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/wfpc2/wfpc2_wfpc2_astrodrizzle_any_n2.json
@@ -73,7 +73,7 @@
         "driz_combine": true,
         "final_pixfrac": 1.0,
         "final_fillval": null,
-        "final_bits": "61439",
+        "final_bits": "61437",
         "final_maskval": null,
         "final_wht_type": "EXP",
         "final_kernel": "square",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1093](https://jira.stsci.edu/browse/HLA-1093)

<!-- describe the changes comprising this PR here -->
The PR updates the WFPC2 SVM parameters, in particular, the final_bits variable. 
