### PR TITLE
[Jenkins] fix install conflicts in `3.11-dev` job

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -45,7 +45,8 @@ bc2.nodetype = 'linux'
 bc2.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc2.conda_packages = ['python=3.11']
 bc2.build_cmds = ["pip install numpy astropy pytest-cov ci-watson || true",
-                 "pip install -r requirements-dev.txt --upgrade -e '.[test]' || true",
+                 "pip install --upgrade -e '.[test]' || true",
+                 "pip install -r requirements-dev.txt' || true",
                  "pip freeze || true"]
 bc2.test_cmds = ["pytest --env=${artifactory_env} --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
                  "${codecov_install}",

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -46,7 +46,7 @@ bc2.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc2.conda_packages = ['python=3.11']
 bc2.build_cmds = ["pip install numpy astropy pytest-cov ci-watson || true",
                  "pip install --upgrade -e '.[test]' || true",
-                 "pip install -r requirements-dev.txt' || true",
+                 "pip install -r requirements-dev.txt || true",
                  "pip freeze || true"]
 bc2.test_cmds = ["pytest --env=${artifactory_env} --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
                  "${codecov_install}",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses install issues in the `3.11-dev` Jenkins job where `stsci.tools` is not installed:
[<img width="701" alt="image" src="https://github.com/user-attachments/assets/3d768d56-f9d1-459e-a64d-6debf31c29ac">](https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FDrizzlepac-Developers-Pull-Requests/detail/Drizzlepac-Developers-Pull-Requests/96/pipeline/251#step-254-log-20)

It appears that multiple dependencies are missing,
[<img width="337" alt="image" src="https://github.com/user-attachments/assets/8cb66227-0eb4-4a3e-8de6-cc963814a45f">](https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FDrizzlepac-Developers-Pull-Requests/detail/Drizzlepac-Developers-Pull-Requests/96/pipeline/142#step-247-log-1)
due to environment resolution conflicts when installing `.[test]` and also `requirements-dev.txt` in the same command:
[<img width="1000" alt="image" src="https://github.com/user-attachments/assets/49d14603-fe16-472f-8f85-e2830e097bb0">](https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FDrizzlepac-Developers-Pull-Requests/detail/Drizzlepac-Developers-Pull-Requests/96/pipeline/142#step-244-log-90)

Separating these two install commands so that `requirements-dev.txt` overrides the `test` requirements will probably fix this.

**Checklist for maintainers**
- [x] ~added entry in `CHANGELOG.rst` within the relevant release section~
- [x] updated or added relevant tests
- [x] ~updated relevant documentation~
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
