### PR TITLE
HLA-1323: s_region fix using simplify-polyline

### DIFF
--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -579,7 +579,7 @@ class SkyFootprint(object):
                 # Perform corner detection on each region/chip separately.
                 mask_corners = corner_peaks(corner_harris(label_mask),
                                        min_distance=3,
-                                       threshold_rel=0.2)
+                                       threshold_rel=0.1)
                 xy_corners = mask_corners * 0.
                 xy_corners[:, 0] = mask_corners[:, 1]
                 xy_corners[:, 1] = mask_corners[:, 0]

--- a/drizzlepac/haputils/cell_utils.py
+++ b/drizzlepac/haputils/cell_utils.py
@@ -581,7 +581,7 @@ class SkyFootprint(object):
 
                 if xy_corners.shape[0] <= 3:
                     # this is surely an error, ought to raise an exception
-                    print("WARNING: Too few corners")
+                    log.info("WARNING: Too few corners")
 
                 # save as output values
                 ordered_xy.append(xy_corners.astype(np.float64))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "stregion>=1.1.7",
     "requests",
     "scikit-learn>=0.20",
+    "simplify-polyline"
     "bokeh",
     "pandas",
     "spherical_geometry>=1.2.22",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "stregion>=1.1.7",
     "requests",
     "scikit-learn>=0.20",
-    "simplify-polyline"
+    "simplify-polyline",
     "bokeh",
     "pandas",
     "spherical_geometry>=1.2.22",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1323](https://jira.stsci.edu/browse/HLA-1323)

<!-- describe the changes comprising this PR here -->
This PR fixes the s_region issues that we have been observing in the SVMs. It uses the simplify-polyline package instead of skimage.corner_harris. Results from initial testing are shown in the Jira ticket. 

These code changes were generously contributed by @rlwastro.

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
      
[Jenkins test](https://plwishmaster.stsci.edu:8081/job/RT/job/Drizzlepac-Developers-Pull-Requests/134/)
