### PR TITLE
HLA-727 Description of Exit Codes in documentation

### DIFF
--- a/doc/source/mast_data_products/hap_api.rst
+++ b/doc/source/mast_data_products/hap_api.rst
@@ -21,6 +21,9 @@ runsinglehap.py is the module which controls the SVM processing.
 
 runmultihap.py is the module which controls the MVM processing.
 
+Sucessful code will result in an exit code of 0.  If there is an error, the exit code will be non-zero. 
+An exit code of 55 is for data containing only SBC or HRC data, and an exit code of 65 is for "no viable data".
+
 .. toctree:: 
     :maxdepth: 1
 

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -101,7 +101,7 @@ class Messages(Enum):
     Define a local classification for OK, Warning, and NoProcess messages
     """
 
-    OK, WARN, NOPROC = 1, -1, -2
+    WARN, NOPROC = -1, -2
 
 
 def mvm_analyze_wrapper(input_filename, log_level=logutil.logging.DEBUG):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-727](https://jira.stsci.edu/browse/HLA-727)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1302 

<!-- describe the changes comprising this PR here -->
This PR adds documentaion describing the HAP exit codes. This includes a couple of short sentences host on the main HAP API readthedocs page. 

An additional warning code (not currently in use) was removed to avoid confusion as the code for _okay_ was the same as _error_ in another Class. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
