### PR TITLE
HLA-1413: Replaced deprecated class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.2 (unreleased)
 ==================
 
-- Replaced deprecated class IntegratedGaussianPRF with CircularGaussianSigmaPRF.
+- Replaced deprecated class IntegratedGaussianPRF with CircularGaussianSigmaPRF. [#1950]
 
 - Updated path for regression test results on artifactory. [#1933]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.2 (unreleased)
 ==================
 
+- Replaced deprecated class IntegratedGaussianPRF with CircularGaussianSigmaPRF.
+
 - Updated path for regression test results on artifactory. [#1933]
 
 - Added new header keywords and match requirements for relative fitting. [#1860]

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -51,8 +51,8 @@ import photutils
 from photutils.segmentation import (detect_sources, SourceCatalog, detect_threshold,
                                     deblend_sources, SegmentationImage)
 
-from photutils.psf import (IntegratedGaussianPRF, SourceGrouper,
-                           IterativePSFPhotometry)
+from photutils.psf import (SourceGrouper, IterativePSFPhotometry,
+                           CircularGaussianSigmaPRF)
 
 from photutils.utils import circular_footprint
 
@@ -864,10 +864,9 @@ def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
     aperture_radius = 1.5 * default_fwhm
     mmm_bkg = MMMBackground()
     iraffind = DAOStarFinder(threshold=2.5 * mmm_bkg(psf), fwhm=default_fwhm)
-    # LevMarLSQFitter is in disfavor and will be deprecated
     fitter = LMLSQFitter()
     sigma_psf = gaussian_fwhm_to_sigma * default_fwhm
-    gaussian_prf = IntegratedGaussianPRF(sigma=sigma_psf)
+    gaussian_prf = CircularGaussianSigmaPRF(sigma=sigma_psf)
     gaussian_prf.sigma.fixed = False
     try:
         itr_phot_obj = IterativePSFPhotometry(finder=iraffind,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1413](https://jira.stsci.edu/browse/HLA-1413)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
The PR replaces the deprected class IntegratedGaussianPRF with CircularGaussianSigmaPRF.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)