### PR TITLE
HLA-1302: Avoid application of cosmic ray threshold for ACS/SBC and WFC3/IR

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.1 (unreleased)
 ==================
+- Avoid applying the estimated cosmic ray vs real sources threshold for the
+  ACS/SBC and WFC3/IR detectors. [#1858]
+
 - Corrected the way the n1_exposure_time and tot_exposure_time values
   are computed as these values are used in the computation for rejecting
   catalog creation based on expected cosmic ray detections.  Generalized


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1302](https://jira.stsci.edu/browse/HLA-1302)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Catalogs based upon images which suffer from cosmic rays are evaluated based upon an estimate of the number of cosmic rays expected for a given exposure time.  If the total number of sources does not exceed the estimated number of cosmic rays (plus a fudge factor), the catalogs can be rejected. This evaluation does not apply to ACS/SBC and WFC3/IR detectors.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
