### PR TITLE
WIP: HLA-1251: Include "modest" sized sources on the deblend list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,11 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ======================
+- Added the modest and smaller sized segments (segments < kernel size) to
+  the list of segments to be deblended.  These segments were inadvertently
+  left off the deblending list when the code was updated to handle enormously
+  large segments. [#]
+
 - Exclude single filter images from the generation of the total detection
   image to minimize cosmic ray contamination, unless there are only single
   filter images in the visit. [#1797]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Added the modest and smaller sized segments (segments < kernel size) to
   the list of segments to be deblended.  These segments were inadvertently
   left off the deblending list when the code was updated to handle enormously
-  large segments. [#]
+  large segments. [#1801]
 
 - Exclude single filter images from the generation of the total detection
   image to minimize cosmic ray contamination, unless there are only single

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2794,6 +2794,10 @@ class HAPSegmentCatalog(HAPCatalogBase):
         segm_img.big_segments = None
         big_segments = np.where(segm_img.areas >= deb_limit)[0] + 1  # Segment labels are 1-based
 
+        # Get the labels of the modest sized segments as these should also be
+        # deblended as necessary
+        modest_segments = np.where(segm_img.areas < deb_limit)[0] + 1
+
         # The biggest_source may be > max_biggest_source indicating there are "big islands"
         # and is_poor_quality should be set to True.  The is_poor_quality is only an indicator that
         # a different kernel type or background computation could be tried for improved results.
@@ -2841,9 +2845,16 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 segm_img.big_segments = big_segments
             else:
                 segm_img.big_segments = None
-            log.info("Total number of sources suitable for deblending: {}".format(len(big_segments)))
+            log.info("Total number of big sources suitable for deblending: {}".format(len(big_segments)))
         else:
             log.info("There are no big segments larger than the deblending limit.")
+
+        # Add the modest sized segments to the deblending array
+        if modest_segments.size > 0 and segm_img.big_segments is not None:
+            segm_img.big_segments = np.concatenate((segm_img.big_segments, modest_segments))
+        elif modest_segments.size > 0:
+            segm_img.big_segments =  modest_segments
+        log.info("Total number of all sources suitable for deblending: {}".format(len(segm_img.big_segments)))
 
         # Always compute the source_fraction so the value can be reported.  Setting the
         # big_island_only parameter allows control over whether the source_fraction should

--- a/tests/hap/test_alignpipe_randomlist.py
+++ b/tests/hap/test_alignpipe_randomlist.py
@@ -56,6 +56,7 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.bigdata
 @pytest.mark.slow
 @pytest.mark.unit
+@pytest.mark.skip(reason="Test designed to run *large* numbers of datasets for alignment statistics.")
 def test_alignpipe_randomlist(tmpdir, dataset):
     """ Tests which validate whether mosaics can be aligned to an astrometric standard.
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1251](https://jira.stsci.edu/browse/HLA-1251)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...
Added the "modest" sized sources (segments < kernel size) to the
deblending list as these sources need deblending too.  During the update to ease the burden of deblending enormously large sources where the largest sources are ignored, the modest sized sources did not get added to the deblending list as an oversight.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
