### PR TITLE
HLA-1315: Fix "finally" block handling Grism/Prism under PyTest

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -751,17 +751,28 @@ def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_
         # The Grism/Prism SVM FLT/FLC images which have had their WCS reconciled with the
         # corresponding direct images need trailer files.  This is also true of the Ramp images
         # which have only been processed through the "align to Gaia" stage.  At this time, just
-        # copy the total trailer file, and rename it appropriately.
+        # copy the full SVM processing log and rename it appropriately to the Grism or Ramp
+        # trailer filename.
+        # Note: When running under PyTest, the logname file cannot be found.  Since the Grism
+        # and Ramp log files are really placeholders, just create an empty file.
         if total_obj_list:
             for tot_obj in total_obj_list:
                 for gitem in grism_product_list:
                     if gitem.endswith('trl.txt'):
-                        shutil.copy(logname, gitem)
+                        if not os.path.exists(logname):
+                            open(gitem, 'a').close()
+                        else:
+                            shutil.copy(logname, gitem)
                 for ritem in ramp_product_list:
                     if ritem.endswith('trl.txt'):
-                        shutil.copy(logname, ritem)
+                        if not os.path.exists(logname):
+                            open(ritem, 'a').close()
+                        else:
+                            shutil.copy(logname, ritem)
 
-        # Append total trailer file (from astrodrizzle) to all total log files
+        # The tot_obj.trl_filename contains the astrodrizzle log.  The "logname"
+        # contains all the logging from the SVM processing.
+        # Append the full SVM processing log to the astrodrizzle log.
         if total_obj_list:
             for tot_obj in total_obj_list:
                 if found_data:

--- a/tests/hap/test_svm_j97e06.py
+++ b/tests/hap/test_svm_j97e06.py
@@ -32,21 +32,21 @@ from pathlib import Path
 WCS_SUB_NAME = "IDC_4BB1536OJ"
 POLLER_FILE = "acs_97e_06_input.out"
 EXPECTED_POINT_SOURCES = {"wfc": 2}
-EXPECTED_SEG_SOURCES = {"wfc": 2}
+EXPECTED_SEG_SOURCES = {"wfc": 6}
 MEAN_CAT_MAGAP1_POINT = {
-"hst_10374_06_acs_wfc_f814w_j97e06_point-cat.ecsv": 18.79,
-"hst_10374_06_acs_wfc_f625w_j97e06_point-cat.ecsv": 18.86,
-"hst_10374_06_acs_wfc_f775w_j97e06_point-cat.ecsv": 18.78,
-"hst_10374_06_acs_wfc_f555w_j97e06_point-cat.ecsv": 19.05,
-"hst_10374_06_acs_wfc_f850lp_j97e06_point-cat.ecsv": 18.84,
-"hst_10374_06_acs_wfc_f606w_j97e06_point-cat.ecsv": 18.97}
+"hst_10374_06_acs_wfc_f814w_j97e06_point-cat.ecsv": 17.55,
+"hst_10374_06_acs_wfc_f625w_j97e06_point-cat.ecsv": 17.86,
+"hst_10374_06_acs_wfc_f775w_j97e06_point-cat.ecsv": 17.53,
+"hst_10374_06_acs_wfc_f555w_j97e06_point-cat.ecsv": 18.14,
+"hst_10374_06_acs_wfc_f850lp_j97e06_point-cat.ecsv": 17.75,
+"hst_10374_06_acs_wfc_f606w_j97e06_point-cat.ecsv": 17.94}
 MEAN_CAT_MAGAP1_SEGMENT = {
-"hst_10374_06_acs_wfc_f850lp_j97e06_segment-cat.ecsv": 20.56,
-"hst_10374_06_acs_wfc_f555w_j97e06_segment-cat.ecsv": 21.73,
-"hst_10374_06_acs_wfc_f775w_j97e06_segment-cat.ecsv": 20.71,
-"hst_10374_06_acs_wfc_f814w_j97e06_segment-cat.ecsv": 20.73,
-"hst_10374_06_acs_wfc_f625w_j97e06_segment-cat.ecsv": 21.08,
-"hst_10374_06_acs_wfc_f606w_j97e06_segment-cat.ecsv": 21.17}
+"hst_10374_06_acs_wfc_f850lp_j97e06_segment-cat.ecsv": 20.36,
+"hst_10374_06_acs_wfc_f555w_j97e06_segment-cat.ecsv": 21.80,
+"hst_10374_06_acs_wfc_f775w_j97e06_segment-cat.ecsv": 20.48,
+"hst_10374_06_acs_wfc_f814w_j97e06_segment-cat.ecsv": 20.38,
+"hst_10374_06_acs_wfc_f625w_j97e06_segment-cat.ecsv": 21.26,
+"hst_10374_06_acs_wfc_f606w_j97e06_segment-cat.ecsv": 21.28}
 POINT_DIFF = 0.5
 SEGMENT_DIFF = 0.5
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1315](https://jira.stsci.edu/browse/HLA-1315)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #
<!-- describe the changes comprising this PR here -->
Fixed the code handling log/trailer file creation for Grism/Prism data in the "finally" block of run_hap_processing, as an error under PyTest 
was being generated as the designated log file could not be found to be copied and used as the Grism/Prism log file. The Grism/Prism log files are just placeholders, so an empty file is created if the designated log file cannot be found.  Added comments.  The code executes properly when not run under PyTest.

I manually ran test_svm_j97e06.py (test which revealed the problem) and test_svm_je281u.py in my workspace to test with Pytest.  I also ran both visits without PyTest.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [X] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
