### PR TITLE
HLA-1203: Bug fix for HCALDP Reunion 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,6 @@
 [project]
 name = 'drizzlepac'
-description = """
-    HST image combination using the drizzle algorithm to
-    combine astronomical images, to model image distortion,
-    to remove cosmic rays, and
-    generally to improve the fidelity of data in the final image.
-    """
+description = """ HST image combination using the drizzle algorithm to combine astronomical images, to model image distortion, to remove cosmic rays, and generally to improve the fidelity of data in the final image. """
 readme = { file = 'README.md', content-type = 'text/x-rst' }
 requires-python = '>=3.9'
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
This PR should address a deprecation warning in the building of drizzlepac for the recent HCALDP Reunion branch build. The error is:

```
 writing /srv/jenkins/tmp/pip-modern-metadata-lp4ht0h1/drizzlepac.egg-info/PKG-INFO
 /srv/jenkins/tmp/pip-build-env-w6qtofwu/overlay/lib/python3.11/site-packages/setuptools/_core_metadata.py:157: SetuptoolsDeprecationWarning: Invalid config.
  !!

          ********************************************************************************
          newlines are not allowed in `summary` and will break in the future
          ********************************************************************************

  !!
```

This fix moves the description in the pyproject.toml from multiple lines to one line. The summary in the PKGINFO appears to be taken from the pyproject.toml description. 


**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
