### PR TITLE
HLA-1084:Fix regression tests

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -22,7 +22,7 @@ bc1.nodetype = 'linux'
 bc1.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc1.name = '3.9'
 bc1.conda_packages = ['python=3.9']
-bc1.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson==0.5",
+bc1.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson",
 		 "pip install --upgrade -e '.[test]'",
                  "pip freeze"]
 bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml results.xml --bigdata",
@@ -38,17 +38,15 @@ bc3 = new BuildConfig()
 bc3.runtime.add('CFLAGS=-std=gnu99')
 bc3.nodetype = 'linux'
 bc3.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
-bc3.name = '3.10-dev'
+bc3.name = '3.10'
 bc3.conda_packages = ['python=3.10']
-bc3.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson==0.5",
-		 "pip install -r requirements-dev.txt --upgrade -e '.[test]'",
+bc3.build_cmds = ["pip install numpy astropy ci-watson",
+		 "pip install --upgrade -e '.[test]'",
                  "pip freeze"]
-bc3.test_cmds = ["pytest --cov=./ --basetemp=tests_output --bigdata",
-                "codecov"]
 bc3.test_configs = [data_config]
 
 bc4 = utils.copy(bc3)
-bc4.name = '3.11-dev'
+bc4.name = '3.11'
 bc4.conda_packages = ['python=3.11']
 
 // Iterate over configurations that define the (distributed) build matrix.

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,4 +52,4 @@ bc4.conda_packages = ['python=3.11']
 // Iterate over configurations that define the (distributed) build matrix.
 // Spawn a host (or workdir) for each combination and run in parallel.
 // Also apply the job configuration defined in `jobconfig` above.
-utils.run([bc1, bc3, bc4, jobconfig])
+utils.run([bc1, bc2, bc3, bc4, jobconfig])

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -25,7 +25,7 @@ bc1.conda_packages = ['python=3.9']
 bc1.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson",
 		 "pip install --upgrade -e '.[test]'",
                  "pip freeze"]
-bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml results.xml --bigdata",
+bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata",
                 "codecov"]
 bc1.test_configs = [data_config]
 bc1.failedFailureThresh = 0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,9 @@
 git+https://github.com/astropy/photutils.git#egg=photutils
 git+https://github.com/spacetelescope/stsci.tools.git#egg=stsci.tools
 git+https://github.com/spacetelescope/stwcs.git#egg=stwcs
-git+https://github.com/astropy/astroquery.git#egg=astroquery
+#git+https://github.com/astropy/astroquery.git#egg=astroquery
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
+
+--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 numpy>=0.0.dev0
+scipy>=0.0.dev0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1084](https://jira.stsci.edu/browse/HLA-1084)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses failures in drizzlpac regression tests and reports on Jenkins.
Changes include
- remove the limit on `ci_watson` and use the latest release
- run tests with dev versions of dependencies in one job only (no reason to run it with all Python versions)
- run code coverage on one job only (no reason to run it in all jobs)
- add the location of numpy nightly wheels
- remove astroquery from the dev dependencies (my understanding is it's used only in testing) 
- fixed the RTD build. RTD deprecated `use-system-packages` in configuration files

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
Regression test run
https://plwishmaster.stsci.edu:8081/job/RT/job/Drizzlepac-Developers-Pull-Requests/6/