### PR TITLE
Newcandidate 370rc3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.7.0rc2 (22-Mar-2024) Infrastructure Build
 ===========================================
 
+- Modified the pyproject.toml file in order to force the use of
+  stsci-imagestats >= 1.8.1.  Version 1.8.1 contains a bug fix which caused
+  drizzlepac to fail in Linux machines.  It was necessary to force this 
+  change as the build sequence is "in progress" and will not allow changes
+  to non-domestic packages until the build sequence is complete.
+
 - Force the identified bad rows to be removed from the total (aka white light)
   source catalog before the corresponding bad segments are removed from the
   segmentation image. [#1771]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'matplotlib',
     'stsci.tools>=4.0',
     'stsci.image>=2.3.4',
-    'stsci.imagestats',
+    'stsci.imagestats>=1.8.1',
     'stsci.skypac>=1.0.9',
     'stsci.stimage',
     'stwcs>=1.5.3',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1222: <Fix a bug> -->
Resolves [HLA-1222](https://jira.stsci.edu/browse/HLA-1222)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Modified the pyproject.toml file in order to force the use of stsci-imagestats >= 1.8.1.  Version 1.8.1 contains a bug fix for lesser versions which caused drizzlepac to fail in Linux machines. 

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
