### PR TITLE
HLA-1384: Force an exit with a return code, KEYWORD_UPDATE_PROBLEM, in try/exce…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Force an exit with a return code, KEYWORD_UPDATE_PROBLEM, in try/exception block
   when invoking refine_product_headers in hapsequencer.py and hapmultisequencer.py.
   If the FITS header keywords are not properly updated, this can cause errors during
-  CAOM ingest. [#nnnn]
+  CAOM ingest. [#1911]
 
 - Introduce warnings for fits extensions with science data of all zeros, and ensure 
   data with zeros in all science extensions are not processed. [#998]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.7.2 (unreleased)
 ==================
+- Force an exit with a return code, KEYWORD_UPDATE_PROBLEM, in try/exception block
+  when invoking refine_product_headers in hapsequencer.py and hapmultisequencer.py.
+  If the FITS header keywords are not properly updated, this can cause errors during
+  CAOM ingest. [#nnnn]
 
 - Introduce warnings for fits extensions with science data of all zeros, and ensure 
   data with zeros in all science extensions are not processed. [#998]

--- a/drizzlepac/hapmultisequencer.py
+++ b/drizzlepac/hapmultisequencer.py
@@ -53,6 +53,7 @@ from astropy.table import Table
 import numpy as np
 import drizzlepac
 
+from drizzlepac.haputils import analyze
 from drizzlepac.haputils import cell_utils
 from drizzlepac.haputils import config_utils
 from drizzlepac.haputils import poller_utils
@@ -245,6 +246,9 @@ def create_drizzle_products(total_obj_list, custom_limits=None):
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
         logging.exception("message")
+        # When there is not enough disk space, there can be a problem updating the
+        # header keywords. This can cause problems for CAOM.
+        sys.exit(analyze.Ret_code.KEYWORD_UPDATE_PROBLEM.value)
 
     # Remove rules files copied to the current working directory
     for rules_filename in list(rules_files.values()):

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -457,6 +457,10 @@ def create_drizzle_products(total_obj_list):
         exc_type, exc_value, exc_tb = sys.exc_info()
         traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.stdout)
         logging.exception("message")
+        # When there is not enough disk space, there can be a problem updating the
+        # header keywords. This can cause problems for CAOM.
+        sys.exit(analyze.Ret_code.KEYWORD_UPDATE_PROBLEM.value)
+
     # Remove rules files copied to the current working directory
     for rules_filename in list(rules_files.values()):
         log.info("Removed rules file {}".format(rules_filename))

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -92,6 +92,7 @@ class Ret_code(Enum):
     Define return status codes for Operations 
     """
     OK = 0
+    KEYWORD_UPDATE_PROBLEM = 15
     SBCHRC_DATA = 55 
     NO_VIABLE_DATA = 65
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1384: <Fix a bug> -->
Resolves [HLA-1384](https://jira.stsci.edu/browse/HLA-1384)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Force an exit with a return code, KEYWORD_UPDATE_PROBLEM, in try/exception block when invoking refine_product_headers in hapsequencer.py and hapmultisequencer.py. If the FITS header keywords are not properly updated, this can cause errors during CAOM ingest.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
