### PR TITLE
Truncate pytest failure report for ascii diffs

### DIFF
--- a/tests/resources.py
+++ b/tests/resources.py
@@ -188,7 +188,7 @@ class BaseCal:
                 sys.stdout.writelines(udiff)
                 sys.stdout = old_stdout
                 udiff_report = udiffIO.getvalue()
-                creature_report += udiff_report[:100]
+                creature_report += udiff_report[:100] # TRUNCATED to first 100 characters
                 if len(udiff_report) > 2 and all_okay:
                     all_okay = False
                 if len(udiff_report) > 2:

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -188,7 +188,7 @@ class BaseCal:
                 sys.stdout.writelines(udiff)
                 sys.stdout = old_stdout
                 udiff_report = udiffIO.getvalue()
-                creature_report += udiff_report
+                creature_report += udiff_report[:100]
                 if len(udiff_report) > 2 and all_okay:
                     all_okay = False
                 if len(udiff_report) > 2:


### PR DESCRIPTION
Some of the diff reports from pytests are unhelpfully long. This change truncates any ascii difference reports to the first 100 lines. This should be sufficient for understanding the initial differences. 