### PR TITLE
Move environment variable declaration into env_vars list

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -52,9 +52,9 @@ bc1.test_configs = [data_config]
 bc1.failedFailureThresh = 1000
 
 bc3 = new BuildConfig()
-bc3.runtime.add('CFLAGS=-std=gnu99')
 bc3.nodetype = 'linux'
-bc3.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
+bc3.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory',
+                'CFLAGS=-std=gnu99']
 bc3.name = '3.11'
 bc3.conda_packages = ['python=3.11']
 bc3.build_cmds = ["pip install numpy astropy ci-watson",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -44,12 +44,12 @@ bc2.conda_packages = ['python=3.10']
 bc2.build_cmds = ["pip install numpy astropy codecov pytest-cov ci-watson || true",
                  "pip install -r requirements-dev.txt --upgrade -e '.[test]' || true",
                  "pip freeze || true"]
-bc1.test_cmds = ["pytest --env=${artifactory_env} --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
+bc2.test_cmds = ["pytest --env=${artifactory_env} --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
                 "codecov || true"]
-bc1.test_configs = [data_config]
+bc2.test_configs = [data_config]
 // Apply a large failure threshold to prevent marking the pipeline job failed
 // when xunit ingests any test results
-bc1.failedFailureThresh = 1000
+bc2.failedFailureThresh = 1000
 
 bc3 = new BuildConfig()
 bc3.nodetype = 'linux'


### PR DESCRIPTION
The sparse implementation of the `BuildConfig` class in `testenv`'s groovy "accessor" does not include the `runtime` list member.

```
Applying environment variables...
Traceback (most recent call last):
  File "***/local/miniforge3/envs/TEMPORARY/bin/testenv", line 33, in <module>
    sys.exit(load_entry_point('testenv', 'console_scripts', 'testenv')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***/testenv/testenv/cli/main.py", line 135, in main
    context = TestContext(pkg)
              ^^^^^^^^^^^^^^^^
  File "***/testenv/testenv/testcontext.py", line 108, in __init__
    self.apply_env_vars()
  File "***/testenv/testenv/testcontext.py", line 191, in apply_env_vars
    key, value = var.split('=')
```

The real error was:

```
$ groovy testenv/scripts/jfile_accessor.groovy REPO/JenkinsfileRT test_cmds
Caught: groovy.lang.MissingPropertyException: No such property: env for class: JenkinsfileRT
groovy.lang.MissingPropertyException: No such property: env for class: JenkinsfileRT
        at JenkinsfileRT.run(JenkinsfileRT:6)
```
