### PR TITLE
HLA-1407: Implemented fixes to address uneven detection thresholds in HAP catalogs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,8 @@ number of the code change for that issue.  These PRs can be viewed at:
   the compute_threshold method associated with only the Segment catalog was also
   addressed.  The "scale factor" which causes the RMS computation to be too small
   was deleted.  The RMS computation for the Point and Segment catalogs is now the
-  same. [#nnnn]
+  same. [#1939]
+
 
 3.9.1 (30-Jan-2025)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,13 +17,23 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
-
-3.9.1 (unreleased)
+3.9.2 (unreleased)
 ==================
 
 - Updated path for regression test results on artifactory. [#1933]
 
 - Added new header keywords and match requirements for relative fitting. [#1860]
+
+- Implemented fixes to address uneven detection thresholds in the HAP catalogs
+  due to bugs in the function, make_wht_masks, which intends to create weight
+  masks covering the full drizzled output footprint. A somewhat related bug in
+  the compute_threshold method associated with only the Segment catalog was also
+  addressed.  The "scale factor" which causes the RMS computation to be too small
+  was deleted.  The RMS computation for the Point and Segment catalogs is now the
+  same. [#nnnn]
+
+3.9.1 (30-Jan-2025)
+===================
 
 - Further updates done to address the deprecated Photutils functionality as the
   original changes did not produce results at least as good as the results


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-407](https://jira.stsci.edu/browse/HLA-1407)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Implemented fixes recommended by R.White to address uneven detection thresholds in the HAP catalogs due to bugs in the function, make_wht_masks, which intends to create weight masks covering the full drizzled output footprint. A somewhat related bug in the compute_threshold method associated with only the Segment catalog was also addressed. The "scale factor" which causes the RMS computation to be too small was deleted.  The RMS computation for the Point and Segment catalogs is now the same.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)