### PR TITLE
HLA-1222: Remove the restriction on the version of stsci.imagestats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     'matplotlib',
     'stsci.tools>=4.0',
     'stsci.image>=2.3.4',
-    'stsci.imagestats>=1.8.1',
+    'stsci.imagestats',
     'stsci.skypac>=1.0.9',
     'stsci.stimage',
     'stwcs>=1.5.3',


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1222 <Fix a bug> -->
Resolves [HLA-1222](https://jira.stsci.edu/browse/HLA-1222)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Remove the restriction on the stsci.imagestats package version.  This is specifically to help with the generation of a release candidate as a build sequence with is already in-play.  We need to use an older version of stsci.imagestats (1.6.3) at this time, and the previous release candidate was manually installed to force the use of stsci.imagestats 1.6.3.  This means the next release candidate is automatically restricted to use the same version of the package (which is what we want).

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
