### PR TITLE
Eliminate Python 3.13 from the target list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,13 @@ jobs:
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
       targets: |
-        # Linux wheels
-        - cp3*-manylinux_x86_64
-        # MacOS wheels
-        - cp3*-macosx_x86_64
+        # Linux wheels (except python 313)
+        - cp31[!3]-manylinux_x86_64
+        # MacOS wheels (except python 313)
+        - cp31[!3]-macosx_x86_64
         # Until we have arm64 runners, we can't automatically test arm64 wheels
-#        - cp3*-macosx_arm64
+        # (except python 313)
+#        - cp31[!3]-macosx_arm64
       sdist: true
       test_command: python -c "from drizzlepac import cdriz"
     secrets:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1307](https://jira.stsci.edu/browse/HLA-1307)

<!-- describe the changes comprising this PR here -->
Since there are very few wheel packages on pypi right now for
Python 3.13, we must do a workaround and exclude 3.13 from the target list.  This is advice from Joe H. with an example from JWST.  This is necessary to do to push out the final Drizzlepac v3.7.1.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
