### PR TITLE
Correct the arguments being passed to Photutils InteractivePSFPhotometry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,4 @@
 .. _release_notes:
-
 ========================
 DrizzlePac Release Notes
 ========================
@@ -20,8 +19,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ==================
-- Corrected parameters being sent to InteractivePSFPhotometry() as the 
-  original update [#1798] passed deprecated arguments. 
+- Corrected arguments being sent to InteractivePSFPhotometry() as the 
+  original update [#1798] passed deprecated arguments. [#1827]
 
 - Corrected the way that the number of constituent images are accumulated
   per pixel by ensuring each contributing pixel has a finite value and 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ==================
+- Corrected parameters being sent to InteractivePSFPhotometry() as the 
+  original update [#1798] passed deprecated arguments. 
+
 - Corrected the way that the number of constituent images are accumulated
   per pixel by ensuring each contributing pixel has a finite value and 
   is not zero. [#1820]

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -874,12 +874,12 @@ def find_fwhm(psf, default_fwhm):
     gaussian_prf.sigma.fixed = False
     try:
         itr_phot_obj = IterativePSFPhotometry(finder=iraffind,
-                                              group_maker=daogroup,
-                                              bkg_estimator=mmm_bkg,
+                                              grouper=daogroup,
+                                              localbkg_estimator=mmm_bkg,
                                               psf_model=gaussian_prf,
                                               fitter=fitter,
-                                              fitshape=(11, 11),
-                                              niters=2)
+                                              fit_shape=(11, 11),
+                                              maxiters=2)
         phot_results = itr_phot_obj(psf)
     except Exception:
         log.error("The find_fwhm() failed due to problem with fitting.")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-nnnn](https://jira.stsci.edu/browse/HLA-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Corrected the arguments being passed to the InteractivePSFPhotometry function which replaced a similar, but deprecated, function.  The deprecated function, InterativelySubtractPSFPhotometry, had differently named arguments which were not updated when the deprecated function was updated.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
