### PR TITLE
SVM: Reconcile removal of bad segments from segmentation image with removal of corresponding rows from the "total" or white light source catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,18 +19,18 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 
 
-3.7.1 (unreleased)
-=====================
+3.7.0rc2 (22-Mar-2024) Infrastructure Build
+===========================================
+
+- Force the identified bad rows to be removed from the total (aka white light)
+  source catalog before the corresponding bad segments are removed from the
+  segmentation image. [#1771]
 
 - Reverted PR #1222 allowing pixels to be filled with available data where WHT=0. [#1767]
 
 - Improved calculation of S_REGION using dialation and erosion. [#1762]
 
 - Skycell added to flt(c) and drz(c) science headers for the pipeline and svm products. [#1729]
-
-
-3.7.0rc1 (22-Feb-2024) Infrastructure Build
-===========================================
 
 - Update project.toml file to specify numpy>=1.18,  <2.0 [#1743]
 
@@ -60,6 +60,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   
 - Initial setup for Architectural Design Records used to keep track of top-level
   thinking behind the code. [#1697]
+
 
 3.6.2 (27-Nov-2023)
 ===================


### PR DESCRIPTION
To remove bad rows from the "total" or white light source catalog, as well
as to remove the corresponding segments from the segmentation image, ensure the rows are first eliminated from the catalog before the segments are
removed from the segmentation image and reordered.   This dataset
seems to reveal an awareness by the catalog as the row lists, both
good and bad, based upon the original segment ordering cause a fatal
error if the segmentation image is trimmed/re-ordered before the catalog
rows are removed.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1238](https://jira.stsci.edu/browse/HLA-1238)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses ...

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
