### PR TITLE
HLA-1484: Resolve issue of duplicate IDs in the Total Point Catalog product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   returned tables are stacked to generate a final table. The "id" number was not
   updated to reflect the stacking of the tables which created rows with the same
   "id".  This error did not cause the code to fail, but it did generate a garbled
-  table. [#nnnn]
+  table. [#2007]
 
 - Removed the extra column in the Point source identifcation table when using the
   DAOStarFinder or IRAFStarFinder utilities.  The extra column, daofind_mag, was

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,14 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.10.0 (24-Mar-2025)
 ====================
+- Resolved the issue of duplicate "ID"s in the rows of the Total Point catalog.
+  For "point" source identification, looping is done over a list of weight masks,
+  tp_masks, when invoking the "finder" algorithms. Tables are returned with a
+  unique "id" number for each row/source in the table. When tp_masks > 1, the
+  returned tables are stacked to generate a final table. The "id" number was not
+  updated to reflect the stacking of the tables which created rows with the same
+  "id".  This error did not cause the code to fail, but it did generate a garbled
+  table. [#nnnn]
 
 - Removed the extra column in the Point source identifcation table when using the
   DAOStarFinder or IRAFStarFinder utilities.  The extra column, daofind_mag, was

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1080,6 +1080,7 @@ class HAPPointCatalog(HAPCatalogBase):
             log.info("{}".format("=" * 80))
 
             sources = None
+            last_used_id = 0
             for masknum, mask in enumerate(self.tp_masks):
                 # apply mask for each separate range of WHT values
                 region = image * mask['mask']
@@ -1170,6 +1171,8 @@ class HAPPointCatalog(HAPCatalogBase):
                     raise ValueError(err_msg)
                 log.info("{}".format("=" * 80))
                 # Concatenate sources found in each region.
+                # NOTE: The unique "id" column must be updated manually so when the sources
+                # and reg_sources are "vstacked", all the rows stil have a unique id.
                 if reg_sources is not None:
                     # Convert the QTable to an Astropy Table
                     reg_sources = Table(reg_sources)
@@ -1180,9 +1183,12 @@ class HAPPointCatalog(HAPCatalogBase):
                         reg_sources.remove_column("daofind_mag")
 
                     if sources is None:
+                        last_used_id = reg_sources['id'][-1]
                         sources = reg_sources
                     else:
+                        reg_sources['id'][:] +=  last_used_id
                         sources = vstack([sources, reg_sources])
+                        last_used_id = sources['id'][-1]
 
             # If there are no detectable sources in the total detection image, return as there is nothing more to do.
             if not sources:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1484](https://jira.stsci.edu/browse/HLA-1484)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Resolved the issue of duplicate "ID"s in the rows of the Total Point catalog. For "point"
source identification, looping is done over a list of weight masks, tp_masks, when invoking the "finder" algorithms. These algorithms return tables with a unique "id" number for each row/source in the table. When tp_masks > 1, the returned tables are "vstacked" to generate a final table. Unfortunately, the "id" number was not updated to reflect the stacking of the tables which created rows with the same "id".  This error did not cause the code to fail, but it did generate a garbled table.

It is believed this bug was introduced in HLA-1407/PR#1939 which is an update for this latest build (v3.10x) when the computation of the tp_masks was fixed as previously only one mask was ever generated (or so it is believed).  In essence, this was a bug waiting to happen.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)