### PR TITLE
remove unsupported `system_packages` RTD config setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,7 +25,6 @@ conda:
   environment: doc/.rtd-environment.yml
 
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
RTD no longer supports any `system_packages` setting:
https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused `system_packages` setting

**Checklist for maintainers**
- [ ] ~added entry in `CHANGELOG.rst` within the relevant release section~
- [ ] ~updated or added relevant tests~
- [x] updated relevant documentation
- [ ] ~added relevant milestone~
- [x] added relevant label(s)
- [ ] ~ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)~
