### PR TITLE
HLA-1370: Fixed a bug from a previous commit for computing statistics

### DIFF
--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -275,14 +275,13 @@ class CatalogImage:
         # this for SBC.
         if (self.imghdu[0].header['DETECTOR'].upper() == "SBC"):
             num_of_zeros = np.count_nonzero(imgdata[self.footprint_mask] == 0)
-            num_of_nonzeros = num_of_illuminated_pixels - num_of_zeros
 
             # If there are too many background zeros in the image
             # (> number_of_zeros_in_background_threshold), set the background median to
             # zero and the background rms to the real rms of the non-zero values in the image.
             if num_of_zeros / float(num_of_illuminated_pixels) * 100.0 > zero_percent:
                 self.bkg_median = 0.0
-                self.bkg_rms_median = stats.tstd(num_of_nonzeros, limits=[0, None], inclusive=[False, True])
+                self.bkg_rms_median = stats.tstd(imgdata[self.footprint_mask], limits=[0, None], inclusive=[False, True])
                 self.bkg_background_ra = np.full_like(imgdata, 0.0)
                 self.bkg_rms_ra = np.full_like(imgdata, self.bkg_rms_median)
                 self.bkg_type = 'zero_background'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1370](https://jira.stsci.edu/browse/HLA-1370)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Fixed a bug associated with a previous commit when computing statistics on the illuminated portion only of the drizzled image.  The computation now uses the footprint_mask which is based on the DRZ CTX image which reports the number of images which contributed to the final pixel value.  If the CTX[i,j] > 0, then the pixel is illuminated.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
