### PR TITLE
Ignore nans in staticmask call to stsci.imagestats

### DIFF
--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -27,7 +27,7 @@ _step_num_ = 1
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
-#this is called by the user
+# this is called by the user
 def createMask(input=None, static_sig=4.0, group=None, editpars=False, configObj=None, **inputDict):
     """ The user can input a list of images if they like to create static masks
         as well as optional values for static_sig and inputDict.
@@ -53,7 +53,7 @@ def createMask(input=None, static_sig=4.0, group=None, editpars=False, configObj
     if not editpars:
         run(configObj)
 
-#this is called by the TEAL interface
+# this is called by the TEAL interface
 def run(configObj):
 
     #now we really just need the imageObject list created for the dataset
@@ -63,7 +63,7 @@ def run(configObj):
     createStaticMask(imageObjList,configObj)
 
 
-#this is the workhorse function called by MultiDrizzle
+# this is the workhorse function called by MultiDrizzle
 def createStaticMask(imageObjectList=[],configObj=None,procSteps=None):
     if procSteps is not None:
         procSteps.addStep('Static Mask')
@@ -167,7 +167,7 @@ class staticMask:
         if chips is None:
             chips = imagePtr.getExtensions()
 
-        #for chip in range(1,numchips+1,1):
+        # for chip in range(1,numchips+1,1):
         for chip in chips:
             chipid=imagePtr.scienceExt + ','+ str(chip)
             chipimage=imagePtr.getData(chipid)
@@ -186,8 +186,13 @@ class staticMask:
                         maskname  = self.masknames[s]
                         break
             imagePtr[chipid].outputNames['staticMask'] = maskname
-
-            stats = ImageStats(chipimage,nclip=3,fields='mode')
+            stats = ImageStats(
+                chipimage,
+                nclip=3,
+                fields="mode",
+                lower=np.nanmin(chipimage),
+                upper=np.nanmax(chipimage),
+            )
             mode = stats.mode
             rms  = stats.stddev
             nbins = len(stats.histogram)
@@ -259,10 +264,10 @@ class staticMask:
         virtual = imageObjectList[0].inmemory
 
         for key in self.masklist.keys():
-            #check to see if the file already exists on disk
+            # check to see if the file already exists on disk
             filename = self.masknames[key]
-            #create a new fits image with the mask array and a standard header
-            #open a new header and data unit
+            # create a new fits image with the mask array and a standard header
+            # open a new header and data unit
             newHDU = fits.PrimaryHDU()
             newHDU.data = self.masklist[key]
 


### PR DESCRIPTION
In investigating a build error ([HLA-1368](https://jira.stsci.edu/browse/HLA-1368)) we found an error where a nan in the science image array caused an error in a call to stsci.imagestats. The call to stsci.imagestats calculates a min and max (used for cuts), that results in nans for both. 

Here I am passing min and max values using np.nanmin and np.nanmax, which ignore nans in the calculation. 