### PR TITLE
update change log entry for release ahead of Numpy 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ number of the code change for that issue.  These PRs can be viewed at:
     https://github.com/spacetelescope/drizzlepac/pulls
 
 
-3.7.1 (unreleased)
+3.7.1 (2024-06-12)
 ==================
 
 - Removed the use of a custom smoothing kernel based upon actual image
@@ -78,6 +78,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Skycell added to flt(c) and drz(c) science headers for the pipeline and svm products. [#1729]
 
 - resolved ``AstropyDeprecationWarning`` s [#1798]
+
+- build wheels with Numpy 2.0 release candidate ahead of Numpy 2.0 release [#1806]
 
 3.7.0 (02-Apr-2024)
 ===================


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->


<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
We should make a release ahead of the Numpy 2.0 release next week including the pin of `numpy>=2.0.0rc2` in the build requirements, so that user installs and tests don't immediately fail next Wednesday when Numpy 2.0 is released.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
