### PR TITLE
HLA-935: Update HDRTAB for MVM products

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.7.2 (unreleased)
 ==================
 
+- Update to HDRTABLE for MVM products to include SVM rootname and SVM creation date [#1846].
+
 - Added python 3.12 to testing matrix for Jenkins and github actions. [#1843]
 
 - ``manageInputCopies`` now copies successfully even if the original files were

--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -45,7 +45,8 @@ bc2.nodetype = 'linux'
 bc2.env_vars = ['TEST_BIGDATA=https://bytesalad.stsci.edu/artifactory']
 bc2.conda_packages = ['python=3.11']
 bc2.build_cmds = ["pip install numpy astropy pytest-cov ci-watson || true",
-                 "pip install -r requirements-dev.txt --upgrade -e '.[test]' || true",
+                 "pip install --upgrade -e '.[test]' || true",
+                 "pip install -r requirements-dev.txt || true",
                  "pip freeze || true"]
 bc2.test_cmds = ["pytest --env=${artifactory_env} --cov=./ --basetemp=tests_output --junitxml=results.xml --bigdata || true",
                  "${codecov_install}",

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -275,10 +275,11 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
                     for exposure in tot_obj.edp_list:                      
                         if rootname in exposure.full_filename:
                             name_col.append(exposure.product_basename)
+                            # check to see if all MVMs are correctly labeled as level 4
+                            # can remove second condition and below if statement / warning once verified. 
                             if level == 4 or "skycell" in update_filename:
                                 svmrootname_col.append(exposure.svm_exposure_name)
                                 svm_gendata_col.append(exposure.svm_gendate)
-                                # check if consistent level. can remove if not needed
                                 if level !=4:
                                     log.warning(f"Incorrect level associated with {update_filename}.")
                                     log.warning(f"Skipping HDRTABLE update.")

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -291,24 +291,24 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
         # will accommodate a string of at least 51 characters which handles an ACS image
         max_len = max(max([len(name) for name in name_col]), 51)
         hapcol = Column(array=np.array(name_col, dtype=np.str_), name=HAPCOLNAME, format='{}A'.format(max_len))
-        newcol = fits.ColDefs([hapcol])
-        hdrtab_cols += newcol
+        new_hap_col = fits.ColDefs([hapcol])
+        hdrtab_cols += new_hap_col
+        
+    if svm_gendata_col:
+        gendate_column = Column(name="GENDATE", format="10A", array=svm_gendata_col)
+        new_gendate_col = fits.ColDefs([gendate_column])
+        hdrtab_cols = new_gendate_col + hdrtab_cols
     
-    if level == 4:
-        if svm_gendata_col and svmrootname_col:
-            gendate_column = Column(name="GENDATE", format="10A", array=svm_gendata_col)
-            svm_char_len = np.max(np.char.str_len(svmrootname_col))
-            svmrootname_column = Column(
-                name="SVMROOTNAME", format=f"{svm_char_len}A", array=svmrootname_col
-            )
-            columns_to_prepend = fits.ColDefs([svmrootname_column, gendate_column])
-        else:
-            log.warning(f"Missing SVMROOTNAME or SVM_GENDATE for {update_filename}.")
-            log.warning(f"Skipping HDRTABLE update.")
-            return
+    if svmrootname_col:
+        svm_char_len = np.max(np.char.str_len(svmrootname_col))
+        svmrootname_column = Column(
+            name="SVMROOTNAME", format=f"{svm_char_len}A", array=svmrootname_col
+        )
+        new_svmrootname_col = fits.ColDefs([svmrootname_column])
+        hdrtab_cols = new_svmrootname_col + hdrtab_cols
 
     # define new extension
-    haphdu = fits.BinTableHDU.from_columns(columns_to_prepend + hdrtab_cols)
+    haphdu = fits.BinTableHDU.from_columns(hdrtab_cols)
     haphdu.header['extname'] = 'HDRTAB'
     haphdu.header['extver'] = 1
     # remove old extension

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -275,9 +275,13 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
                     for exposure in tot_obj.edp_list:                      
                         if rootname in exposure.full_filename:
                             name_col.append(exposure.product_basename)
-                            if level == 4:
+                            if level == 4 or "skycell" in update_filename:
                                 svmrootname_col.append(exposure.svm_exposure_name)
                                 svm_gendata_col.append(exposure.svm_gendate)
+                                # check if consistent level. can remove if not needed
+                                if level !=4:
+                                    log.warning(f"Incorrect level associated with {update_filename}.")
+                                    log.warning(f"Skipping HDRTABLE update.")
                             break
 
     hdrtab_cols = orig_tab.columns

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -243,7 +243,6 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
     name_col = []
     svmrootname_col = []
     svm_gendata_col = []
-    columns_to_prepend = []
 
     orig_tab = image['hdrtab'].data
     # get the name of the product so it can be selected from

--- a/drizzlepac/haputils/processing_utils.py
+++ b/drizzlepac/haputils/processing_utils.py
@@ -282,7 +282,6 @@ def update_hdrtab(image, level, total_obj_list, input_exposures):
                                 svm_gendata_col.append(exposure.svm_gendate)
                                 if level !=4:
                                     log.warning(f"Incorrect level associated with {update_filename}.")
-                                    log.warning(f"Skipping HDRTABLE update.")
                             break
 
     hdrtab_cols = orig_tab.columns

--- a/drizzlepac/haputils/product.py
+++ b/drizzlepac/haputils/product.py
@@ -1153,6 +1153,8 @@ class SkyCellExposure(HAPProduct):
 
         filter_str = layer[0]
 
+        self.svm_exposure_name = "_".join(filename.split("_")[:-1])
+
         # parse layer information into filename layer_str
         # layer: [filter_str, pscale_str, exptime_str, epoch_str]
         # e.g.: [f160w, coarse, all, all]
@@ -1181,6 +1183,7 @@ class SkyCellExposure(HAPProduct):
         hdu_list = fits.open(filename)
         self.mjdutc = hdu_list[0].header["EXPSTART"]
         self.exptime = hdu_list[0].header["EXPTIME"]
+        self.svm_gendate = hdu_list[0].header['DATE']
         hdu_list.close()
 
         self.product_basename = self.basename + "_".join(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-935](https://jira.stsci.edu/browse/HLA-935)

<!-- describe the changes comprising this PR here -->
This PR adds two new HDRTABLE entries to MVM drizzled (drc/z) products. These include the name (SVMROOTNAME) and creation date (GENDATE) of each of the SVM images included within the MVM. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

[Jenkins test](https://plwishmaster.stsci.edu:8081/blue/organizations/jenkins/RT%2FDrizzlepac-Developers-Pull-Requests/detail/Drizzlepac-Developers-Pull-Requests/119/pipeline)
