### PR TITLE
Update pyproject.toml to force use of stsci-imagestats>=1.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'matplotlib',
     'stsci.tools>=4.0',
     'stsci.image>=2.3.4',
-    'stsci.imagestats',
+    'stsci.imagestats>=1.8.1',
     'stsci.skypac>=1.0.9',
     'stsci.stimage',
     'stwcs>=1.5.3',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1222: <Fix a bug> -->
Resolves [HLA-1222](https://jira.stsci.edu/browse/HLA-1222)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
The stsci-imagestats v1.8.0 package contains a bug which causes drizzlepac to fail regression testing during the creation of an HSTDP release candidate.  Since the build/release candidate sequence is already in play, and the stsci-imagestats package is not on the list of a package which can be specified in the build GUI, the only way to force use of the latest version of stsci-imagestats is to have it specified in the pyproject.toml file of drizzlepac.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
