### PR TITLE
HLA-1237: Removing user facing aspects of TEAL GUI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.9.2 (unreleased)
 ==================
 
+- Deprecated the TEAL GUI; TEAL is still used for loading configuration 
+  files. [#1975]
+
 - Fixed the crfactor designation for the WFPC2 detector (PC) which caused the
   the computation for rejecting catalog creation based on expected cosmic ray
   detections to fail ONLY for WFPC2.  Also, updated the WFPC2 cr_residual factor

--- a/doc/source/mast_data_products/reproducing_mast_data_products.rst
+++ b/doc/source/mast_data_products/reproducing_mast_data_products.rst
@@ -21,8 +21,8 @@ Alternative Usage
     >>> runastrodriz.process(inputFilename,force=False,newpath=None,inmemory=False)
 
 
-GUI Usage under Python (Legacy only)
-====================================
+GUI Usage under Python (no longer supported)
+============================================
 
     >>> python
     >>> from stsci.tools import teal

--- a/doc/source/user_reprocessing/image_registration.rst
+++ b/doc/source/user_reprocessing/image_registration.rst
@@ -10,9 +10,7 @@ for IRAF's ``tweakshifts``, currently named ``TweakReg``, along
 with tasks for updating the WCS in HST images and performing
 photometry equalization for WFPC2 data.
 
-These pages describe how to run the new ``TEAL``-enabled task,
-as well as use the classes in the task to generate catalogs interactively
-for any chip and work with that catalog. The current implementation of this
+The current implementation of this
 code relies on a very basic source finding algorithm loosely patterned
 after the DAOFIND algorithm and does not provide all the same features
 or outputs found in DAOFIND. The fitting algorithm also reproduces the

--- a/drizzlepac/__init__.py
+++ b/drizzlepac/__init__.py
@@ -23,6 +23,18 @@ from .version import __version__
 #if sys.version_info < (3, 8):
 #    raise ImportError("Drizzlepac requires Python 3.8 and above.")
 
+class hide_printed_output:
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self._original_stdout
+
+with hide_printed_output():        
+  import stsci.skypac
+
 from . import ablot
 from . import adrizzle
 from . import astrodrizzle
@@ -70,14 +82,6 @@ from . import pixreplace
 from . import haputils
 from . import align
 from . import runastrodriz
-
-# These lines allow TEAL to print out the names of TEAL-enabled tasks
-# upon importing this package.
-from stsci.tools import teal
-
-
-teal.print_tasknames(__name__, os.path.dirname(__file__),
-                     hidden=['adrizzle','ablot','buildwcs'])
 
 
 def help():

--- a/drizzlepac/ablot.help
+++ b/drizzlepac/ablot.help
@@ -157,11 +157,3 @@ command line, using the default parameter settings:
 >>> blotobj = teal.load('ablot') # get default values
 >>> ablot.blot('adriz_aligned_wcs_f814w_med.fits','j8c0d1bwq_flc.fits[sci,1]',
 'aligned_f814w_sci1_blot.fits',configObj=blotobj)
-
-or
-
->>> a = teal.teal('ablot')
-# set data = adriz_aligned_wcs_f814w_med.fits
-# set reference = j8c0d1bwq_flc.fits[sci,1]
-# set outdata = aligned_f814w_sci1_blot.fits
-

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -9,12 +9,10 @@ cosmic-rays.
 
 """
 import os
-import sys
 import numpy as np
-from stsci.tools import fileutil, teal, logutil
+from stsci.tools import fileutil, logutil
 from . import outputimage
 from . import wcs_functions
-from . import processInput
 from . import util
 import stwcs
 from stwcs import distortion
@@ -37,9 +35,6 @@ _blot_step_num_ = 5
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET)
 
 
-#
-#### User level interface run from TEAL
-#
 
 def blot(data, reference, outdata, configObj=None, wcsmap=wcs_functions.WCSMap,
          editpars=False, **input_dict):
@@ -49,8 +44,7 @@ def blot(data, reference, outdata, configObj=None, wcsmap=wcs_functions.WCSMap,
     input_dict['reference'] = reference
     input_dict['outdata'] = outdata
 
-    # If called from interactive user-interface, configObj will not be
-    # defined yet, so get defaults using EPAR/TEAL.
+    # gets configObj defaults using EPAR/TEAL.
     #
     # Also insure that the input_dict (user-specified values) are folded in
     # with a fully populated configObj instance.

--- a/drizzlepac/acsData.py
+++ b/drizzlepac/acsData.py
@@ -6,8 +6,6 @@ Class used to model ACS specific instrument data.
 :License: :doc:`/LICENSE`
 
 """
-from stsci.tools import fileutil
-import numpy as np
 from .imageObject import imageObject
 
 

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -9,11 +9,10 @@ Interfaces to main drizzle functions.
 import os
 import copy
 import time
-import platform
 from . import util
 import numpy as np
 from astropy.io import fits
-from stsci.tools import fileutil, logutil, mputil, teal
+from stsci.tools import fileutil, logutil, mputil
 from . import outputimage, wcs_functions
 import stwcs
 from stwcs import distortion
@@ -60,8 +59,7 @@ def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input
     input_dict['input'] = input
     input_dict['outdata'] = outdata
 
-    # If called from interactive user-interface, configObj will not be
-    # defined yet, so get defaults using EPAR/TEAL.
+    # gets configObj defaults using EPAR/TEAL.
     #
     # Also insure that the input_dict (user-specified values) are folded in
     # with a fully populated configObj instance.
@@ -617,8 +615,7 @@ def run_driz(imageObjectList, output_wcs, paramDict, single, build, wcsmap=None)
     # This buffer should be reused for each input if possible.
     #
     _outsci = _outwht = _outctx = _hdrlist = None
-    if (not single) or \
-       (single and (not run_parallel) and (not imageObjectList[0].inmemory)):
+    if (not single) or (single and (not run_parallel) and (not imageObjectList[0].inmemory)):
         # Note there are four cases/combinations for single drizzle alone here:
         # (not-inmem, serial), (not-inmem, parallel), (inmem, serial), (inmem, parallel)
         _outsci = np.empty(output_wcs.array_shape, dtype=np.float32)

--- a/drizzlepac/align.py
+++ b/drizzlepac/align.py
@@ -3,7 +3,6 @@
 """This script is a modernized implementation of tweakreg.
 
 """
-import copy
 import datetime
 import sys
 import glob

--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -34,12 +34,11 @@ Functions to build mask files for PyDrizzle.
 #
 import os
 
-from stsci.tools import fileutil, readgeis
+from stsci.tools import fileutil
 from stsci.tools.bitmask import bitfield_to_boolean_mask
 
 from astropy.io import fits
 import numpy as np
-from scipy import ndimage
 
 from . import processInput, util
 
@@ -55,8 +54,7 @@ __taskname__ = 'buildmask'
 def run(configObj=None, input_dict={}, loadOnly=False):
     """ Build DQ masks from all input images, then apply static mask(s).
     """
-    # If called from interactive user-interface, configObj will not be
-    # defined yet, so get defaults using EPAR/TEAL.
+    # gets configObj defaults using EPAR/TEAL.
     #
     # Also insure that the input_dict (user-specified values) are folded in
     # with a fully populated configObj instance.

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -6,15 +6,15 @@ Provides function for manipulating WCS in images.
 :License: :doc:`/LICENSE`
 
 """
-import sys, types, os, copy
+import os
 from . import util
 import numpy as np
 from astropy.io import fits
 
-from stsci.tools import fileutil,teal
-from . import outputimage, wcs_functions, processInput,util
+from stsci.tools import fileutil
+from . import wcs_functions, util
 import stwcs
-from stwcs import distortion, wcsutil
+from stwcs import wcsutil
 from stwcs.wcsutil import headerlet
 from . import __version__
 
@@ -32,9 +32,6 @@ user_hstwcs_pars = {'outscale':'pscale','orient':'orientat',
 model_attrs = ['cpdis1','cpdis2','det2im','det2im1','det2im2',
                     'ocx10','ocx11','ocy10','ocy11','sip']
 
-#
-#### User level interface run from TEAL
-#
 
 def buildwcs(outwcs, configObj=None,editpars=False,**input_dict):
     if input_dict is None:

--- a/drizzlepac/catalogs.py
+++ b/drizzlepac/catalogs.py
@@ -7,15 +7,12 @@ import os, sys
 import copy
 
 import numpy as np
-import astropy
 from astropy import wcs as pywcs
 import astropy.coordinates as coords
 from astropy import units as u
 from stsci.tools import logutil, textutil
 from stsci.skypac.utils import basicFITScheck, get_extver_list
 
-import stwcs
-from stwcs import wcsutil
 from astropy.io import fits
 import stsci.imagestats as imagestats
 import stregion as pyregion

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -14,9 +14,8 @@ from astropy.io import fits
 
 from stsci.imagestats import ImageStats
 from stsci.image import numcombine
-from stsci.tools import iterfile, teal, logutil
+from stsci.tools import iterfile, logutil
 
-from . import imageObject
 from . import util
 from .minmed import min_med
 from . import processInput

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -13,7 +13,7 @@ import re
 import numpy as np
 from scipy import signal
 from astropy.io import fits
-from stsci.tools import fileutil, logutil, mputil, teal
+from stsci.tools import fileutil, logutil, mputil
 
 
 from . import quickDeriv
@@ -44,8 +44,10 @@ def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     if not editpars:
         run(configObj)
 
-
-# this is the function that will be called from TEAL
+#--------------------------------
+# TEAL Interface functions
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
     # outwcs is not neaded here
     imgObjList, outwcs = processInput.setCommonInput(configObj,

--- a/drizzlepac/findobj.py
+++ b/drizzlepac/findobj.py
@@ -6,7 +6,6 @@ A suite of functions for finding sources in images.
 :License: :doc:`/LICENSE`
 
 """
-import sys
 import math
 
 import numpy as np

--- a/drizzlepac/imagefindpars.py
+++ b/drizzlepac/imagefindpars.py
@@ -4,8 +4,6 @@
 :License: :doc:`/LICENSE`
 
 """
-import os, string
-from stsci.tools import teal
 from . import util
 from . import __version__
 

--- a/drizzlepac/linearfit.py
+++ b/drizzlepac/linearfit.py
@@ -13,7 +13,6 @@
 
 """
 import numpy as np
-from numpy import linalg as npla
 from stsci.tools import logutil
 
 

--- a/drizzlepac/mapreg.py
+++ b/drizzlepac/mapreg.py
@@ -12,8 +12,6 @@ from astropy.io import fits
 import stregion as pyregion
 import stwcs
 import os
-from stsci.tools.fileutil import findExtname
-from stsci.tools import teal
 from . import util
 from .regfilter import fast_filter_outer_regions
 
@@ -1063,9 +1061,10 @@ def _check_FITS_extensions(img, extensions):
     return all_present
 
 
-#--------------------------
+#--------------------------------
 # TEAL Interface functions
-#--------------------------
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
     MapReg(input_reg   = configObj['input_reg'],
            images      = configObj['images'],

--- a/drizzlepac/mdriz.py
+++ b/drizzlepac/mdriz.py
@@ -8,10 +8,9 @@ Main program for running MultiDrizzle from the command line.
 
 """
 import getopt
-import sys, os
+import sys
 from drizzlepac.astrodrizzle import AstroDrizzle
 from drizzlepac import __version__
-from drizzlepac import util
 
 
 ruler = '-' * 80
@@ -34,13 +33,14 @@ def main() :
 
     # read options
     help = False
-    editpars = False
+    editpars = False # deprecated parameter left over from TEAL
     long_help = False
     for opt, value in optlist:
         if opt == '-h':
             help = True
         elif opt == '-g':
             editpars = True
+            raise ValueError('The -g option and TEAL GUI are no longer supported.')
         elif opt == '-?':
             long_help = True
 
@@ -50,7 +50,7 @@ def main() :
     if help:
         print('Syntax: mdriz.py -[h|g|?] [name=value,...]')
         print('  Options: -h: help')
-        print('           -g: edit parameters with TEAL')
+        print('           -g: deprecated parameter left over from TEAL')
         print('           -?: extended help message')
         print('  Parameters should be given as "name=value" pairs for all parameters')
         print('      understood by MultiDrizzle. These values will ALWAYS override')

--- a/drizzlepac/photeq.py
+++ b/drizzlepac/photeq.py
@@ -21,18 +21,12 @@ import logging
 
 # THIRD PARTY
 import numpy as np
-from astropy.io import fits
 from . import __version__
 
 __all__ = ['photeq']
 __taskname__ = 'photeq'
 __author__ = 'Mihai Cara'
 
-
-try:
-    from stsci.tools import teal
-except ImportError:
-    teal = None
 
 # LOCAL
 from stsci.skypac import parseat, utils
@@ -591,9 +585,10 @@ def photeq(files='*_flt.fits', sciext='SCI', errext='ERR',
             _log.removeHandler(h)
 
 
-#--------------------------
+#--------------------------------
 # TEAL Interface functions
-#--------------------------
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
     logfile = configObj['logfile'] if len(configObj['logfile'].strip()) > 0 \
         else None

--- a/drizzlepac/pixreplace.py
+++ b/drizzlepac/pixreplace.py
@@ -3,9 +3,6 @@
     :License: :doc:`/LICENSE`
 
 """
-
-import os
-
 import numpy as np
 from astropy.io import fits
 
@@ -107,11 +104,10 @@ def replace(input, **pars):
         fimg.close()
 
 
-##############################
-#
-# TEAL Interfaces
-#
-##############################
+#--------------------------------
+# TEAL Interface functions
+# (these functions are deprecated)
+#---------------------------------
 def run(configobj):
 
     ext = util.check_blank(configobj['ext'])

--- a/drizzlepac/pixtopix.py
+++ b/drizzlepac/pixtopix.py
@@ -92,10 +92,9 @@
                 output="xy_flt1.dat")
 
 """
-import os
 import numpy as np
 
-from stsci.tools import fileutil, teal
+from stsci.tools import fileutil
 from stwcs import wcsutil, distortion
 from . import wcs_functions
 from . import util
@@ -202,9 +201,10 @@ def tran(inimage, outimage, direction='forward', x=None, y=None,
     return outx, outy
 
 
-# --------------------------
+#--------------------------------
 # TEAL Interface functions
-# --------------------------
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
     coordfile = util.check_blank(configObj['coordfile'])
     colnames = util.check_blank(configObj['colnames'])

--- a/drizzlepac/pixtosky.py
+++ b/drizzlepac/pixtosky.py
@@ -81,15 +81,12 @@
        ...                      colnames=['c3','c4'], output="radec_sci1.dat")
 
 """
-import os,copy
 import warnings
 import numpy as np
 
-from stsci.tools import fileutil, teal
 from . import util
 from . import wcs_functions
-import stwcs
-from stwcs import distortion, wcsutil
+from stwcs import wcsutil
 from . import __version__
 
 __taskname__ = 'pixtosky'
@@ -183,9 +180,10 @@ def xy2rd(input,x=None,y=None,coords=None, coordfile=None,colnames=None,separato
 
     return ra,dec
 
-#--------------------------
+#--------------------------------
 # TEAL Interface functions
-#--------------------------
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
 
     if 'coords' in configObj:

--- a/drizzlepac/processInput.py
+++ b/drizzlepac/processInput.py
@@ -28,7 +28,6 @@ as well to fully setup all inputs for use with the rest of the MultiDrizzle
 steps either as stand-alone tasks or internally to MultiDrizzle itself.
 
 """
-import datetime
 import os
 import shutil
 import string

--- a/drizzlepac/refimagefindpars.py
+++ b/drizzlepac/refimagefindpars.py
@@ -5,8 +5,6 @@
 :License: :doc:`/LICENSE`
 
 """
-import os
-from stsci.tools import teal
 from . import util
 from . import __version__
 

--- a/drizzlepac/resetbits.py
+++ b/drizzlepac/resetbits.py
@@ -62,9 +62,6 @@ EXAMPLES
         >>> resetbits.reset_dq_bits("input_file_flt.fits", 2+32+64+4096, extver=2)
 
 """
-import os
-import numpy as np
-
 from stsci.tools import stpyfits as fits
 from stsci.tools import parseinput, logutil
 from stsci.tools.bitmask import interpret_bit_flags
@@ -149,9 +146,10 @@ def reset_dq_bits(input,bits,extver=None,extname='dq'):
         # close the file with the updated DQ array(s)
         p.close()
 
-#
-#### Interfaces used by TEAL
-#
+#--------------------------------
+# TEAL Interface functions
+# (these functions are deprecated)
+#---------------------------------
 def run(configobj=None):
     """ Teal interface for running this code. """
     reset_dq_bits(configobj['input'],configobj['bits'],

--- a/drizzlepac/sky.help
+++ b/drizzlepac/sky.help
@@ -57,9 +57,7 @@ inputDict : dict, optional
       parameters can be altered on the fly using the ``inputDict``. If ``configObj``
       is set to None and there is no ``inputDict`` information, then the values
       for the parameters will be pulled from the default configuration files
-      for the task. These are the same configuration files that are
-      referenced in the TEAL parameter interface GUI. If you wish to edit
-      these parameters by hand in the GUI, simply set editpars=True.
+      for the task.
 
     Table of optional parameters that should be in ``configobj`` and can also be
     specified in ``inputDict``.

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -13,17 +13,16 @@ import os, sys
 
 import numpy as np
 
-from stsci.tools import fileutil, teal, logutil
+from stsci.tools import fileutil, logutil
 from stsci.tools.bitmask import interpret_bit_flags
 import stsci.imagestats as imagestats
 
 from stsci.skypac.skymatch import skymatch
-from stsci.skypac.utils import MultiFileLog, ResourceRefCount, ext2str, \
+from stsci.skypac.utils import MultiFileLog, ext2str, \
      file_name_components, in_memory_mask, temp_mask_file, openImageEx
 from stsci.skypac.parseat import FileExtMaskInfo, parse_at_file
 
 from . import processInput
-from .imageObject import imageObject
 
 from . import util
 from . import __version__

--- a/drizzlepac/skytopix.help
+++ b/drizzlepac/skytopix.help
@@ -75,7 +75,7 @@ couple of common modes.
 
 1. Convert a single sky position (0:22:07.0088,-72:03:05.429)
     from a calibrated ACS image (j94f05bgq\_flt.fits) into a
-    pixel position (X,Y) without using the TEAL GUI:
+    pixel position (X,Y):
 
   >>> from drizzlepac import skytopix
   >>> x,y = skytopix.rd2xy("j8bt06nyq_flt.fits[sci,1]",
@@ -84,7 +84,7 @@ couple of common modes.
 2. Convert a list of (undistorted) sky positions from the file,
     'radec.dat' for a calibrated ACS image (j8bt06nyq_flt.fits)
      into distorted pixel positions, and write out the result to
-     the file 'xypos.dat' without using the TEAL GUI:
+     the file 'xypos.dat':
 
   >>> x,y = skytopix.rd2xy("j8bt06nyq_flt.fits[sci,1]",
   ...                      coordfile="radec.dat", output="xypos.dat")

--- a/drizzlepac/skytopix.py
+++ b/drizzlepac/skytopix.py
@@ -70,14 +70,10 @@
                 colnames=['c3','c4'], output="xy_sci1.dat")
 
 """
-import os,copy
 import numpy as np
 
-from astropy.io import fits
-from stsci.tools import fileutil, teal
-from . import util,wcs_functions,tweakutils
-import stwcs
-from stwcs import distortion,wcsutil
+from . import util,tweakutils
+from stwcs import wcsutil
 from . import __version__
 
 __taskname__ = 'skytopix'
@@ -159,9 +155,10 @@ def rd2xy(input,ra=None,dec=None,coordfile=None,colnames=None,
     return outx, outy
 
 
-#--------------------------
+#--------------------------------
 # TEAL Interface functions
-#--------------------------
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
 
     coordfile = util.check_blank(configObj['coordfile'])

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -13,8 +13,7 @@ import os
 import sys
 
 import numpy as np
-from stsci.tools import fileutil, teal, logutil
-import astropy
+from stsci.tools import fileutil, logutil
 from astropy.io import fits
 from stsci.imagestats import ImageStats
 from . import util
@@ -53,7 +52,10 @@ def createMask(input=None, static_sig=4.0, group=None, editpars=False, configObj
     if not editpars:
         run(configObj)
 
-# this is called by the TEAL interface
+#--------------------------------
+# TEAL Interface functions
+# (these functions are deprecated)
+#---------------------------------
 def run(configObj):
 
     #now we really just need the imageObject list created for the dataset

--- a/drizzlepac/tweakback.py
+++ b/drizzlepac/tweakback.py
@@ -837,9 +837,10 @@ def update_chip_wcs(chip_wcs, drz_old_wcs, drz_new_wcs,
         chip_wcs.wcs.crder = np.array([xrms,yrms])
 
 
-#### TEAL Interfaces to run this task
-
-
+#--------------------------------
+# TEAL Interface functions
+# (these functions are deprecated)
+#---------------------------------
 def run(configobj):
     # Interpret user-input from TEAL GUI and call function
     tweakback(configobj['drzfile'], newname = configobj['newname'],

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -6,11 +6,10 @@
 
 """
 import os
-import sys
 import numpy as np
 from copy import copy
 
-from stsci.tools import parseinput, teal
+from stsci.tools import teal
 from stsci.tools import logutil, textutil
 from stsci.tools.cfgpars import DuplicateKeyError
 from stwcs import updatewcs
@@ -69,24 +68,6 @@ def _managePsets(configobj, section_name, task_name, iparsobj=None, input_dict=N
 
     # merge these parameters into full set
     configobj[section_name].merge(iparsobj_cfg)
-
-    # clean up configobj a little to make it easier for later...
-#   if '_RULES_' in configobj:
-#       del configobj['_RULES_']
-
-
-def edit_imagefindpars():
-    """ Allows the user to edit the imagefindpars configObj in a TEAL GUI
-        """
-    teal.teal(imagefindpars.__taskname__, returnAs=None,
-              autoClose=True, loadOnly=False, canExecute=False)
-
-def edit_refimagefindpars():
-    """ Allows the user to edit the refimagefindpars configObj in a TEAL GUI
-        """
-    teal.teal(refimagefindpars.__taskname__, returnAs=None,
-              autoClose=True, loadOnly=False, canExecute=False)
-
 
 @util.with_logging
 def run(configobj):

--- a/drizzlepac/updatenpol.py
+++ b/drizzlepac/updatenpol.py
@@ -228,9 +228,10 @@ def find_npolfile(flist,detector,filters):
                 npolfile = f
     return npolfile
 
-#
-#### Interfaces used by TEAL
-#
+#--------------------------------
+# TEAL Interface functions
+# (these functions are deprecated)
+#---------------------------------
 def run(configobj=None,editpars=False):
     """ Teal interface for running this code.
     """

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -709,8 +709,8 @@ def getDefaultConfigObj(taskname, configObj, input_dict={}, loadOnly=True):
             what gets loaded in from the .cfg file for the task
 
         loadOnly : bool
-            Setting 'loadOnly' to False causes the TEAL GUI to start allowing the
-            user to edit the values further and then run the task if desired.
+            Deprecated parameter left over from TEAL. The teal.load function is 
+            still used for loading configuration files. 
 
     """
     if configObj is None:
@@ -741,12 +741,6 @@ def getDefaultConfigObj(taskname, configObj, input_dict={}, loadOnly=True):
 
         # If everything looks good, merge user inputs with configObj and continue
         cfgpars.mergeConfigObj(configObj, input_dict)
-
-    if not loadOnly:
-    # We want to run the GUI AFTER merging in any parameters
-    # specified by the user on the command-line and provided in
-    # input_dict
-        configObj = teal.teal(configObj, loadOnly=False)
 
     return configObj
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1237](https://jira.stsci.edu/browse/HLA-1237)

<!-- describe the changes comprising this PR here -->
This PR removes the user facing aspects of the TEAL GUI. This includes documentation and adds deprecation comments and warnings to some features. I had added comments that TEAL is deprecated in the locations of the code where TEAL calls "run" functions. 

In a subsequent PR I will remove these "run" functions and fold them into the rest of the code. 

I have also remove a number of unused imports, and now suppress the teal import return statement when teal is imported using stsci.skypac. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)