### PR TITLE
HLA-1291: Updated the call to hamming function in deconvolve_utils.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,11 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.7.2 (unreleased)
 ==================
 
+- Modified the call to the hamming function in the deconvolve_utils.py module
+  as SciPy deprecated the way window filtering functions can be invoked. These
+  functions can no longer be imported from the scipy.signal namespace but need
+  to be accessed via scipy.signal.windows.  [#nnnn]
+
 - Added python 3.12 to testing matrix for Jenkins and github actions. [#1843]
 
 - ``manageInputCopies`` now copies successfully even if the original files were

--- a/drizzlepac/haputils/deconvolve_utils.py
+++ b/drizzlepac/haputils/deconvolve_utils.py
@@ -28,7 +28,7 @@ from .. import astrodrizzle
 from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
 from scipy import ndimage
-import scipy.signal as ss
+from scipy.signal import windows
 
 from stsci.tools import logutil
 
@@ -479,7 +479,7 @@ def _create_input_psf(psf_name, calimg, total_flux):
     lib_size = [lib_psf_arr.shape[0] // 2, lib_psf_arr.shape[1] // 2]
 
     # create hamming 2d filter to avoid edge effects
-    h = ss.hamming(lib_psf_arr.shape[0])
+    h = windows.hamming(lib_psf_arr.shape[0])
     h2d = np.sqrt(np.outer(h, h))
     lib_psf_arr *= h2d
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1291](https://jira.stsci.edu/browse/HLA-1291)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Modified the call to the hamming function in the **deconvolve_utils.py** module as SciPy deprecated the way window filtering functions can be invoked. These
  functions can no longer be imported from the scipy.signal namespace but need to be accessed via scipy.signal.windows. 

Performed my own regression testing using results from caldp_20240509 (many differences due to many changes in drizzlepac), paying particular attention to the *trl.txt files to ensure the processing after the fix matches this previous build.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
