### PR TITLE
Finalize drizzlepac v3.7.1 for HSTDP-2024.2.0 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,13 @@ jobs:
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
       targets: |
-        # Linux wheels
-        - cp3*-manylinux_x86_64
-        # MacOS wheels
-        - cp3*-macosx_x86_64
+        # Linux wheels (except python 313)
+        - cp31[!3]-manylinux_x86_64
+        # MacOS wheels (except python 313)
+        - cp31[!3]-macosx_x86_64
         # Until we have arm64 runners, we can't automatically test arm64 wheels
-#        - cp3*-macosx_arm64
+        # (except python 313)
+#        - cp31[!3]-macosx_arm64
       sdist: true
       test_command: python -c "from drizzlepac import cdriz"
     secrets:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ formats:
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-23.11"
 
 conda:
   environment: doc/.rtd-environment.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "drizzlepac"
 description = " HST image combination using the drizzle algorithm to combine astronomical images, to model image distortion, to remove cosmic rays, and generally to improve the fidelity of data in the final image. "
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 authors = [
     { name = "Megan Sosey" },
     { name = "Warren Hack" },


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1307](https://jira.stsci.edu/browse/HLA-1307)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR finalizes drizzlepac v3.7.1 for the HSTDP build.  Only infrastructure changes were added in this update which includes spacetelescope PR#1834, 1861, and 1864.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
