### PR TITLE
Update requirements-dev to not use eggs

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -36,7 +36,7 @@ bc2.nodetype = 'linux'
 bc2.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc2.conda_packages = ['python=3.9']
 bc2.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson || true",
-                 "pip install -r requirements-dev.txt --upgrade -e '.[test]' || true"
+                 "pip install -r requirements-dev.txt --upgrade -e '.[test]' || true",
                  "pip freeze || true"]
 bc1.test_cmds = ["pytest --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
                 "codecov || true"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
-git+https://github.com/astropy/photutils.git#egg=photutils
-git+https://github.com/spacetelescope/stsci.tools.git#egg=stsci.tools
-git+https://github.com/spacetelescope/stwcs.git#egg=stwcs
+git+https://github.com/astropy/photutils.git
+git+https://github.com/spacetelescope/stsci.tools.git
+git+https://github.com/spacetelescope/stwcs.git
+git+https://github.com/spacetelescope/stregion.git
 #git+https://github.com/astropy/astroquery.git#egg=astroquery
 --extra-index-url https://pypi.anaconda.org/astropy/simple astropy --pre
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->

This PR changes requirements-dev.txt to not install eggs, which causes problems for the regression tests on Jenkins, and fixes a typo in JenkinsfileRT. Thanks to @jhunkeler for pointing the solution.

Regression tests passing here

https://plwishmaster.stsci.edu:8081/job/RT/job/Drizzlepac-Developers-Pull-Requests/42/


<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
