### PR TITLE
Update the Pyproject.toml file to force use of Photutils >= 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 ==================
 
 - Updated the Pyproject.toml file to force use of Photutils v2.0.0 or greater.
-  This update is in support of the change addressed by #1950. [#nnnn]
+  This update is in support of the change addressed by #1950. [#1966]
 
 - Set non-positive catalog fluxes to nans to remove warnings for dividing by 
   zero and calculating the log of negative numbers. [#1959]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.2 (unreleased)
 ==================
 
+- Updated the Pyproject.toml file to force use of Photutils v2.0.0 or greater.
+  This update is in support of the change addressed by #1950. [#nnnn]
+
 - Set non-positive catalog fluxes to nans to remove warnings for dividing by 
   zero and calculating the log of negative numbers. [#1959]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "spherical_geometry>=1.2.22",
     "astroquery>=0.4",
     "astrocut<=0.9",
-    "photutils>=1.10.0",
+    "photutils>=2.0.0",
     "lxml",
     "PyPDF2",
     "scikit-image>=0.14.2",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Updated the Pyproject.toml file to force use of Photutils v2.0.0 or greater. This update is in support of the change addressed by #1950.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)