### PR TITLE
Small update to buildmask for Numpy 2.0

### DIFF
--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -84,7 +84,7 @@ def buildDQMasks(imageObjectList,configObj):
 
 def buildMask(dqarr, bitvalue):
     """ Builds a bit-mask from an input DQ array and a bitvalue flag """
-    return bitfield_to_boolean_mask(dqarr.astype(np.int16), bitvalue, good_mask_value=1,
+    return bitfield_to_boolean_mask(dqarr.astype(np.uint16), ignore_flags=bitvalue, good_mask_value=1,
                                     dtype=np.uint8)
 
 


### PR DESCRIPTION
This change is necessary as an int is being truncated in numpy 2.0. This change converts the int to a uint, which has more positive available characters and is fine as the values should never be negative. 