### PR TITLE
Reverting EXPFLAG change from PR #1968

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,11 +44,6 @@ number of the code change for that issue.  These PRs can be viewed at:
   from 0.0 to 0.05 as it had never be set correctly.  Created a PyTest for
   WFPC2 SVM processing. [#1969]
 
-- Added a check on the EXPFLAG keyword to eliminate any images from being
-  processed as part of a mosaic if the value EXPFLAG is not equal to NORMAL.
-  Any value other than NORMAL indicates there was an issue during the exposure.
-  [#1968]
-
 - Updated the Pyproject.toml file to force use of Photutils v2.0.0 or greater.
   This update is in support of the change addressed by #1950. [#1966]
 

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -515,9 +515,9 @@ def analyze_data(input_file_list, log_level=logutil.logging.DEBUG, type=""):
             no_proc_value = chinject
 
         # Exposure flag indicates a "issue" happened during an exposure
-        elif (expflag != 'NORMAL'):
-            no_proc_key = hdr_keys['QUALKEY']
-            no_proc_value = expflag
+        # elif (expflag != 'NORMAL'):
+        #     no_proc_key = hdr_keys['QUALKEY']
+        #     no_proc_value = expflag
 
         # Ramp filter images should not be processed for MVM products.
         #


### PR DESCRIPTION
This PR comments out the behavior the recently added behavior for the EXPFLAG in #1968.

I have commented out code that was taking files with EXPFLAG not set as "NORMAL" and adding a no_procesing flag to them during alignment. This was resulting in these files not being aligned. As the fraction of these files is actually quite high, we have elected to remove this change for the time being until a more tempered solution is found. 