### PR TITLE
HLA-1164: Disable code that changes HAP catalog flag values

### DIFF
--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -580,8 +580,6 @@ def hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, p
             if saturation_flag[i]:
                 table_row["Flags"] = int(table_row["Flags"]) | 4
 
-        # phot_table_rows = flag4and8_hunter_killer(phot_table_rows, column_titles)
-
         if diagnostic_mode:
             phot_table_temp = phot_table_root + '_SATFILT.txt'
             phot_table_rows.write(phot_table_temp, delimiter=",", format='ascii')

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -580,7 +580,7 @@ def hla_saturation_flags(drizzled_image, flt_list, catalog_name, catalog_data, p
             if saturation_flag[i]:
                 table_row["Flags"] = int(table_row["Flags"]) | 4
 
-        phot_table_rows = flag4and8_hunter_killer(phot_table_rows, column_titles)
+        # phot_table_rows = flag4and8_hunter_killer(phot_table_rows, column_titles)
 
         if diagnostic_mode:
             phot_table_temp = phot_table_root + '_SATFILT.txt'

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -1612,43 +1612,6 @@ def xytord(xy_coord_array, image, image_ext, origin=1):
 
 # ======================================================================================================================
 
-
-def flag4and8_hunter_killer(catalog_data, column_titles):
-    """This function searches through photometry catalogs for sources whose flags contain
-    both bits 4 (multi-pixel saturation), and 8 (faint magnitude limit).
-    If found, the subroutine removes the "8" bit value from the set of flags for that source.
-
-    Parameters
-    ----------
-    catalog_data : astropy Table object
-        catalog data to process
-
-    column_titles : dictionary
-        Relevant column titles
-
-    Returns
-    -------
-    catalog_data : astropy Table object
-        input catalog data with updated flags
-    """
-    conf_ctr = 0
-    log.info("Searching for flag 4 + flag 8 conflicts....")
-    for catalog_line in catalog_data:
-        if ((catalog_line["Flags"] & 4 > 0) and (catalog_line["Flags"] & 8 > 0)):
-            conf_ctr += 1
-            catalog_line["Flags"] = int(catalog_line["Flags"]) - 8
-    if conf_ctr == 0:
-        log.info("No conflicts found.")
-    if conf_ctr == 1:
-        log.info("{} conflict fixed.".format(conf_ctr))
-    if conf_ctr > 1:
-        log.info("{} conflicts fixed.".format(conf_ctr))
-
-    return catalog_data
-
-# ======================================================================================================================
-
-
 def make_mask_array(drz_image):
     """
     Creates _msk.fits mask file that contains pixel values of 1 outside the drizzled image footprint and pixel values


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1164](https://jira.stsci.edu/browse/HLA-1164)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1706 

<!-- describe the changes comprising this PR here -->
This PR removed a previous function that tried to rflag spurious sources near bright sources. After an investigation, it was found that the code was not improving the catalog as hoped (see [full discussion here](https://innerspace.stsci.edu/pages/viewpage.action?spaceKey=CSB&title=Saturation+flag+in+HAP+catalogs) or within the jira ticket). 

The result of this change should be slightly fewer catalog sources flagged as 4 and 5, and more with higher numbers (e.g. 13, 14+). 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
