### PR TITLE
HLA-1110: aperture keyword from poller to header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.6.2rc0 (unreleased)
 =====================
 
+- Added functionality to allow the use of a two-column poller file. This is used
+  to update the WFPC2 SVM aperture header keywords from the values in the poller 
+  file.
+
 - Removed the version restriction on matplotlib. [#1649]
 
 - Forced a preferential order on the final selection of the WCS solution 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -769,7 +769,6 @@ def run_align_to_gaia(tot_obj, log_level=logutil.logging.INFO, diagnostic_mode=F
             gaia_obj = product.FilterProduct(prod_list[0], prod_list[1], prod_list[2],
                                              prod_list[3], prod_list[4], prod_list[5], "all",
                                              prod_list[6][0:3], log_level)
-            import ipdb; ipdb.set_trace()
             gaia_obj.configobj_pars = tot_obj.configobj_pars
         gaia_obj.add_member(exp_obj)
 

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -765,10 +765,11 @@ def run_align_to_gaia(tot_obj, log_level=logutil.logging.INFO, diagnostic_mode=F
     for exp_obj in tot_obj.edp_list:
         if gaia_obj is None:
             prod_list = exp_obj.info.split("_")
-            prod_list[4] = "metawcs"
+            prod_list[5] = "metawcs"
             gaia_obj = product.FilterProduct(prod_list[0], prod_list[1], prod_list[2],
-                                             prod_list[3], prod_list[4], "all",
-                                             prod_list[5][0:3], log_level)
+                                             prod_list[3], prod_list[4], prod_list[5], "all",
+                                             prod_list[6][0:3], log_level)
+            import ipdb; ipdb.set_trace()
             gaia_obj.configobj_pars = tot_obj.configobj_pars
         gaia_obj.add_member(exp_obj)
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -127,7 +127,6 @@ def interpret_obset_input(results, log_level):
     """
     # set logging level to user-specified level
     log.setLevel(log_level)
-
     log.debug("Interpret the poller file for the observation set.")
     obset_table = build_poller_table(results, log_level)
     # Add INSTRUMENT column
@@ -946,7 +945,7 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
             is_poller_file = False # gets important keywords from file headers instead of poller file
             
         # unique logic to collect WFPC2 aperture data from poller file
-        if len(input_table.columns) == 2:
+        elif len(input_table.columns) == 2:
             input_table.columns[0].name = 'filename'
             input_table.columns[1].name = 'aperture'
             # add dtype for aperture column
@@ -1092,6 +1091,8 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
     if input_table:
         if 'aperture' in input_table.colnames:
             cols['aperture'] = input_table['aperture'].tolist()
+        else:
+            cols['aperture'] = [' '] * len(usable_datasets)
         
     # If MVM processing and a poller file is the input, this implies there is
     # only one skycell of interest for all the listed filenames in the poller

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -1097,7 +1097,8 @@ def build_poller_table(input: str, log_level, all_mvm_exposures=[], poller_type=
         if 'aperture' in input_table.colnames:
             cols['aperture'] = input_table['aperture'].tolist()
         else:
-            cols['aperture'] = ['empty_aperture'] * len(usable_datasets)
+            add_col = Column(['empty_aperture'] * len(usable_datasets), name='aperture', dtype='str')
+            input_table.add_column(add_col, index=7)
             poller_dtype+=('str',)
     else:
         raise ValueError("Input table is empty. Exiting...")

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -671,7 +671,7 @@ def parse_obset_tree(det_tree, log_level):
 
                 # Determine if this image is a Grism/Prism or a nominal direct exposure
                 is_grism = False
-                if prod_list[5].lower().find('g') != -1 or prod_list[5].lower().find('pr') != -1:
+                if prod_list[6].lower().find('g') != -1 or prod_list[6].lower().find('pr') != -1:
                     is_grism = True
                     filt_indx -= 1
                     grism_sep_obj = GrismExposureProduct(prod_list[0], prod_list[1], prod_list[2],
@@ -704,7 +704,6 @@ def parse_obset_tree(det_tree, log_level):
                     filt_obj.add_member(sep_obj)
                     # Populate filter product dictionary with input filename
                     obset_products[fprod]['files'].append(filename[1])
-
                 # Set up the total detection product dictionary and create a total detection product object
                 # Initialize `info` key for total detection product
                 if not obset_products[totprod]['info']:
@@ -713,7 +712,6 @@ def parse_obset_tree(det_tree, log_level):
                     # Create a total detection product object for this instrument/detector
                     tdp_obj = TotalProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
                                            prod_list[4], prod_list[5], prod_list[7], log_level)
-
                 if not is_grism:
                     # Append exposure object to the list of exposure objects for this specific total detection product
                     tdp_obj.add_member(sep_obj)
@@ -1099,7 +1097,7 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
         if 'aperture' in input_table.colnames:
             cols['aperture'] = input_table['aperture'].tolist()
         else:
-            cols['aperture'] = ['aperture'] * len(usable_datasets)
+            cols['aperture'] = ['empty_aperture'] * len(usable_datasets)
             poller_dtype+=('str',)
     else:
         raise ValueError("Input table is empty. Exiting...")
@@ -1164,7 +1162,6 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
             for i, old_row in enumerate(input_table):
                 if d == input_table['filename'][i]:
                     good_rows.append(old_row)
-        import ipdb; ipdb.set_trace()
 
         # This table contains the pipeline specified skycell_id for each row
         # which should be the same value in every row

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -146,7 +146,6 @@ def interpret_obset_input(results, log_level):
     # Now create the output product objects
     log.debug("Parse the observation set tree and create the exposure, filter, and total detection objects.")
     obset_dict, tdp_list = parse_obset_tree(obset_tree, log_level)
-    import ipdb; ipdb.set_trace()
     
     # This little bit of code adds an attribute to single exposure objects that is True
     # if a given filter only contains one input (e.g. n_exp = 1)

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -197,7 +197,7 @@ def build_obset_tree(obset_table):
 def create_row_info(row):
     """Build info string for a row from the obset table"""
     info_list = [str(row['proposal_id']), "{}".format(row['obset_id']), row['instrument'],
-                 row['detector'], row['filename'][:row['filename'].find('_')], row['filters'], row['aperture']]
+                 row['detector'], row['aperture'], row['filename'][:row['filename'].find('_')], row['filters']]
     return ' '.join(map(str.upper, info_list)), row['filename']
 
 
@@ -675,11 +675,11 @@ def parse_obset_tree(det_tree, log_level):
                     is_grism = True
                     filt_indx -= 1
                     grism_sep_obj = GrismExposureProduct(prod_list[0], prod_list[1], prod_list[2],
-                                                         prod_list[3], filename[1], prod_list[5],
-                                                         prod_list[6], log_level)
+                                                         prod_list[3], prod_list[4], filename[1], prod_list[6],
+                                                         prod_list[7], log_level)
                 else:
-                    sep_obj = ExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
-                                              filename[1], prod_list[5], prod_list[6], log_level)
+                    sep_obj = ExposureProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3], prod_list[4],
+                                              filename[1], prod_list[6], prod_list[7], log_level)
                 # Now that we have defined the ExposureProduct for this input exposure,
                 # do not include it any total or filter product.
                 if not is_member:
@@ -699,7 +699,7 @@ def parse_obset_tree(det_tree, log_level):
 
                         # Create a filter product object for this instrument/detector
                         filt_obj = FilterProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
-                                                 prod_list[4], prod_list[5], prod_list[6], log_level)
+                                                 prod_list[4], prod_list[5], prod_list[6], prod_list[7], log_level)
                     # Append exposure object to the list of exposure objects for this specific filter product object
                     filt_obj.add_member(sep_obj)
                     # Populate filter product dictionary with input filename
@@ -712,7 +712,7 @@ def parse_obset_tree(det_tree, log_level):
 
                     # Create a total detection product object for this instrument/detector
                     tdp_obj = TotalProduct(prod_list[0], prod_list[1], prod_list[2], prod_list[3],
-                                           prod_list[4], prod_list[6], log_level)
+                                           prod_list[4], prod_list[5], prod_list[7], log_level)
 
                 if not is_grism:
                     # Append exposure object to the list of exposure objects for this specific total detection product

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -939,9 +939,10 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
 
     if isinstance(input, str):
         input_table = ascii.read(input, format='no_header', converters=obs_converters)
-        
         if len(input_table.columns) == 1:
             input_table.columns[0].name = 'filename'
+            input_table['aperture']= 'empty_aperture'
+            poller_dtype+=('str',)
             is_poller_file = False # gets important keywords from file headers instead of poller file
             
         # unique logic to collect WFPC2 aperture data from poller file
@@ -1098,7 +1099,10 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
         if 'aperture' in input_table.colnames:
             cols['aperture'] = input_table['aperture'].tolist()
         else:
-            cols['aperture'] = [' '] * len(usable_datasets)
+            cols['aperture'] = ['aperture'] * len(usable_datasets)
+            poller_dtype+=('str',)
+    else:
+        raise ValueError("Input table is empty. Exiting...")
         
     # If MVM processing and a poller file is the input, this implies there is
     # only one skycell of interest for all the listed filenames in the poller
@@ -1160,6 +1164,7 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
             for i, old_row in enumerate(input_table):
                 if d == input_table['filename'][i]:
                     good_rows.append(old_row)
+        import ipdb; ipdb.set_trace()
 
         # This table contains the pipeline specified skycell_id for each row
         # which should be the same value in every row

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -91,38 +91,50 @@ def interpret_obset_input(results: str, log_level):
     Interpret the database query for a given obset to prepare the returned
     values for use in generating the names of all the expected output products.
 
-    Input will have format of::
-
+    Input will have formated rows of one of the following three options::
+    
+    1) Full poller file
         ib4606c5q_flc.fits,11665,B46,06,1.0,F555W,UVIS,/foo/bar/ib4606c5q_flc.fits
+        
+    2) Simpler poller file (list); other info taken from file header keywords
+        ib4606c5q_flc.fits
+        
+    3) For updating the WFPC2 SVM aperture keyword using the poller file; it
+        is important that there are no spaces within the poller aperture keyword(s)
+    
+        ib4606c5q_flc.fits, PC1-FIX;F160BN15
 
-    which are filename, proposal_id, program_id, obset_id, exptime, filters, detector, pathname.
+    Full poller files contain filename, proposal_id, program_id, obset_id, exptime, filters, detector, pathname.
 
     The output dict will have format (as needed by further code for creating the product filenames) of::
 
-        obs_info_dict["single exposure product 00": {"info": '11665 06 wfc3 uvis ib4606c5q f555w drc',
+        obs_info_dict["single exposure product 00": {"info": '11665 06 wfc3 uvis empty_aperture ib4606c5q f555w drc',
                                                      "files": ['ib4606c5q_flc.fits']}
         .
         .
         .
-        obs_info_dict["single exposure product 08": {"info": '11665 06 wfc3 ir ib4606clq f110w drz',
+        obs_info_dict["single exposure product 08": {"info": '11665 06 wfc3 ir empty_aperture ib4606clq f110w drz',
                                                      "files": ['ib4606clq_flt.fits']}
 
-        obs_info_dict["filter product 00": {"info": '11665 06 wfc3 uvis ib4606c5q f555w drc',
+        obs_info_dict["filter product 00": {"info": '11665 06 wfc3 uvis empty_aperture ib4606c5q f555w drc',
                                             "files": ['ib4606c5q_flc.fits', 'ib4606c6q_flc.fits']},
         .
         .
         .
-        obs_info_dict["filter product 01": {"info": '11665 06 wfc3 ir ib4606cmq f160w drz',
+        obs_info_dict["filter product 01": {"info": '11665 06 wfc3 ir empty_aperture ib4606cmq f160w drz',
                                             "files": ['ib4606cmq_flt.fits', 'ib4606crq_flt.fits']},
 
 
-        obs_info_dict["total detection product 00": {"info": '11665 06 wfc3 uvis ib4606c5q f555w drc',
+        obs_info_dict["total detection product 00": {"info": '11665 06 wfc3 uvis empty_aperture ib4606c5q f555w drc',
                                                      "files": ['ib4606c5q_flc.fits', 'ib4606c6q_flc.fits']}
         .
         .
         .
-        obs_info_dict["total detection product 01": {"info": '11665 06 wfc3 ir ib4606cmq f160w drz',
+        obs_info_dict["total detection product 01": {"info": '11665 06 wfc3 ir empty_aperture ib4606cmq f160w drz',
                                                      "files": ['ib4606cmq_flt.fits', 'ib4606crq_flt.fits']}
+
+    The aperture keyword, which has a default value of 'empty_aperture' is filled in the case of WFPC2 observations,
+    and the use of the two-column format. 
 
     """
     # set logging level to user-specified level
@@ -728,7 +740,7 @@ def parse_obset_tree(det_tree, log_level):
                     if is_ccd and len(filt_obj.edp_list) == 1:
                         for e in filt_obj.edp_list:
                             e.crclean = True
-
+                    import ipdb;ipdb.set_trace()
                 elif is_grism:
                     tdp_obj.add_grism_member(grism_sep_obj)
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -146,7 +146,8 @@ def interpret_obset_input(results, log_level):
     # Now create the output product objects
     log.debug("Parse the observation set tree and create the exposure, filter, and total detection objects.")
     obset_dict, tdp_list = parse_obset_tree(obset_tree, log_level)
-
+    import ipdb; ipdb.set_trace()
+    
     # This little bit of code adds an attribute to single exposure objects that is True
     # if a given filter only contains one input (e.g. n_exp = 1)
     for tot_obj in tdp_list:
@@ -198,7 +199,7 @@ def build_obset_tree(obset_table):
 def create_row_info(row):
     """Build info string for a row from the obset table"""
     info_list = [str(row['proposal_id']), "{}".format(row['obset_id']), row['instrument'],
-                 row['detector'], row['filename'][:row['filename'].find('_')], row['filters']]
+                 row['detector'], row['filename'][:row['filename'].find('_')], row['filters'], row['aperture']]
     return ' '.join(map(str.upper, info_list)), row['filename']
 
 
@@ -888,9 +889,12 @@ def determine_filter_name(raw_filter):
 # ------------------------------------------------------------------------------
 
 
-def build_poller_table(input, log_level, all_mvm_exposures=[], poller_type='svm',
+def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], poller_type='svm',
                        include_small=True, only_cte=False):
-    """Create a poller file from dataset names.
+    """Create a poller file from dataset names for either SMV or MVM processing. Information is either gathered 
+    from the poller file or by using the filename to open the file and pulling information from the header keywords. 
+    The code treats WFPC2 differently, by uses both approaches. For WFPC2, We use simple poller files with a second column 
+    that includes the aperture. The code gathers the rest of the relevant informaiton from the header keywords.
 
     Parameters
     -----------
@@ -942,7 +946,7 @@ def build_poller_table(input, log_level, all_mvm_exposures=[], poller_type='svm'
             input_table.columns[0].name = 'filename'
             is_poller_file = False # gets important keywords from file headers instead of poller file
             
-        # unique logic to collect wfpc2 aperture data from poller file
+        # unique logic to collect WFPC2 aperture data from poller file
         if len(input_table.columns) == 2:
             input_table.columns[0].name = 'filename'
             input_table.columns[1].name = 'aperture'
@@ -1039,6 +1043,7 @@ def build_poller_table(input, log_level, all_mvm_exposures=[], poller_type='svm'
         # datasets = input_table[input_table.colnames[0]].tolist()
         filenames = list(input_table.columns[0])
 
+    # If input is a list of filenames
     elif isinstance(input, list):
         filenames = input
         input_table= None

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -481,7 +481,7 @@ def parse_mvm_tree(det_tree, all_mvm_exposures, log_level):
                 # mvm prod_info = 'skycell_p1234_x01y01 wfc3 uvis f200lp all 2009 1 drz'
                 #
                 prod_list = prod_info.split(" ")
-                multi_scale = prod_list[2].upper() in ['IR']
+                multi_scale = prod_list[2].upper() in ['IR', 'PC']
                 pscale = 'fine' if not multi_scale else 'coarse'
                 prod_info += " {:s}".format(pscale)
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -64,7 +64,7 @@ log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.s
 # -----------------------------------------------------------------------------
 # Single Visit Processing Functions
 #
-def interpret_obset_input(results, log_level):
+def interpret_obset_input(results: str, log_level):
     """
 
     Parameters
@@ -885,7 +885,7 @@ def determine_filter_name(raw_filter):
 # ------------------------------------------------------------------------------
 
 
-def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], poller_type='svm',
+def build_poller_table(input: str, log_level, all_mvm_exposures=[], poller_type='svm',
                        include_small=True, only_cte=False):
     """Create a poller file from dataset names for either SMV or MVM processing. Information is either gathered 
     from the poller file or by using the filename to open the file and pulling information from the header keywords. 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -671,15 +671,18 @@ def parse_obset_tree(det_tree, log_level):
                 sep_indx += 1
 
                 # Create a single exposure product object
-                #
-                # The prod_list[5] is the filter - use this information to distinguish between
+                
+                # The GrismExposureProduct is only an attribute of the TotalProduct.
+                prod_list = exp_prod_info.split(" ")
+                
+                # prod_list is 0: proposal_id, 1:observation_id, 2:instrument, 3:detector, 
+                # 4:aperture_from_poller, 5:filename, 6:filters, 7:filetype
+                
+                # The prod_list[6] is the filter - use this information to distinguish between
                 # a direct exposure for drizzling (ExposureProduct) and an exposure
                 # (GrismExposureProduct) which is carried along (Grism/Prism) to make analysis
                 # easier for the user by having the same WCS in both the direct and
                 # Grism/Prism products.
-                #
-                # The GrismExposureProduct is only an attribute of the TotalProduct.
-                prod_list = exp_prod_info.split(" ")
 
                 # Determine if this image is a Grism/Prism or a nominal direct exposure
                 is_grism = False
@@ -740,7 +743,6 @@ def parse_obset_tree(det_tree, log_level):
                     if is_ccd and len(filt_obj.edp_list) == 1:
                         for e in filt_obj.edp_list:
                             e.crclean = True
-                    import ipdb;ipdb.set_trace()
                 elif is_grism:
                     tdp_obj.add_grism_member(grism_sep_obj)
 

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -1019,17 +1019,23 @@ def build_poller_table(input: str | list, log_level, all_mvm_exposures=[], polle
             # an exception and exit.
             for table_line in input_table:
                 if os.path.exists(table_line['filename']):
-                    log.info("Input image {} found in current working directory.".format(table_line['filename']))
+                    log.info(f"Input image {table_line['filename']} found in current working directory.")
                 elif os.path.exists(table_line['pathname']):
-                    log.info("Input image {} not found in current working directory. However, it was found in the path specified in the poller file.".format(table_line['filename']))
+                    log.info(f"Input image {table_line['filename']} not found in current working directory. However, it was found in the path specified in the poller file.")
                     shutil.copy(table_line['pathname'], os.getcwd())
-                    log.info("Input image {} copied to current working directory.".format(table_line['pathname']))
+                    log.info(f"Input image {table_line['pathname']} copied to current working directory.")
                 else:
-                    log.error("Input image {} not found in current working directory.".format(table_line['filename']))
-                    log.error("Archived input image {} not found.".format(table_line['pathname']))
-                    err_msg = "Input image {} missing from current working directory and from the path specified in the poller file. Exiting... ".format(table_line['filename'])
+                    log.error(f"Input image {table_line['filename']} not found in current working directory.")
+                    log.error(f"Archived input image {table_line['pathname']} not found.")
+                    err_msg = f"Input image {table_line['filename']} missing from current working directory and from the path specified in the poller file. Exiting... "
                     log.error(err_msg)
                     raise Exception(err_msg)
+        
+        elif (poller_type == 'mvm') & (len(input_table.columns) != len(poller_colnames)):
+            log.error(f"MVMs should use full poller files with {len(poller_colnames)} columns.")
+            err_msg = f"Full poller files should have {len(poller_colnames)} columns. Exiting... "
+            log.error(err_msg)
+            raise Exception(err_msg)
                 
         # input is string with unexpected number of columns
         else:

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -171,10 +171,12 @@ def refine_product_headers(product, total_obj_list):
         phdu['filter'] = get_acs_filters(hdu, delimiter=';')
         
     # WFPC2 update aperture if in poller file
-    if total_obj_list[0].aperture != 'empty_aperture':
+    if (total_obj_list[0].aperture != 'empty_aperture') & (phdu['instrume'] =='WFPC2'):
         log.info(f"Updating aperture header keyword from {phdu['aperture']} to {total_obj_list[0].aperture}")
         phdu['aperture'] = total_obj_list[0].aperture
-
+    else:
+        log.debug("Not updating aperture keyword.")
+        
     # Insure PHOT* keywords are always in SCI extension
     for pkw in PHOT_KEYWORDS:
         if pkw in phdu:

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -171,9 +171,9 @@ def refine_product_headers(product, total_obj_list):
         phdu['filter'] = get_acs_filters(hdu, delimiter=';')
         
     # WFPC2 update aperture if in poller file
-    if (total_obj_list[0].aperture != 'empty_aperture') & (phdu['instrume'] =='WFPC2'):
-        log.info(f"Updating aperture header keyword from {phdu['aperture']} to {total_obj_list[0].aperture}")
-        phdu['aperture'] = total_obj_list[0].aperture
+    if (total_obj_list[0].aperture_from_poller != 'empty_aperture') & (phdu['instrume'] =='WFPC2'):
+        log.info(f"Updating aperture header keyword from {phdu['aperture']} to {total_obj_list[0].aperture_from_poller}")
+        phdu['aperture'] = total_obj_list[0].aperture_from_poller
     else:
         log.debug("Not updating aperture keyword.")
         

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -169,6 +169,11 @@ def refine_product_headers(product, total_obj_list):
     # Re-format ACS filter specification
     if phdu['instrume'] == 'ACS':
         phdu['filter'] = get_acs_filters(hdu, delimiter=';')
+        
+    # WFPC2 update aperture if in poller file
+    if total_obj_list[0].aperture != 'empty_aperture':
+        log.info(f"Updating aperture header keyword from {phdu['aperture']} to {total_obj_list[0].aperture}")
+        phdu['aperture'] = total_obj_list[0].aperture
 
     # Insure PHOT* keywords are always in SCI extension
     for pkw in PHOT_KEYWORDS:

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -64,7 +64,7 @@ class HAPProduct:
     """
 
     def __init__(
-        self, prop_id, obset_id, instrument, detector, filename, filetype, log_level
+        self, prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
     ):
         # set logging level to user-specified level
         log.setLevel(log_level)
@@ -79,6 +79,7 @@ class HAPProduct:
         self.obset_id = obset_id
         self.instrument = instrument
         self.detector = detector
+        self.aperture = aperture
         self.filetype = filetype
         self.rules_file = None
         self.basename = (
@@ -536,13 +537,13 @@ class TotalProduct(HAPProduct):
     """
 
     def __init__(
-        self, prop_id, obset_id, instrument, detector, filename, filetype, log_level
+        self, prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
         )
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, filename, filetype]
+            [prop_id, obset_id, instrument, detector, aperture, filename, filetype]
         )
         self.exposure_name = filename[0:6]
 
@@ -702,17 +703,18 @@ class FilterProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
+        aperture,
         filename,
         filters,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
         )
 
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, filename, filters, filetype]
+            [prop_id, obset_id, instrument, detector, aperture, filename, filters, filetype]
         )
         if filename[0:7].lower() != "metawcs":
             self.exposure_name = filename[0:6]
@@ -849,17 +851,18 @@ class ExposureProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
+        aperture, 
         filename,
         filters,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
         )
 
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, filename, filters, filetype]
+            [prop_id, obset_id, instrument, detector, aperture, filename, filters, filetype]
         )
         self.filters = filters
         self.full_filename = self.copy_exposure(filename)
@@ -1014,17 +1017,18 @@ class GrismExposureProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
+        aperture,
         filename,
         filters,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
         )
 
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, filename, filters, filetype]
+            [prop_id, obset_id, instrument, detector, aperture, filename, filters, filetype]
         )
         self.filters = filters
         self.full_filename = self.copy_exposure(filename)
@@ -1110,13 +1114,14 @@ class SkyCellExposure(HAPProduct):
         obset_id,
         instrument,
         detector,
+        aperture,
         filename,
         layer,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
         )
 
         filter_str = layer[0]
@@ -1345,13 +1350,14 @@ class SkyCellProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
+        aperture,
         skycell_name,
         layer,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, skycell_name, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture, skycell_name, filetype, log_level
         )
         # May need to exclude 'filter' component from layer_str
         filter_str = layer[0]
@@ -1369,7 +1375,7 @@ class SkyCellProduct(HAPProduct):
         layer_scale = layer[1]
 
         self.info = "_".join(
-            ["hst", skycell_name, instrument, detector, filter_str, layer_str]
+            ["hst", skycell_name, instrument, detector, aperture, filter_str, layer_str]
         )
         self.exposure_name = skycell_name
         self.cell_id = skycell_name.strip("skycell-")

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -64,7 +64,7 @@ class HAPProduct:
     """
 
     def __init__(
-        self, prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+        self, prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
     ):
         # set logging level to user-specified level
         log.setLevel(log_level)
@@ -79,7 +79,7 @@ class HAPProduct:
         self.obset_id = obset_id
         self.instrument = instrument
         self.detector = detector
-        self.aperture = aperture
+        self.aperture_from_poller = aperture_from_poller
         self.filetype = filetype
         self.rules_file = None
         self.basename = (
@@ -537,13 +537,13 @@ class TotalProduct(HAPProduct):
     """
 
     def __init__(
-        self, prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+        self, prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
         )
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, aperture, filename, filetype]
+            [prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype]
         )
         self.exposure_name = filename[0:6]
 
@@ -703,18 +703,18 @@ class FilterProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
-        aperture,
+        aperture_from_poller,
         filename,
         filters,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
         )
 
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, aperture, filename, filters, filetype]
+            [prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filters, filetype]
         )
         if filename[0:7].lower() != "metawcs":
             self.exposure_name = filename[0:6]
@@ -851,18 +851,18 @@ class ExposureProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
-        aperture, 
+        aperture_from_poller, 
         filename,
         filters,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
         )
 
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, aperture, filename, filters, filetype]
+            [prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filters, filetype]
         )
         self.filters = filters
         self.full_filename = self.copy_exposure(filename)
@@ -1017,18 +1017,18 @@ class GrismExposureProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
-        aperture,
+        aperture_from_poller,
         filename,
         filters,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
         )
 
         self.info = "_".join(
-            [prop_id, obset_id, instrument, detector, aperture, filename, filters, filetype]
+            [prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filters, filetype]
         )
         self.filters = filters
         self.full_filename = self.copy_exposure(filename)
@@ -1114,14 +1114,14 @@ class SkyCellExposure(HAPProduct):
         obset_id,
         instrument,
         detector,
-        aperture,
+        aperture_from_poller,
         filename,
         layer,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, aperture, filename, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture_from_poller, filename, filetype, log_level
         )
 
         filter_str = layer[0]
@@ -1350,14 +1350,14 @@ class SkyCellProduct(HAPProduct):
         obset_id,
         instrument,
         detector,
-        aperture,
+        aperture_from_poller,
         skycell_name,
         layer,
         filetype,
         log_level,
     ):
         super().__init__(
-            prop_id, obset_id, instrument, detector, aperture, skycell_name, filetype, log_level
+            prop_id, obset_id, instrument, detector, aperture_from_poller, skycell_name, filetype, log_level
         )
         # May need to exclude 'filter' component from layer_str
         filter_str = layer[0]
@@ -1375,7 +1375,7 @@ class SkyCellProduct(HAPProduct):
         layer_scale = layer[1]
 
         self.info = "_".join(
-            ["hst", skycell_name, instrument, detector, aperture, filter_str, layer_str]
+            ["hst", skycell_name, instrument, detector, aperture_from_poller, filter_str, layer_str]
         )
         self.exposure_name = skycell_name
         self.cell_id = skycell_name.strip("skycell-")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1110](https://jira.stsci.edu/browse/HLA-1110)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1661 

<!-- describe the changes comprising this PR here -->
This PR adds the aperture keyword to HAPProduct object as well as its child products (TotalProduct, FilterProduct, ExposureProduct). The code changes how the poller file data is used. 

Previously the code either  1) used the poller file filenames and pulled the other relevant data from the header keywords 2) used full poller files with all of the relevant data. We have now implemented a third option where if the poller file has two columns, it is assumed that the second column is the aperture keyword. This code will then update the aperture keyword in the output SVM data for only WFPC2. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
