### PR TITLE
HLA-1302: Avoid application of cosmic ray threshold for ACS/SBC and WFC3/IR catalogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ==================
+- Added an if statement in verify_crthresh() so the evaluation for the possible
+  rejection of catalogs due to not enough sources vs estimated cosmic rays is
+  not done for ACS/SBC and WFC3/IR. [#nnnn]
+
 - Corrected the way the n1_exposure_time and tot_exposure_time values
   are computed as these values are used in the computation for rejecting
   catalog creation based on expected cosmic ray detections.  Generalized

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,9 +28,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ==================
-- Added an if statement in verify_crthresh() so the evaluation for the possible
-  rejection of catalogs due to not enough sources vs estimated cosmic rays is
-  not done for ACS/SBC and WFC3/IR. [#nnnn]
+- Avoid applying the estimated cosmic ray vs real sources threshold for the
+  ACS/SBC and WFC3/IR detectors. [#1858]
 
 - Corrected the way the n1_exposure_time and tot_exposure_time values
   are computed as these values are used in the computation for rejecting

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -565,7 +565,7 @@ class HAPCatalogs:
     # WFPC2: 1600**2 pixels, pixel size (15um)**2
     # acs/wfc-> crfactor = {'aperture': 300, 'segment': 150}  # CRs / hr / 4kx4k pixels
     crfactor = {'WFC': {'aperture': 300, 'segment': 150}, 'HRC': {'aperture': 37, 'segment': 18.5},
-                'UVIS': {'aperture': 300, 'segment': 150}, 'PC': {'aperture': 46, 'segment': 23}} 
+                'UVIS': {'aperture': 300, 'segment': 150}, 'WFPC2': {'aperture': 46, 'segment': 23}}
 
     def __init__(self, fitsfile, param_dict, param_dict_qc, num_images_mask, log_level, diagnostic_mode=False, types=None,
                  tp_sources=None):

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -696,10 +696,10 @@ class HAPCatalogs:
                 if source_cat.sources:
                     thresh = self.crfactor[detector][cat_type] * n1_exposure_time**2 / self.image.keyword_dict['texpo_time']
                     source_cat = source_cat.sources if cat_type == 'aperture' else source_cat.source_cat
-                    n_sources = source_cat.sources_num_good  # len(source_cat)
+                    n_sources = source_cat.sources_num_good
                     all_sources = len(source_cat)
                     log.info("{} catalog with {} good sources out of {} total sources :  CR threshold = {}".format(cat_type, n_sources, all_sources, thresh))
-                    if n_sources < thresh and 0 < n_sources:
+                    if 0 < n_sources < thresh:
                         self.reject_cats[cat_type] = True
                         log.info("{} catalog FAILED CR threshold.".format(cat_type))
 

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -690,17 +690,18 @@ class HAPCatalogs:
         log.info("  based on EXPTIME = {}sec for the n=1 filters".format(n1_exposure_time))
 
         detector = self.image.keyword_dict["detector"].upper()
-        for cat_type in self.catalogs:
-            source_cat = self.catalogs[cat_type]
-            if source_cat.sources:
-                thresh = self.crfactor[detector][cat_type] * n1_exposure_time**2 / self.image.keyword_dict['texpo_time']
-                source_cat = source_cat.sources if cat_type == 'aperture' else source_cat.source_cat
-                n_sources = source_cat.sources_num_good  # len(source_cat)
-                all_sources = len(source_cat)
-                log.info("{} catalog with {} good sources out of {} total sources :  CR threshold = {}".format(cat_type, n_sources, all_sources, thresh))
-                if n_sources < thresh and 0 < n_sources:
-                    self.reject_cats[cat_type] = True
-                    log.info("{} catalog FAILED CR threshold.".format(cat_type))
+        if detector not in ['IR', 'SBC']:
+            for cat_type in self.catalogs:
+                source_cat = self.catalogs[cat_type]
+                if source_cat.sources:
+                    thresh = self.crfactor[detector][cat_type] * n1_exposure_time**2 / self.image.keyword_dict['texpo_time']
+                    source_cat = source_cat.sources if cat_type == 'aperture' else source_cat.source_cat
+                    n_sources = source_cat.sources_num_good  # len(source_cat)
+                    all_sources = len(source_cat)
+                    log.info("{} catalog with {} good sources out of {} total sources :  CR threshold = {}".format(cat_type, n_sources, all_sources, thresh))
+                    if n_sources < thresh and 0 < n_sources:
+                        self.reject_cats[cat_type] = True
+                        log.info("{} catalog FAILED CR threshold.".format(cat_type))
 
         # Ensure if any catalog is rejected, the remaining catalogs are also rejected
         if any([True for k,v in self.reject_cats.items() if v == True]):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1302](https://jira.stsci.edu/browse/HLA-1302)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Added an if statement so the evaluation of possible rejection of catalogs due to not enough sources vs estimated cosmic rays is not done for ACS/SBC and WFC3/IR.  This oversight was found during regression testing.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
