### PR TITLE
Pins drizzlepac to the most recent STWCS version that also requires numpy>2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "stsci.imagestats>=1.8.2",
     "stsci.skypac>=1.0.9",
     "stsci.stimage",
-    "stwcs>=1.5.3",
+    "stwcs>=1.7.4",
     "tweakwcs>=0.8.7",
     "stregion>=1.1.7",
     "requests",


### PR DESCRIPTION
Closes issue [#212](https://github.com/spacetelescope/stwcs/issues/212) in STWCS. 