### PR TITLE
RT: Allow -dev jobs to fail

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -30,9 +30,20 @@ bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml=results.xml
 bc1.test_configs = [data_config]
 bc1.failedFailureThresh = 0
 
-bc2 = utils.copy(bc1)
+bc2 = new BuildConfig()
 bc2.name = '3.9-dev'
-bc2.build_cmds[1] = "pip install -r requirements-dev.txt --upgrade -e '.[test]'"
+bc2.nodetype = 'linux'
+bc2.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
+bc2.conda_packages = ['python=3.9']
+bc2.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson || true",
+                 "pip install -r requirements-dev.txt --upgrade -e '.[test]' || true"
+                 "pip freeze || true"]
+bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
+                "codecov || true"]
+bc1.test_configs = [data_config]
+// Apply a large failure threshold to prevent marking the pipeline job failed
+// when xunit ingests any test results
+bc1.failedFailureThresh = 1000
 
 bc3 = new BuildConfig()
 bc3.runtime.add('CFLAGS=-std=gnu99')


### PR DESCRIPTION
Test results and artifacts will continue to be reported and ingested from the `-dev` job, however it will not mark the entire run as failed when an error occurs. Rather, the pipeline will be marked "unstable" (yellow) until the failure conditions can be fixed up by a developer.