### PR TITLE
HLA-1138: Exclude single filter images in the generation of the total detection image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 ======================
 - Exclude single filter images from the generation of the total detection
   image to minimize cosmic ray contamination, unless there are only single
-  filter images in the visit. [#nnnn]
+  filter images in the visit. [#1797]
 
 - Implemented a series of bug fixes for the segmentation catalog [#1793]
 - Define the threshold image to be (nsigma * background_rms).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ======================
+- Exclude single filter images from the generation of the total detection
+  image to minimize cosmic ray contamination, unless there are only single
+  filter images in the visit. [#nnnn]
+
 - Implemented a series of bug fixes for the segmentation catalog [#1793]
 - Define the threshold image to be (nsigma * background_rms).
 - Fixed bug in the generation of the threshold image - ensure the final

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -632,6 +632,7 @@ class TotalProduct(HAPProduct):
 
         .. note:: Cosmic-ray identification is NOT performed when creating the total detection image.
         """
+
         # This insures that keywords related to the footprint are generated for this
         # specific object to use in updating the output drizzle product.
         self.meta_wcs = meta_wcs
@@ -657,7 +658,41 @@ class TotalProduct(HAPProduct):
             )
         )
 
-        edp_filenames = [element.full_filename for element in self.edp_list]
+        # Determine if there are any single exposure filter images which 
+        # should NOT be used in the computation of the total detection image in
+        # order to minimize cosmic ray contamination
+        #
+        # Determine the unique filters in the total product and create a
+        # dictionary to hold the filter name and the number of exposures per filter
+        set_of_filters = set([element.filters for element in self.edp_list])
+        count_dict = {key: [] for key in set_of_filters}
+
+        # Loop over the exposure objects to collect the exposures for each filter
+        for expo in self.edp_list:
+            for key in count_dict:
+                if key == expo.filters:
+                    count_dict[key].append(expo.full_filename)
+                    break
+
+        # Accumulate the exposure file names for only the filters which have
+        # more than one exposure
+        exclude_string = []
+        edp_filenames = []
+        for key, value in count_dict.items():
+            if len(value) > 1:
+                edp_filenames += value
+            else:
+                exclude_string.append("Excluding single exposure filter image {} for {}.".format(value, key))
+
+        # However, if all the filters only have one exposure, just use all
+        # the exposures
+        if not edp_filenames:
+            for value in count_dict.values():
+                edp_filenames += value
+        else:
+            for entry in exclude_string:
+                log.info(entry)
+
         astrodrizzle.AstroDrizzle(
             input=edp_filenames, output=self.drizzle_filename, **drizzle_pars
         )
@@ -803,7 +838,7 @@ class FilterProduct(HAPProduct):
         )
 
         edp_filenames = [element.full_filename for element in self.edp_list]
-
+    
         if len(edp_filenames) == 1:
             drizzle_pars["resetbits"] = "0"  # Use any pixels already flagged as CRs
 

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -662,17 +662,10 @@ class TotalProduct(HAPProduct):
         # should NOT be used in the computation of the total detection image in
         # order to minimize cosmic ray contamination
         #
-        # Determine the unique filters in the total product and create a
-        # dictionary to hold the filter name and the number of exposures per filter
-        set_of_filters = set([element.filters for element in self.edp_list])
-        count_dict = {key: [] for key in set_of_filters}
-
         # Loop over the exposure objects to collect the exposures for each filter
+        count_dict = {}
         for expo in self.edp_list:
-            for key in count_dict:
-                if key == expo.filters:
-                    count_dict[key].append(expo.full_filename)
-                    break
+            count_dict.setdefault(expo.filters, []).append(expo.full_filename)
 
         # Accumulate the exposure file names for only the filters which have
         # more than one exposure
@@ -689,6 +682,7 @@ class TotalProduct(HAPProduct):
         if not edp_filenames:
             for value in count_dict.values():
                 edp_filenames += value
+            log.info("All filters are single exposures, so all exposures are included.")
         else:
             for entry in exclude_string:
                 log.info(entry)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1138(https://jira.stsci.edu/browse/HLA-1138)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...
Exclude single filter images in the generation of the total detection
image to minimize cosmic ray contamination, unless there are only single filter images in the visit.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
