### PR TITLE
HLA-1295: Fixed the computations associated with rejection of catalogs due to cosmic rays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ==================
+- Corrected the way the n1_exposure_time and tot_exposure_time values
+  are computed as these values are used in the computation for rejecting
+  catalog creation based on expected cosmic ray detections.  Generalized
+  the crfactor dictionary for all detectors. Ensure if any catalog type
+  is rejected, all the catalog types are rejected. [#nnnn]
+
 - Modified the call to the hamming function in the deconvolve_utils.py module
   as SciPy deprecated the way window filtering functions can be invoked. These
   functions can no longer be imported from the scipy.signal namespace but need

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -556,7 +556,16 @@ class CatalogImage:
 class HAPCatalogs:
     """Generate photometric sourcelist for specified TOTAL or FILTER product image.
     """
-    crfactor = {'aperture': 300, 'segment': 150}  # CRs / hr / 4kx4k pixels
+
+    # This reference for the crfactor is Rick White.  It is based upon the physical
+    # area of the detector.  From the instrument handbooks:
+    # ACS/WFC: 4096**2 pixels, pixel size (15 um)**2
+    # ACS/HRC: 1024**2 pixels, pixel size (21 um)**2
+    # WFC3/UVIS: 4096**2 pixels, pixel size (15 um)**2
+    # WFPC2: 1600**2 pixels, pixel size (15um)**2
+    # acs/wfc-> crfactor = {'aperture': 300, 'segment': 150}  # CRs / hr / 4kx4k pixels
+    crfactor = {'WFC': {'aperture': 300, 'segment': 150}, 'HRC': {'aperture': 37, 'segment': 18.5},
+                'UVIS': {'aperture': 300, 'segment': 150}, 'PC': {'aperture': 46, 'segment': 23}} 
 
     def __init__(self, fitsfile, param_dict, param_dict_qc, num_images_mask, log_level, diagnostic_mode=False, types=None,
                  tp_sources=None):
@@ -664,6 +673,9 @@ class HAPCatalogs:
             crthresh_mask = None
             source_cat = self.catalogs[cat_type].sources if cat_type == 'aperture' else self.catalogs[cat_type].source_cat
 
+            # Collect up the names of all the columns which start with "Flag" - there will be
+            # a flag column for each filter in the visit - even the filters which did not end up
+            # contributing to the total detection image.
             flag_cols = [colname for colname in source_cat.colnames if colname.startswith('Flag')]
             for colname in flag_cols:
                 catalog_crmask = source_cat[colname] < 2
@@ -677,10 +689,11 @@ class HAPCatalogs:
         log.info("Determining whether point and/or segment catalogs meet cosmic-ray threshold")
         log.info("  based on EXPTIME = {}sec for the n=1 filters".format(n1_exposure_time))
 
+        detector = self.image.keyword_dict["detector"].upper()
         for cat_type in self.catalogs:
             source_cat = self.catalogs[cat_type]
             if source_cat.sources:
-                thresh = self.crfactor[cat_type] * n1_exposure_time**2 / self.image.keyword_dict['texpo_time']
+                thresh = self.crfactor[detector][cat_type] * n1_exposure_time**2 / self.image.keyword_dict['texpo_time']
                 source_cat = source_cat.sources if cat_type == 'aperture' else source_cat.source_cat
                 n_sources = source_cat.sources_num_good  # len(source_cat)
                 all_sources = len(source_cat)
@@ -688,6 +701,11 @@ class HAPCatalogs:
                 if n_sources < thresh and 0 < n_sources:
                     self.reject_cats[cat_type] = True
                     log.info("{} catalog FAILED CR threshold.".format(cat_type))
+
+        # Ensure if any catalog is rejected, the remaining catalogs are also rejected
+        if any([True for k,v in self.reject_cats.items() if v == True]):
+            for k in self.reject_cats.keys():
+                self.reject_cats[k] = True
 
         return self.reject_cats
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1295](https://jira.stsci.edu/browse/HLA-1295)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Corrected the way the n1_exposure_time and tot_exposure_time values
are computed as these values are used in the computation for rejecting catalog creation based on expected cosmic ray detections.  Generalized the crfactor dictionary for all detectors. Ensure if any catalog type is rejected, all the catalog types are rejected.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
