### PR TITLE
Fix for I/O astrometry database bug

### DIFF
--- a/drizzlepac/__init__.py
+++ b/drizzlepac/__init__.py
@@ -17,22 +17,11 @@ cosmic-ray cleaned, and combined image as a FITS file.
 import os
 import re
 import sys
+import contextlib
 
 from .version import __version__
 
-#if sys.version_info < (3, 8):
-#    raise ImportError("Drizzlepac requires Python 3.8 and above.")
-
-class hide_printed_output:
-    def __enter__(self):
-        self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        sys.stdout.close()
-        sys.stdout = self._original_stdout
-
-with hide_printed_output():        
+with contextlib.redirect_stdout(None):  
   import stsci.skypac
 
 from . import ablot


### PR DESCRIPTION
This issue is resolved by using _contextlib_ instead of a standalone function for silencing the teal import line from stsci.skypac. 