### PR TITLE
HLA-1483: Remove the extraneous column from Point source Total catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.10.0 (24-Mar-2025)
 ====================
 
+- Removed the extra column in the Point source identifcation table when using the
+  DAOStarFinder or IRAFStarFinder utilities.  The extra column, daofind_mag, was
+  added in Photutils 2.0. [#nnnn]
+
 - Dropped support for Python v3.10 due to conflict with upgrading to
   Photutils v2.2.0. [#1987]
 

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1164,8 +1164,6 @@ class HAPPointCatalog(HAPCatalogBase):
                         daofind = DAOStarFinder(fwhm=source_fwhm,
                                                 threshold=self.param_dict['nsigma'] * reg_rms_median)
                         reg_sources = daofind(region, mask=self.image.inv_footprint_mask)
-                        reg_sources = Table(reg_sources)  # Insure 'reg_sources' is NOT a QTable
-
                 else:
                     err_msg = "'{}' is not a valid 'starfinder_algorithm' parameter input in the catalog_generation parameters json file. Valid options are 'dao' for photutils.detection.DAOStarFinder() or 'iraf' for photutils.detection.IRAFStarFinder().".format(self.param_dict["starfinder_algorithm"])
                     log.error(err_msg)
@@ -1173,6 +1171,14 @@ class HAPPointCatalog(HAPCatalogBase):
                 log.info("{}".format("=" * 80))
                 # Concatenate sources found in each region.
                 if reg_sources is not None:
+                    # Convert the QTable to an Astropy Table
+                    reg_sources = Table(reg_sources)
+
+                    # Remove the extra column added in Photutils v2.0.  A "daofind_mag"
+                    # column was added for comparison to the original IRAF DAOFIND algorithm.
+                    #if "daofind_mag" in reg_sources.colnames:
+                    #    reg_sources.remove_column("daofind_mag")
+
                     if sources is None:
                         sources = reg_sources
                     else:

--- a/tests/hap/test_svm_je281u.py
+++ b/tests/hap/test_svm_je281u.py
@@ -166,6 +166,42 @@ def test_svm_wcs(gather_output_data):
         assert WCS_SUB_NAME in wcsname, f"WCSNAME is not as expected for file {tdp}."
 
 
+def test_svm_point_cat_cols(gather_output_data):
+    # Check the total catalog product does not contain any unexpected, non-filter dependent columns
+    tdp_files = [files for files in gather_output_data if files.lower().find("total") > -1 and files.lower().endswith("point-cat.ecsv")]
+
+    ref_strings = ["ID", "Center", "RA", "DEC"]
+    for tdp in tdp_files:
+        table = ascii.read(tdp, format="ecsv")
+        sub_columns = []
+        for c in table.colnames:
+            if "_f" not in c:
+                strip_c = c.lstrip("XY-")
+                sub_columns.append(strip_c)
+
+        for c in sub_columns:
+            if c not in ref_strings:
+                assert 0, f"Unexpected column, {c}, found in Total Point Catalog file"
+
+
+def test_svm_segment_cat_cols(gather_output_data):
+    # Check the total catalog product does not contain any unexpected, non-filter dependent columns
+    tdp_files = [files for files in gather_output_data if files.lower().find("total") > -1 and files.lower().endswith("segment-cat.ecsv")]
+
+    ref_strings = ["ID", "Centroid", "RA", "DEC"]
+    for tdp in tdp_files:
+        table = ascii.read(tdp, format="ecsv")
+        sub_columns = []
+        for c in table.colnames:
+            if "_f" not in c:
+                strip_c = c.lstrip("XY-")
+                sub_columns.append(strip_c)
+
+        for c in sub_columns:
+            if c not in ref_strings:
+                assert 0, f"Unexpected column, {c}, found in Total Segment Catalog file"
+
+
 def test_svm_cat_sources(gather_output_data):
     # Check the output catalogs should contain > 0 measured sources
     cat_files = [files for files in gather_output_data if files.lower().endswith("-cat.ecsv")]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1483](https://jira.stsci.edu/browse/HLA-1483)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Removed the extra column in the Point source identification table when using DAOStarFinder or IRAFStarFinder.  The extra column, daofind_mag, was added in Photutils 2.0.  Ensure all returned tables from these "finders" are converted from QTable to Astropy Table.  Modified the hap/test_svm_je281u.py PyTest to look for unexpected column.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [X] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)