### PR TITLE
Update align_utils.py

### DIFF
--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -20,7 +20,8 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 from astropy.modeling import models, fitting
 
-from photutils import background, DAOStarFinder
+from photutils import background
+from photutils.detection import DAOStarFinder
 from photutils.background import Background2D
 from photutils.utils import NoDetectionsWarning
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses a deprecation warning when DAOStarFinder is imported. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
