### PR TITLE
HLA-1401: Updating main branch based on changes on 3.9.0 (build-related changes)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,8 +18,15 @@ number of the code change for that issue.  These PRs can be viewed at:
     https://github.com/spacetelescope/drizzlepac/pulls
 
 
-3.7.2 (unreleased)
+3.9.1 (unreleased)
 ==================
+
+- Added new header keywords and match requirements for relative fitting. [#1860]
+  
+
+3.9.0 (16-Dec-2024)
+===================
+
 - Include a minimum RMS value for the SBC detector, as is done for the other
   detectors, as there seems to be a lot of noise in the source catalogs due to 
   a low detection threshold. [#1908]
@@ -51,9 +58,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Added documentation describing regression tests. [#1881]
 
-- Addressed additional issures related to numpy 2.0 scalar promotion. [#1875]
-
-- Added new header keywords and match requirements for relative fitting. [#1860]
+- Addressed additional issues related to numpy 2.0 scalar promotion. [#1875]
 
 - Update to HDRTABLE for MVM products to include SVM rootname and SVM creation date. [#1846]
 
@@ -62,6 +67,11 @@ number of the code change for that issue.  These PRs can be viewed at:
 - ``manageInputCopies`` now copies successfully even if the original files were
   defined by full paths rather than being in the current working directory. [#1835]
 
+
+3.8.0
+=====
+
+- Version not released; internal testing only. 
 
 3.7.1.1 (1-Oct-2024)
 ====================

--- a/doc/ADRs.md
+++ b/doc/ADRs.md
@@ -1,3 +1,18 @@
+# Pinning Versions of Dependencies 12/17/24
+
+## Context
+
+To ensure that our HAP pipeline products are consistent with each build, and to ensure that the drizzlepac code is working, sometimes we have to force the code to only install a certain version of a dependency package. 
+
+## Decision
+
+We aim to avoid pinning the versions of packages on the main branch (where we develop), but each build does pin all dependency version.
+
+## Consequences 
+
+This will avoid sudden changes to the build, while new bugs may pop up where we are developing on main. This leaves us in a better place to fix them and update the code. 
+
+
 # Updating WCS in Headers 11/14/23
 
 ## Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "lxml",
     "PyPDF2",
     "scikit-image>=0.14.2",
-    "numpy<2.0",
+    "numpy>2.0",
 ]
 dynamic = [
     "version",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ git+https://github.com/spacetelescope/stsci.tools.git
 git+https://github.com/spacetelescope/stwcs.git
 git+https://github.com/spacetelescope/stregion.git
 #git+https://github.com/astropy/astroquery.git
-numpy<2.0.dev0
+numpy>2.0.dev0
 scipy>=0.0.dev0
 pyerfa>=0.0.dev0
 astropy>=0.0.dev0

--- a/tests/hap/test_svm_j97e06.py
+++ b/tests/hap/test_svm_j97e06.py
@@ -187,7 +187,7 @@ def test_svm_wcs(gather_output_data):
         print("\ntest_svm_wcs.  WCSNAME: {} Output file: {}".format(wcsname, tdp))
         assert WCS_SUB_NAME in wcsname, f"WCSNAME is not as expected for file {tdp}."
 
-
+@pytest.mark.skip(reason="Need to update logic as changes in the small number of catalog sources is too sensitive.")
 def test_svm_point_cat_numsources(gather_output_data):
    # Check that the point catalogs have the expected number of sources
     cat_files = [files for files in gather_output_data if files.lower().endswith("point-cat.ecsv")]
@@ -202,7 +202,7 @@ def test_svm_point_cat_numsources(gather_output_data):
     bad_cats = [cat for cat in valid_cats if not valid_cats[cat][0]]
     assert len(bad_cats) == 0,  f"Point Catalog(s) {bad_cats} had {valid_cats} sources, expected {EXPECTED_POINT_SOURCES}"
 
-
+@pytest.mark.skip(reason="Need to update logic as changes in the small number of catalog sources is too sensitive.")
 def test_svm_segment_cat_numsources(gather_output_data):
    # Check that the point catalogs have the expected number of sources
     cat_files = [files for files in gather_output_data if files.lower().endswith("segment-cat.ecsv")]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1401](https://jira.stsci.edu/browse/HLA-1401)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1921 

<!-- describe the changes comprising this PR here -->
This PR cleans up the main branch. We have been making build-related changes on branch 3.9.0, however, there are some changes that are only on main that we don't want to clobber with a merge. I have therefore added difference manually in one go in order to avoid conflicts. 

These changes include changes to the pyproject.toml and requirements-dev.txt file that specify the requirement for numpy > 2.0. I have also updated the changelog, skipped two SVM tests (similar to build), and added an ADR about our dependency pinning strategy. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)
- [x] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)

[Jenkins Test](https://plwishmaster.stsci.edu:8081/job/RT/job/Drizzlepac-Developers-Pull-Requests/162/)
