### PR TITLE
[WIP] HLA-1161: MagErrAp2 and other magnitude errors in HAP catalogs have incorrect negative values

### DIFF
--- a/doc/ADRs.md
+++ b/doc/ADRs.md
@@ -1,4 +1,4 @@
-# Updating WCS in Headers
+# Updating WCS in Headers 11/14/23
 
 ## Context
 
@@ -13,7 +13,7 @@ In order to ensure reproducibility and the ability to share consistent datasets 
 Headerlets can now be used to easily update and select WCS for datasets. Headerlets are files with the _hlet.fits suffix
 
 
-# Updating APERTURE keyword through poller
+# Updating APERTURE keyword through poller 11/14/23
 
 ## Context
 

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -249,7 +249,12 @@ def ci_filter(drizzled_image, catalog_name, catalog_data, proc_type, param_dict,
             merr2 = numpy.nan
         else:
             merr2 = float(merr2)
-        good_snr = merr2 <= 2.5 / (snr * numpy.log(10))
+        
+        # SNR calculation based on flux instead of magnitude as negative magnitudes are possible
+        fluxap2 = table_row["FluxAp2"]
+        fluxerr2 = table_row["FluxErrAp2"]
+        good_snr = fluxap2 >= snr*fluxerr2
+        
         ci_err = numpy.sqrt(merr1 ** 2 + merr2 ** 2)
 
         if not good_snr:

--- a/drizzlepac/haputils/photometry_tools.py
+++ b/drizzlepac/haputils/photometry_tools.py
@@ -150,7 +150,7 @@ def iraf_style_photometry(phot_apertures, bg_apertures, data, photflam, photplam
         if math.isclose(photflam, 0.0, abs_tol=constants.TOLERANCE):
             mag_err = mag
         else:
-            mag_err = 1.0857 * flux_error / flux
+            mag_err = 1.0857 * flux_error / flux if flux > 0.0 else np.inf
 
         # Build the final data table
         stacked = np.stack([flux, flux_error, mag, mag_err], axis=1)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1161](https://jira.stsci.edu/browse/HLA-1161)

<!-- describe the changes comprising this PR here -->
This PR addresses two issues in the HAP catalogs. 

1. Magnitude errors are being calculated as negative numbers, and these are used for threshold calculations. The threshold calculations then result in bad sources with good flags. 
2. Negative fluxes result in magnitude errors that are incorrect

This PR adds two fixes: 

1. A threshold calculation using flux errors (that will never be negative) instead of magnitude errors. 
3. Magnitude errors calculated using negative fluxes are set to infinity

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
