### PR TITLE
HLA-1433: Remove parameter deprecated in Photutils 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Removed deprecated parameter, edge_method, from the instantiation of a 
   Background2D.  The default for this value is now always equal to "pad"
-  which was the setting in use in our code. [####]
+  which was the setting in use in our code. [#1957]
 
 - Removed python<3.13 restriction and remove some warnings. [#1936]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.2 (unreleased)
 ==================
 
+- Removed deprecated parameter, edge_method, from the instantiation of a 
+  Background2D.  The default for this value is now always equal to "pad"
+  which was the setting in use in our code. [####]
+
 - Removed python<3.13 restriction and remove some warnings. [#1936]
 
 - build and test with latest supported version of Python [#1955]

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -605,7 +605,7 @@ class HAPImage:
                     bkg = Background2D(scidata, box_size, filter_size=win_size,
                                        bkg_estimator=bkg_estimator(),
                                        bkgrms_estimator=rms_estimator(),
-                                       exclude_percentile=percentile, edge_method="pad")
+                                       exclude_percentile=percentile)
                 except Exception:
                     bkg = None
                     continue

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -677,7 +677,7 @@ def compute_2d_background(imgarr, box_size, win_size,
             bkg = Background2D(imgarr, (box_size, box_size), filter_size=(win_size, win_size),
                                bkg_estimator=bkg_estimator(),
                                bkgrms_estimator=rms_estimator(),
-                               exclude_percentile=percentile, edge_method="pad")
+                               exclude_percentile=percentile)
 
         except Exception:
             bkg = None

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -394,7 +394,7 @@ class CatalogImage:
                         bkg = Background2D(imgdata, (box_size, box_size), filter_size=(win_size, win_size),
                                            bkg_estimator=bkg_estimator(),
                                            bkgrms_estimator=rms_estimator(),
-                                           exclude_percentile=percentile, edge_method="pad",
+                                           exclude_percentile=percentile,
                                            coverage_mask=self.inv_footprint_mask)
 
                     except Exception:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1433: <Fix a bug> -->
Resolves [HLA-1433](https://jira.stsci.edu/browse/HLA-1433)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Removed a parameter deprecated in Photutils 2.0, edge_method, from the instantiation of a Background2D.  The default for this parameter is now always equal to "pad" which was the setting in use in our code.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)