### PR TITLE
Dropping support for python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         brew:
           - hdf5
       envs: |
-        - linux: py310-xdist
         - linux: py311-xdist
         - linux: py312-xdist
         # `tox` does not currently respect `requires-python` versions when creating testing environments;

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
-3.9.2 (unreleased)
-==================
+3.10.0 (24-Mar-2025)
+====================
+
+- Dropped support for python 3.10 due to conflict with photutils. [1987]
 
 - Added documentation for the alignment logic and the selection of the SVM
   reference image. [#1967]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "drizzlepac"
 description = " HST image combination using the drizzle algorithm to combine astronomical images, to model image distortion, to remove cosmic rays, and generally to improve the fidelity of data in the final image. "
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Megan Sosey" },
     { name = "Warren Hack" },


### PR DESCRIPTION
We are removing support for python 3.10. 

We have specified that drizzlepac now requires python >=3.11 in the pyproject.toml and this removes the last (CI) test that we do under python 3.10. 