### PR TITLE
HLA-1482/HLA-1487: Added parameter setting to the IterativePSFPhotometry call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 ====================
 - Added parameter setting, sub_shape, to the IterativePSFPhotometry invocation
   to ensure a rectangular shape around the center of a star is defined when
-  subtracting PSF models. [#nnnn]
+  subtracting PSF models. [#2014]
 
 - Resolved the issue of duplicate "ID"s in the rows of the Total Point catalog.
   For "point" source identification, looping is done over a list of weight masks,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,10 +19,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.10.0 (24-Mar-2025)
 ====================
-- Force use of Astropy 6.1.7 in pyproject.toml at this time. Significant
-  upgrades in the underlying functionality, particularly in astropy.modelling.fitting
-  have not been accommodated resulting in a degradation of measurement results
-  for the output Point product catalogs. [#2009]
+- Added parameter setting, sub_shape, to the IterativePSFPhotometry invocation
+  to ensure a rectangular shape around the center of a star is defined when
+  subtracting PSF models. [#nnnn]
 
 - Resolved the issue of duplicate "ID"s in the rows of the Total Point catalog.
   For "point" source identification, looping is done over a list of weight masks,

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -879,6 +879,7 @@ def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
                                               aperture_radius=aperture_radius,
                                               fitter=fitter,
                                               fit_shape=(11, 11),
+                                              sub_shape=(11, 11),
                                               maxiters=2)
 
         phot_results = itr_phot_obj(psf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "astropy>=5.0.4,<7",
+    "astropy>=5.0.4",
     "fitsblender>=0.4.2",
     "scipy",
     "matplotlib",
@@ -99,7 +99,7 @@ requires = [
     "setuptools_scm[toml]>=3.4",
     "wheel",
     "numpy>=2.0.0rc2",
-    "astropy>=5.0.4,<7",
+    "astropy>=5.0.4",
     "markupsafe<=2.0.1",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1482](https://jira.stsci.edu/browse/HLA-1482)
Resolves [HLA-1487](https://jira.stsci.edu/browse/HLA-1487)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Added the parameter setting, _sub_shape_, to the IterativePSFPhotometry call to ensure a rectangular shape around the center of a star is defined when subtracting the fitted PSF models. The _sub_shape_ must be specified if the model does not have a "bounding_box" attribute.  This parameter no longer is set in the IterativePSFPhotometry class based upon the _fit_shape_.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)