### PR TITLE
HLA-1448: Fix the crfactor designation for the WFPC2 detector to avoid failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.2 (unreleased)
 ==================
 
+- Fixed the crfactor designation for the WFPC2 detector (PC) which caused the
+  the computation for rejecting catalog creation based on expected cosmic ray
+  detections to fail ONLY for WFPC2.  Also, updated the WFPC2 cr_residual factor
+  from 0.0 to 0.05 as it had never be set correctly.  Created a PyTest for
+  WFPC2 SVM processing. [#nnnn]
+
 - Added a check on the EXPFLAG keyword to eliminate any images from being
   processed as part of a mosaic if the value EXPFLAG is not equal to NORMAL.
   Any value other than NORMAL indicates there was an issue during the exposure.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   the computation for rejecting catalog creation based on expected cosmic ray
   detections to fail ONLY for WFPC2.  Also, updated the WFPC2 cr_residual factor
   from 0.0 to 0.05 as it had never be set correctly.  Created a PyTest for
-  WFPC2 SVM processing. [#nnnn]
+  WFPC2 SVM processing. [#1969]
 
 - Added a check on the EXPFLAG keyword to eliminate any images from being
   processed as part of a mosaic if the value EXPFLAG is not equal to NORMAL.

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -595,10 +595,10 @@ class HAPCatalogs:
     # ACS/WFC: 4096**2 pixels, pixel size (15 um)**2
     # ACS/HRC: 1024**2 pixels, pixel size (21 um)**2
     # WFC3/UVIS: 4096**2 pixels, pixel size (15 um)**2
-    # WFPC2: 1600**2 pixels, pixel size (15um)**2
+    # WFPC2/PC: 1600**2 pixels, pixel size (15um)**2
     # acs/wfc-> crfactor = {'aperture': 300, 'segment': 150}  # CRs / hr / 4kx4k pixels
     crfactor = {'WFC': {'aperture': 300, 'segment': 150}, 'HRC': {'aperture': 37, 'segment': 18.5},
-                'UVIS': {'aperture': 300, 'segment': 150}, 'WFPC2': {'aperture': 46, 'segment': 23}}
+                'UVIS': {'aperture': 300, 'segment': 150}, 'PC': {'aperture': 46, 'segment': 23}}
 
     def __init__(self, fitsfile, param_dict, param_dict_qc, num_images_mask, log_level, diagnostic_mode=False, types=None,
                  tp_sources=None):

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/pc/wfpc2_pc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/pc/wfpc2_pc_catalog_generation_all.json
@@ -12,7 +12,7 @@
     "scale": 1.5,
     "sensitivity": 0.95,
     "block_size": [1024, 1024],
-    "cr_residual": 0.0,
+    "cr_residual": 0.05,
     "region_size": 11,
     "flag_trim_value": 5,
     "simple_bkg": false,

--- a/tests/hap/test_svm_u2as01.py
+++ b/tests/hap/test_svm_u2as01.py
@@ -1,0 +1,141 @@
+""" This module tests full pipeline SVM processing as a demonstration template.
+
+"""
+import datetime
+import glob
+import os
+import pytest
+import numpy as np
+
+from drizzlepac.haputils import astroquery_utils as aqutils
+from drizzlepac import runsinglehap
+from astropy.io import fits, ascii
+from pathlib import Path
+
+"""
+    test_svm_u2as01.py
+
+    This test file can be executed in the following manner:
+        $ pytest -s --basetemp=/internal/hladata/yourUniqueDirectoryHere test_svm_u2as01.py >& test_svm_u2as01.log &
+        $ tail -f test_svm_u2as01.log
+      * Note: When running this test, the `--basetemp` directory should be set to a unique
+        existing directory to avoid deleting previous test output.
+      * The POLLER_FILE exists in the tests/hap directory.
+
+"""
+
+POLLER_FILE = "wfpc2_2as_01_input.out"
+
+
+@pytest.fixture(scope="module")
+def read_csv_for_filenames():
+    # Read the CSV poller file residing in the tests directory to extract the individual visit FLT filenames
+    path = os.path.join(os.path.dirname(__file__), POLLER_FILE)
+    table = ascii.read(path, format="no_header")
+    filename_column = table.colnames[0]
+    filenames = list(table[filename_column])
+    print("\nread_csv_for_filenames. Filesnames from poller: {}".format(filenames))
+
+    return filenames
+
+
+@pytest.fixture(scope="module")
+def gather_data_for_processing(read_csv_for_filenames, tmp_path_factory):
+    # create working directory specified for the test
+    curdir = tmp_path_factory.mktemp(os.path.basename(__file__))
+    os.chdir(curdir)
+
+    # Establish FLT lists and obtain the requested data
+    flt_flag = ""
+    # In order to obtain individual FLT images from MAST (if the files do not reside on disk) which
+    # may be part of an ASN, use only IPPPSS with a wildcard.  The unwanted images have to be removed
+    # after-the-fact.
+    for fn in read_csv_for_filenames:
+        if fn.lower().endswith("flt.fits") and flt_flag == "":
+            flt_flag = fn[0:6] + "*"
+
+    # Get test data through astroquery - only retrieve the pipeline processed FLT files
+    # (e.g., j*_flt.fits) as necessary. The logic here and the above for loop is an attempt to
+    # avoid downloading too many images which are not needed for processing.
+    fltfiles = []
+    if flt_flag:
+        fltfiles = aqutils.retrieve_observation(flt_flag, suffix=["FLT"], product_type="pipeline")
+
+    print("\ngather_data_for_processing. Gathered data: {}".format(fltfiles))
+
+    return fltfiles
+
+
+@pytest.fixture(scope="module")
+def gather_output_data(construct_manifest_filename):
+    # Determine the filenames of all the output files from the manifest
+    print(f"\nManifest Filename: {construct_manifest_filename}")
+    files = []
+    with open(construct_manifest_filename, 'r') as fout:
+        for line in fout.readlines():
+            files.append(line.rstrip('\n'))
+    print("\ngather_output_data. Output data files: {}".format(files))
+
+    return files
+
+
+@pytest.fixture(scope="module")
+def construct_manifest_filename(read_csv_for_filenames):
+    # Construct the output manifest filename from input file keywords
+    inst = fits.getval(read_csv_for_filenames[0], "INSTRUME", ext=0).lower()
+    root = fits.getval(read_csv_for_filenames[0], "ROOTNAME", ext=0).lower()
+    tokens_tuple = (inst, root[1:4], root[4:6], "manifest.txt")
+    manifest_filename = "_".join(tokens_tuple)
+    print("\nconstruct_manifest_filename. Manifest filename: {}".format(manifest_filename))
+
+    return manifest_filename
+
+
+@pytest.fixture(scope="module", autouse=True)
+def svm_setup(gather_data_for_processing):
+    # Act: Process the input data by executing runsinglehap - time consuming activity
+
+    current_dt = datetime.datetime.now()
+    print(str(current_dt))
+    print("\nsvm_setup fixture")
+
+    # Read the "poller file" and download the input files, as necessary
+    input_names = gather_data_for_processing
+
+    # Run the SVM processing
+    path = os.path.join(os.path.dirname(__file__), POLLER_FILE)
+    try:
+        status = runsinglehap.perform(path)
+
+    # Catch anything that happens and report it.  This is meant to catch unexpected errors and
+    # generate sufficient output exception information so algorithmic problems can be addressed.
+    except Exception as except_details:
+        print(except_details)
+        pytest.fail("\nsvm_setup. Exception Visit: {}\n", path)
+
+    current_dt = datetime.datetime.now()
+    print(str(current_dt))
+
+
+# TESTS
+
+def test_svm_manifest_name(construct_manifest_filename):
+    # Construct the manifest filename from the header of an input file in the list and check it exists.
+    path = Path(construct_manifest_filename)
+    print("\ntest_svm_manifest. Filename: {}".format(path))
+
+    # Ensure the manifest file uses the proper naming convention
+    assert (path.is_file())
+
+
+def test_svm_empty_cats(gather_output_data):
+    # Check the output catalogs should contain > 0 measured sources
+    cat_files = [files for files in gather_output_data if files.lower().endswith("-cat.ecsv")]
+
+    valid_tables = {}
+    for cat in cat_files:
+        table_length = len(ascii.read(cat, format="ecsv"))
+        print("\ntest_svm_cat_sources. Number of sources in catalog {} is {}.".format(cat, table_length))
+        valid_tables[cat] = table_length > 0
+    bad_tables = [cat for cat in cat_files if not valid_tables[cat]]
+    assert len(bad_tables) == 0, f"Catalog file(s) {bad_tables} is/are unexpectedly empty"

--- a/tests/hap/wfpc2_2as_01_input.out
+++ b/tests/hap/wfpc2_2as_01_input.out
@@ -1,0 +1,8 @@
+u2as0101t_flt.fits
+u2as0102t_flt.fits
+u2as0103t_flt.fits
+u2as0104t_flt.fits
+u2as0105t_flt.fits
+u2as0106t_flt.fits
+u2as0107t_flt.fits
+u2as0108t_flt.fits


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1448](https://jira.stsci.edu/browse/HLA-1448)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Fixed the crfactor designation for the WFPC2 detector (PC) which caused the the computation for rejecting catalog creation based on expected cosmic ray detections to fail ONLY for WFPC2.  Also, updated the WFPC2 cr_residual factor from 0.0 to 0.05 as it had never be set correctly.  Created a PyTest for WFPC2 SVM processing.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [X] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)