### PR TITLE
Update manageInputCopies to work if input files aren't in working directory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,12 +22,15 @@ number of the code change for that issue.  These PRs can be viewed at:
 ==================
 - Reverted #1798 until further testing is done with Photutils.
 
+- ``manageInputCopies`` now copies successfully even if the original files were
+defined by full paths rather than being in the current working directory. [#1835]
+
 - Corrected the way that the number of constituent images are accumulated
-  per pixel by ensuring each contributing pixel has a finite value and 
+  per pixel by ensuring each contributing pixel has a finite value and
   is not zero. [#1820]
 
-- Within the HAP configuration files, increased the minimum number of matches 
-  for a successful "rscale" fit from 6 to 10, and removed "shift" as a fit geometry 
+- Within the HAP configuration files, increased the minimum number of matches
+  for a successful "rscale" fit from 6 to 10, and removed "shift" as a fit geometry
   option. [#1823].
 
 - Removed the use of a custom smoothing kernel based upon actual image
@@ -37,9 +40,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Addressed bugs caught by SonarQube static code analysis.  Interface
   changes listed here: Added missing input data parameter to the create_output
-  calls, Added missing log level to run function, Removed the deprecated 
-  parameter, dao_threshold, from astrometric_utils.py/extract_sources, removed 
-  "ivmlist" parameter from the interface of multiple functions in processInput.py 
+  calls, Added missing log level to run function, Removed the deprecated
+  parameter, dao_threshold, from astrometric_utils.py/extract_sources, removed
+  "ivmlist" parameter from the interface of multiple functions in processInput.py
   as it is an output parameter (buildFileListOrig, buildFileList, checkMultipleFiles,
   and process_input), and addressed missing parameters in the calls to
   get_ci_info and get_ci_from_file.. [#1802]
@@ -64,12 +67,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Created a new method, ricker_matched_kernel(), to generate the RickerWavelet2DKernel
   properly. Sigma is now provided, versus the FWHM, to the RickerWavelet2dKernel
-  constructor, and the normalization is handled by the new method where the 
+  constructor, and the normalization is handled by the new method where the
   normalization causes the RickerWavelet core to match the Gaussian core.  [#1791]
 
 - Added contributors guide to readthedocs. [#1787]
 
-- Removed "tophat" as a kernel option, added warnings for "gaussian" and "lanczos3" 
+- Removed "tophat" as a kernel option, added warnings for "gaussian" and "lanczos3"
   that they may not be conserving flux. [#1786]
 
 - Updated config json to exclude bad pixels in single WFC3/IR SVM processing. [#1783]
@@ -85,7 +88,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Improved calculation of S_REGION using dialation and erosion. [#1762]
 
 - Skycell added to flt(c) and drz(c) science headers for the pipeline and svm products. [#1729]
-  
+
 
 3.7.0 (02-Apr-2024)
 ===================
@@ -109,13 +112,13 @@ number of the code change for that issue.  These PRs can be viewed at:
   error under Python 3.12. [#1714]
 
 - Reorganized the readthedocs documentation with the help of various STScI
-  staff. [#1717] 
+  staff. [#1717]
 
 - Updates requirements-dev.txt to not install eggs that cause problems
   for the regression tests [#1721]
 
 - Regression Testing: allow "dev" jobs to fail [#1718]
-  
+
 - Initial setup for Architectural Design Records used to keep track of top-level
   thinking behind the code. [#1697]
 
@@ -127,15 +130,15 @@ number of the code change for that issue.  These PRs can be viewed at:
   package.  [#1689]
 
 - Added functionality to allow the use of a two-column poller file. This is used
-  to update the WFPC2 SVM aperture header keywords from the values in the poller 
+  to update the WFPC2 SVM aperture header keywords from the values in the poller
   file. [#1683]
 
 - Removed the version restriction on matplotlib. [#1649]
 
-- Forced a preferential order on the final selection of the WCS solution 
-  from the common pool of solutions among all input exposurea.  All input images 
-  need to have the same WCSNAME (same WCS solution) when performing pipeline 
-  alignment to avoid imprinting differences from one catalog to another on the 
+- Forced a preferential order on the final selection of the WCS solution
+  from the common pool of solutions among all input exposurea.  All input images
+  need to have the same WCSNAME (same WCS solution) when performing pipeline
+  alignment to avoid imprinting differences from one catalog to another on the
   final fit and destroying the relative alignment. [#1645, #1638]
 
 - Redesigned the overall structure of the documentation, readthedocs, for the
@@ -143,18 +146,18 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Addressed a bug in the calculation of measurements for each detected source
   in the filter catalogs. The detection catalog, based upon the "total" image,
-  is now used in the correct manner to define the source centroids and shape 
-  properties.  In addition, these properties are used to perform aperture 
+  is now used in the correct manner to define the source centroids and shape
+  properties.  In addition, these properties are used to perform aperture
   photometry. [#1614]
 
-- Updated the HAP drizzle parameters for WFPC2. The primary change includes 
-  changing skymethod='localmin' from the prior 'match' which did not work well 
+- Updated the HAP drizzle parameters for WFPC2. The primary change includes
+  changing skymethod='localmin' from the prior 'match' which did not work well
   for the overlapping chips. [#1617]
 
 - Corrected reference catalog weights from being proportional to sigma to
   the proper 1/sigma**2. [#1616]
 
-- Removed the use of the shadow mask as an initial step in addressing the WFPC2 
+- Removed the use of the shadow mask as an initial step in addressing the WFPC2
   chip gaps [#1551]
 
 - Fixed a bug in processing of the ``group`` argument due to which the code
@@ -172,7 +175,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Fixed projection cell identification in overlapping regions. [#1572]
 
 - Force the version of matplotlib to be <= 3.6.3 as the newer versions of
-  the library cause problems with the calcloud preview generation. [#1571] 
+  the library cause problems with the calcloud preview generation. [#1571]
 
 3.6.0 (12-Jun-2023)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Reverted #1798 until further testing is done with Photutils.
 
 - ``manageInputCopies`` now copies successfully even if the original files were
-defined by full paths rather than being in the current working directory. [#1835]
+  defined by full paths rather than being in the current working directory. [#1835]
 
 - Corrected the way that the number of constituent images are accumulated
   per pixel by ensuring each contributing pixel has a finite value and

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -73,7 +73,7 @@ def setCommonInput(configObj, createOutwcs=True, overwrite_dict={}):
     createOutwcs : bool
         whether of not to update the output WCS infomation
     overwrite_dict: dict
-        dictionary of user input paramters to overwrite in configObj 
+        dictionary of user input paramters to overwrite in configObj
         (needed in particular for using mdriztab=True option)
 
     Notes
@@ -655,14 +655,14 @@ def _process_input_wcs_single(fname, wcskey, updatewcs):
         wcscorr.init_wcscorr(fname)
 
 
-def buildFileList(input, output=None, 
+def buildFileList(input, output=None,
                 wcskey=None, updatewcs=True, **workinplace):
     """
     Builds a file list which has undergone various instrument-specific
     checks for input to MultiDrizzle, including splitting STIS associations.
     """
     newfilelist, ivmlist, output, oldasndict, filelist = \
-        buildFileListOrig(input=input, output=output, 
+        buildFileListOrig(input=input, output=output,
                     wcskey=wcskey, updatewcs=updatewcs, **workinplace)
     return newfilelist, ivmlist, output, oldasndict
 
@@ -924,8 +924,8 @@ def manageInputCopies(filelist, **workinplace):
     # check to see if copies already exist for each file
     for fname in filelist:
         copymade = False # If a copy is made, no need to restore
-        copyname = os.path.join(origdir,fname)
-        short_copyname = os.path.join('OrIg_files',fname)
+        copyname = os.path.join(origdir, os.path.basename(fname))
+        short_copyname = os.path.join('OrIg_files', os.path.basename(fname))
         if workinplace['overwrite']:
             print('Forcibly archiving original of: ',fname, 'as ',short_copyname)
             # make a copy of the file in the sub-directory


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses the case where the input filenames to `manageInputCopies` are full paths rather than base names. Previously, specifying a full path (for example if the input files were in a temp directory, like in the unit test I was trying to write for another package) would result in a `shutil.sameFileError` because the `copyname` would end up unchanged from the input. With this patch that case works.

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

[jenkins test](https://plwishmaster.stsci.edu:8081/job/RT/job/Drizzlepac-Developers-Pull-Requests/90/)
