### PR TITLE
HLA-1145: Pin astrocut to avoid urllib3 version conflict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,12 +18,14 @@ number of the code change for that issue.  These PRs can be viewed at:
     https://github.com/spacetelescope/drizzlepac/pulls
 
 
-3.6.2rc0 (unreleased)
+3.6.2rc2 (unreleased)
 =====================
+- At this time pin Astrocut to versions <=0.9 to avoid conflicts with urllib3
+  package.  [#1145]
 
 - Added functionality to allow the use of a two-column poller file. This is used
   to update the WFPC2 SVM aperture header keywords from the values in the poller 
-  file.
+  file. [#1683]
 
 - Removed the version restriction on matplotlib. [#1649]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     'pandas',
     'spherical_geometry>=1.2.22',
     'astroquery>=0.4',
-    'astrocut',
+    'astrocut<=0.9',
     'photutils>1.5.0',
     'lxml',
     'PyPDF2',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1145](https://jira.stsci.edu/browse/HLA-1145)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Need to pin astrocut due to conflicts with its latest version and urllib3 version when trying to generate the build YAML.  Build complained:
botocore 1.31.64 requires urllib3<1.27,>=1.25.4; python_version < "3.10", but you have urllib3 2.0.4 which is incompatible.

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
