### PR TITLE
Updated the MVM ACS/WFC quality control JSON file

### DIFF
--- a/drizzlepac/pars/hap_pars/mvm_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -25,8 +25,7 @@
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
         "TWEAK_FWHMPSF": 0.073,
-        "TWEAK_THRESHOLD": 3.0,
-        "bthresh": 5.0
+        "TWEAK_THRESHOLD": 3.0
     },
     "sourcex": {
         "fwhm": 0.073,

--- a/drizzlepac/pars/hap_pars/mvm_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -25,8 +25,7 @@
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
         "TWEAK_FWHMPSF": 0.065,
-        "TWEAK_THRESHOLD": 3.0,
-        "bthresh": 5.0
+        "TWEAK_THRESHOLD": 3.0
     },
     "sourcex": {
         "fwhm": 0.065,

--- a/drizzlepac/pars/hap_pars/mvm_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -25,8 +25,7 @@
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
         "TWEAK_FWHMPSF": 0.076,
-        "TWEAK_THRESHOLD": null,
-        "bthresh": 1.5
+        "TWEAK_THRESHOLD": null
     },
     "sourcex": {
         "fwhm": 0.13,

--- a/drizzlepac/pars/hap_pars/mvm_parameters/acs/wfc/acs_wfc_quality_control_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/acs/wfc/acs_wfc_quality_control_all.json
@@ -1,7 +1,7 @@
 {
     "ci filter": {
       "aperture": {
-        "bthresh": 1.5,
+        "bthresh": 5.0,
         "lookup_ci_limits_from_table": true,
         "ci_lower_limit": 0.9,
         "ci_upper_limit": 1.23

--- a/drizzlepac/pars/hap_pars/mvm_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -25,8 +25,7 @@
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
         "TWEAK_FWHMPSF": 0.14,
-        "TWEAK_THRESHOLD": 3.0,
-        "bthresh": 5.0
+        "TWEAK_THRESHOLD": 3.0
     },
     "sourcex": {
         "fwhm": 0.14,

--- a/drizzlepac/pars/hap_pars/mvm_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -25,8 +25,7 @@
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
         "TWEAK_FWHMPSF": 0.076,
-        "TWEAK_THRESHOLD": 3.0,
-        "bthresh": 5.0
+        "TWEAK_THRESHOLD": 3.0
     },
     "sourcex": {
         "fwhm": 0.076,

--- a/drizzlepac/pars/hap_pars/mvm_parameters/wfpc2/pc/wfpc2_pc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/wfpc2/pc/wfpc2_pc_catalog_generation_all.json
@@ -25,8 +25,7 @@
         "bkgsig_sf": 4.0,
         "kernel_sd_aspect_ratio": 0.8,
         "TWEAK_FWHMPSF": 0.14,
-        "TWEAK_THRESHOLD": 3.0,
-        "bthresh": 5.0
+        "TWEAK_THRESHOLD": 3.0
     },
     "sourcex": {
         "fwhm": 0.14,


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
Updated the MVM ACS/WFC quality control JSON file to change the value
of "bthresh" to 5.0 to match the "bthresh" values in the other detector
quality control files, as well as its corresponding SVM file. Modified
all the MVM catalog JSON files to remove the "bthresh" variable.

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)