### PR TITLE
HLA-1406: Truth files saved to correct location on artifactory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.1 (unreleased)
 ==================
 
+- Updated path for regression test results on artifactory. [#1933]
+
 - Added new header keywords and match requirements for relative fitting. [#1860]
   
 

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -21,6 +21,9 @@ from ci_watson.artifactory_helpers import get_bigdata, generate_upload_schema
 from ci_watson.hst_helpers import download_crds, ref_from_image
 
 
+TODAYS_DATE = datetime.datetime.now().strftime("%Y-%m-%d")
+
+
 # Base classes for actual tests.
 # NOTE: Named in a way so pytest will not pick them up here.
 @pytest.mark.bigdata
@@ -146,15 +149,14 @@ class BaseCal:
         testpath, testname = os.path.split(os.path.abspath(os.curdir))
         # organize results by day test was run...could replace with git-hash
         whoami = getpass.getuser() or 'nobody'
-        dt = datetime.datetime.now().strftime("%d%b%YT")
-        ttime = datetime.datetime.now().strftime("%H_%M_%S")
-        user_tag = 'NOT_CI_{}_{}'.format(whoami, ttime)
-        build_tag = os.environ.get('BUILD_TAG',  user_tag)
-        build_suffix = os.environ.get('BUILD_MATRIX_SUFFIX', 'standalone')
-        testdir = "{}_{}_{}".format(testname, build_tag, build_suffix)
-        tree = os.path.join(self.results_root, self.input_loc,
-                            dt, testdir) + os.sep
-
+        user_tag = 'NOT_CI_{}'.format(whoami)
+        build_tag = os.environ.get('BUILD_TAG', user_tag)
+        build_matrix_suffix = os.environ.get('BUILD_MATRIX_SUFFIX', '0')
+        subdir = '{}_{}_{}'.format(TODAYS_DATE, build_tag, build_matrix_suffix)
+        
+        # subdir exmaple: # example: 2025-01-16_GITHUB_CI_Linux-X64-py3.11-783
+        # full path: drizzlepac_results/*subdir*/acs/test_tweak0/filename.fits
+        tree = os.path.join(self.results_root, subdir, self.input_loc, testname) + os.sep
         updated_outputs = []
         for actual, desired in outputs:
             # Get "truth" image

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -206,8 +206,7 @@ class BaseCal:
                       files[0], files[1]))
                 shutil.move(files[0], files[1])
             log_pattern = [os.path.join(os.path.dirname(x), '*.log') for x in new_truths]
-            json_pattern = [os.path.join(os.path.dirname(x), '*.json') for x in new_truths]
-            generate_upload_schema(pattern=new_truths + log_pattern + json_pattern,
+            generate_upload_schema(pattern=new_truths + log_pattern,
                            testname=testname,
                            target= tree)
 

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -206,7 +206,8 @@ class BaseCal:
                       files[0], files[1]))
                 shutil.move(files[0], files[1])
             log_pattern = [os.path.join(os.path.dirname(x), '*.log') for x in new_truths]
-            generate_upload_schema(pattern=new_truths + log_pattern,
+            json_pattern = [os.path.join(os.path.dirname(x), '*.json') for x in new_truths]
+            generate_upload_schema(pattern=new_truths + log_pattern + json_pattern,
                            testname=testname,
                            target= tree)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1406](https://jira.stsci.edu/browse/HLA-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR fixes the incorrect path to artifactory where new truth files are saved to. I was able to confirm this by running `tests/wfpc2/test_wfpc2.py` on our new github actions tests with the artifactory dev (truth) environment set to `3.7.0`. The command uses the gui and looks like this:

 
<img width="318" alt="Screenshot 2025-01-16 at 4 06 29 PM" src="https://github.com/user-attachments/assets/4a3f29de-94b3-49b6-a444-61a2c51d2a7b" />


The results of the tests are [here](https://github.com/spacetelescope/RegressionTests/actions/runs/12817454877/job/35740771937) and an example of the location of the new files is [here](https://bytesalad.stsci.edu/ui/repos/tree/General/drizzlepac-results/2025-01-16_GITHUB_CI_Linux-X64-py3.11-790/wfpc2/test_wfpc2_single0/reference_single_mef.fits). 

The new truth files are now posted to the directories already being produced with summary files (e.g. 2025-01-09_GITHUB_CI_Linux-X64-py3.11-775). Previously they were posted to a different path (e.g. ACS/DATE/testdir/testname).

Still investigating why the json files (used by okify) are not being uploaded as well. That will be in a separate PR. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)