### PR TITLE
HLA-1144: Runastrodriz: handle an empty list generated by do_verify_guiding

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -529,9 +529,13 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
         _good_images = [f for f in _calfiles if fits.getval(f, 'exptime') > 0.]
         _good_images = [f for f in _good_images if fits.getval(f, goodpix_name, ext=("SCI", 1)) > 0.]
         if len(_good_images) == 0:
-            _good_images = _calfiles
-            # Turn off alignment to GAIA since there is no valid data in the exposure.
-            align_to_gaia = False
+            if len(_calfiles)==0:
+                print("ERROR: No valid data found in input exposures.")
+                sys.exit(analyze.Ret_code.NO_VIABLE_DATA.value)
+            else:
+                _good_images = _calfiles
+                # Turn off alignment to GAIA since there is no valid data in the exposure.
+                align_to_gaia = False        
 
         if not wfpc2_input:
             adriz_pars = mdzhandler.getMdriztabParameters(_good_images)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1144: <Fix a bug> -->
Resolves [HLA-1144](https://jira.stsci.edu/browse/HLA-1144)


<!-- describe the changes comprising this PR here -->
This PR addresses an issue when do_verify_guiding removes all of the usable datasets and results in a nonspecific error. This fix implements a system exit code of 65 (NO VIABLE DATA) in the cases when do_verify_guiding results in no god data and the force=True flag is not enabled. 

**Checklist for maintainers**
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

[Jenkins test](https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FDrizzlepac-Developers-Pull-Requests/detail/Drizzlepac-Developers-Pull-Requests/53/pipeline/335)