### PR TITLE
Restrict photutils in pyproject.toml file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,8 +79,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Improved calculation of S_REGION using dialation and erosion. [#1762]
 
 - Skycell added to flt(c) and drz(c) science headers for the pipeline and svm products. [#1729]
-
-- resolved ``AstropyDeprecationWarning`` s [#1798]
+  
 
 3.7.0 (02-Apr-2024)
 ===================

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -61,8 +61,8 @@ from photutils.detection import DAOStarFinder, find_peaks
 
 from photutils.background import (Background2D, MMMBackground,
                                   SExtractorBackground, StdBackgroundRMS)
-from photutils.psf import (IntegratedGaussianPRF, SourceGrouper,
-                           IterativePSFPhotometry)
+from photutils.psf import (IntegratedGaussianPRF, DAOGroup,
+                           IterativelySubtractedPSFPhotometry)
 
 from tweakwcs.correctors import FITSWCSCorrector
 from stwcs.distortion import utils
@@ -847,8 +847,8 @@ def find_fwhm(psf, default_fwhm):
     """Determine FWHM for auto-kernel PSF
 
     This function iteratively fits a Gaussian model to the extracted PSF
-    using `photutils.psf.IterativePSFPhotometry
-    <https://photutils.readthedocs.io/en/stable/api/photutils.psf.IterativePSFPhotometry.html>`_
+    using `photutils.psf.IterativelySubtractedPSFPhotometry
+    <https://photutils.readthedocs.io/en/stable/api/photutils.psf.IterativelySubtractedPSFPhotometry.html>`_
     to determine the FWHM of the PSF.
 
     Parameters
@@ -865,7 +865,7 @@ def find_fwhm(psf, default_fwhm):
         Value of the computed Gaussian FWHM for the PSF
 
     """
-    daogroup = SourceGrouper(min_separation=8)
+    daogroup = DAOGroup(crit_separation=8)
     mmm_bkg = MMMBackground()
     iraffind = DAOStarFinder(threshold=2.5 * mmm_bkg(psf), fwhm=default_fwhm)
     fitter = LevMarLSQFitter()
@@ -873,13 +873,13 @@ def find_fwhm(psf, default_fwhm):
     gaussian_prf = IntegratedGaussianPRF(sigma=sigma_psf)
     gaussian_prf.sigma.fixed = False
     try:
-        itr_phot_obj = IterativePSFPhotometry(finder=iraffind,
-                                              group_maker=daogroup,
-                                              bkg_estimator=mmm_bkg,
-                                              psf_model=gaussian_prf,
-                                              fitter=fitter,
-                                              fitshape=(11, 11),
-                                              niters=2)
+        itr_phot_obj = IterativelySubtractedPSFPhotometry(finder=iraffind,
+                                                          group_maker=daogroup,
+                                                          bkg_estimator=mmm_bkg,
+                                                          psf_model=gaussian_prf,
+                                                          fitter=fitter,
+                                                          fitshape=(11, 11),
+                                                          niters=2)
         phot_results = itr_phot_obj(psf)
     except Exception:
         log.error("The find_fwhm() failed due to problem with fitting.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "spherical_geometry>=1.2.22",
     "astroquery>=0.4",
     "astrocut<=0.9",
-    "photutils>1.5.0",
+    "1.5.0<photutils<1.13.0",
     "lxml",
     "PyPDF2",
     "scikit-image>=0.14.2",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-nnnn](https://jira.stsci.edu/browse/HLA-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR temporarily restricts the version of Photutils allowed to be used until the functions which will be removed once Photutils 1.13.0 is released are properly replaced and thoroughly tested. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
