### PR TITLE
HLA-1284/1287: Properly account for illuminated and non-illuminated pixels

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -238,7 +238,7 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
                 filter_product_catalogs = HAPCatalogs(filter_product_obj.drizzle_filename,
                                                       total_product_obj.configobj_pars.get_pars('catalog generation'),
                                                       total_product_obj.configobj_pars.get_pars('quality control'),
-                                                      total_product_obj.mask,
+                                                      filter_product_obj.mask,
                                                       log_level,
                                                       types=phot_mode,
                                                       diagnostic_mode=diagnostic_mode,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1284](https://jira.stsci.edu/browse/HLA-1284)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Use the filter mask (illuminated vs non-illuminated pixels) when processing the  Filter product.  For all products, properly account for the number of pixels which are illuminated,  the number of pixels that contain true zero in the illuminated portion of the image, and non-illuminated pixels.


**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [X] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

https://plwishmaster.stsci.edu:8081/job/RT/job/Drizzlepac-Developers-Pull-Requests/146/
First run done with unchanged reference/truth files in /dev and results are in /drizzlepac-results/wfc3/11Oct2024T.  Created drizzlepac/3.7.2 which is a copy of drizzlepac/dev, but the different files (WFC3 and WFPC2) have NOT yet been copied to drizzlepac/3.7.2.  I want to process some data locally as it is curious there were no ACS failures.

Investigated the "failed" tests and they have nothing to do with this PR.  The code specifically changed in this PR have nothing to do with the WFC3 tests as the changes are for SVM processing.

Ran in my Mac (23.6.0 Darwin Kernel Version 23.6.0) under caldp_20240813 build with updates from Drizzlepac.  All the WFC3 and WFPC2 tests **_passed._**
