### PR TITLE
HLA-1482: Force use of Astropy 6.1.7 for Drizzlepac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 - Force use of Astropy 6.1.7 in pyproject.toml at this time. Significant
   upgrades in the underlying functionality, particularly in astropy.modelling.fitting
   have not been accommodated resulting in a degradation of measurement results
-  for the output Point product catalogs. [#nnnn]
+  for the output Point product catalogs. [#2009]
 
 - Resolved the issue of duplicate "ID"s in the rows of the Total Point catalog.
   For "point" source identification, looping is done over a list of weight masks,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.10.0 (24-Mar-2025)
 ====================
+- Force use of Astropy 6.1.7 in pyproject.toml at this time. Significant
+  upgrades in the underlying functionality, particularly in astropy.modelling.fitting
+  have not been accommodated resulting in a degradation of measurement results
+  for the output Point product catalogs. [#nnnn]
+
 - Resolved the issue of duplicate "ID"s in the rows of the Total Point catalog.
   For "point" source identification, looping is done over a list of weight masks,
   tp_masks, when invoking the "finder" algorithms. Tables are returned with a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ requires = [
     "setuptools_scm[toml]>=3.4",
     "wheel",
     "numpy>=2.0.0rc2",
-    "astropy>=5.0.4",
+    "astropy>=5.0.4,<7",
     "markupsafe<=2.0.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "astropy>=5.0.4",
+    "astropy>=5.0.4,<7",
     "fitsblender>=0.4.2",
     "scipy",
     "matplotlib",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1482](https://jira.stsci.edu/browse/HLA-1482)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Force use of Astropy 6.1.7 in the Drizzlepac pyproject.toml at this time. Significant upgrades in the underlying functionality, particularly in astropy.modelling.fitting have not been accommodated in the drizzlepac code, resulting in a degradation of measurement results for the output Point product catalogs.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)