### PR TITLE
HLA-1243: final_bits value change in config json for single WFC3/IR SVM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.7.0rc2 (22-Mar-2024) Infrastructure Build
 ===========================================
 
+- Updated config json to exclude bad pixels in single WFC3/IR SVM processing. [#1783]
+
 - Force the identified bad rows to be removed from the total (aka white light)
   source catalog before the corresponding bad segments are removed from the
   segmentation image. [#1771]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,22 +19,26 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 
 
-3.7.0rc2 (22-Mar-2024) Infrastructure Build
-===========================================
+3.7.1 (unreleased)
+======================
 
 - Updated config json to exclude bad pixels in single WFC3/IR SVM processing. [#1783]
-
-- Force the identified bad rows to be removed from the total (aka white light)
-  source catalog before the corresponding bad segments are removed from the
-  segmentation image. [#1771]
 
 - Bug fix for mdriztab=True option in Astrodrizzle previously overwriting user inputs. [#1774]
 
 - Reverted PR #1222 allowing pixels to be filled with available data where WHT=0. [#1767]
 
+- Force the identified bad rows to be removed from the total (aka white light)
+  source catalog before the corresponding bad segments are removed from the
+  segmentation image. [#1771]
+
 - Improved calculation of S_REGION using dialation and erosion. [#1762]
 
 - Skycell added to flt(c) and drz(c) science headers for the pipeline and svm products. [#1729]
+  
+
+3.7.0 (02-Apr-2024)
+===================
 
 - Update project.toml file to specify numpy>=1.18,  <2.0 [#1743]
 

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n1.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfc3/ir/wfc3_ir_astrodrizzle_any_n1.json
@@ -73,7 +73,7 @@
         "driz_combine": true,
         "final_pixfrac": 1.0,
         "final_fillval": null,
-        "final_bits": "65535",
+        "final_bits": "528",
         "final_maskval": null,
         "final_wht_type": "EXP",
         "final_kernel": "square",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1243](https://jira.stsci.edu/browse/HLA-1243)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1780 

<!-- describe the changes comprising this PR here -->
This PR updates the final_bits value in the WFC3/IR SVM config file from 65535 to 528.

Some context from Jenn Mack

> Previously we treated all DQ flags as good pixels (final_bits=65535) with the idea that bad pixels typically do less harm than interpolating over those bad pixels (e.g. near the core of a star where the slope of the PSF is changing rapidly).
> 
> Single IR frames are more likely to be direct image counterparts of grism observations and are thus usually faint targets whose photometry would be more impacted by bad pixels. 
> 
> Therefore we want to treat DQ flags as bad pixels and reject them from the drizzled output.  The exception is DQ 512 (IR blobs) + DQ 16 (stable hot pixels), which are recommended to be okay by the WFC3 team, so we set final_bits= 528 to keep this pixels.

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [x] updated relevant documentation
- [ ] added relevant milestone
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
