### PR TITLE
Testing readthedocs mambaforge versions to fix build failures. 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-23.11"
 
 conda:
   environment: doc/.rtd-environment.yml


### PR DESCRIPTION
The mambforge build version for readthedocs has been updated form 4.10 to 23.11. 