### PR TITLE
HLA-1122: Added log for astrometric catalog source

### DIFF
--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -167,6 +167,7 @@ SUPPORTED_CATALOGS = {
                'mag': 'mag', 'objID': 'objID', 'epoch': 'epoch'},
     }
 
+log.info(f'ASTROMETRIC_CATALOG_URL = {SERVICELOCATION}')
 
 # CRBIT definitions
 CRBIT = 4096


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1122](https://jira.stsci.edu/browse/HLA-1122)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1668 

<!-- describe the changes comprising this PR here -->
This PR adds a logger line to haputils.astrometric utils that specifies the astrometric catalog source. 