### PR TITLE
HLA-1120: Force a consistent default value for do_verify_guiding 

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -200,7 +200,7 @@ wcs_preference = ['IDC_?????????-FIT_REL_GAIA*3', 'IDC_?????????-FIT_IMG_GAIA*3'
 # Primary user interface
 def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
             headerlets=True, align_to_gaia=True, force_alignment=False,
-            do_verify_guiding=True, debug=False, make_manifest=False):
+            do_verify_guiding=False, debug=False, make_manifest=False):
     """ Run astrodrizzle on input file/ASN table
         using default values for astrodrizzle parameters.
     """
@@ -277,7 +277,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     else:
         # start by turning off 'verify_guiding' since loss of lock
         # was exceedingly rare and noted in the quality keywords
-        # which get checked in '_anayze_exposure'.
+        # which get checked in '_analyze_exposure'.
         do_verify_guiding = False
         # Convert input c0m file into compatible flt file
         if 'd0m' in inFilename:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1120](https://jira.stsci.edu/browse/HLA-1120)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes # ---

<!-- describe the changes comprising this PR here -->
This PR forces a consistent default value for do_verify_guiding() when used on the command line or  via the runastrodriz.process() API.  The do_verify_guiding() function is currently set to False (or turned off) for normal processing.  The alogorithm encapsulated in this function is still being worked and is considered experimental.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
