### PR TITLE
Remove duplicated log lines from dependencies in runastrodriz

### DIFF
--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -95,7 +95,6 @@ except ImportError:
     Process = None
 
 # THIRD-PARTY
-import logging
 import numpy as np
 import astropy.units as u
 from astropy.io import fits
@@ -132,7 +131,6 @@ from drizzlepac import photeq
 
 from drizzlepac import __version__
 
-logger = logging.getLogger()
 
 __taskname__ = "runastrodriz"
 
@@ -603,7 +601,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
                 wcs_pos = SkyCoord(header_ex1['CRVAL1']*u.deg, header_ex1['CRVAL2']*u.deg)
                 sep = wcs_pos.separation(targ_pos)
                 if sep > warning_separation_threshold:
-                    logger.warning(f'WARNING: WCS reference pixel is {sep.value:.2f} degrees '+
+                    print(f'WARNING: WCS reference pixel is {sep.value:.2f} degrees '+
                                    'from target position. The astrometry database solution is suspect!')
 
             _trlmsg += "Adding apriori WCS solutions to {}\n".format(_calfiles)


### PR DESCRIPTION
I recently added a simple logger and logged warning to runastrodriz without understanding the complicated nature of logging in drizzlepac. I am working on a full logging solution on [a different branch](https://github.com/spacetelescope/drizzlepac/tree/logging_spring_25), but in the meantime, this small change resulted in some duplicated lines from stwcs:

> Updating astrometry for ib4606c5q
> Updating astrometry for ib4606c5q
> Accessing AstrometryDB service :
> Accessing AstrometryDB service :
>         https://mast.stsci.edu/portal/astrometryDB/observation/read/ib4606c5q
>         https://mast.stsci.edu/portal/astrometryDB/observation/read/ib4606c5q
> AstrometryDB service call succeeded
> AstrometryDB service call succeeded
> Retrieving astrometrically-updated WCS "OPUS" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "OPUS" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "OPUS-GSC240" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "OPUS-GSC240" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-GSC240" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-GSC240" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "OPUS-HSC30" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "OPUS-HSC30" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-HSC30" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-HSC30" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-FIT_REL_GAIADR2" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-FIT_REL_GAIADR2" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-FIT_SVM_GAIADR2" for observation "ib4606c5q"
> Retrieving astrometrically-updated WCS "IDC_2731450pi-FIT_SVM_GAIADR2" for observation "ib4606c5q"

In order to fix these for the time being, I have removed the logger and added the logger warning as a print statement. 

I also removed a duplicated "import logging" statement. 