### PR TITLE
HLA-1497: Corrected the string comparison to "asn" in the poller_utils.py module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   routine of the poller_utils.py module as these characters are
   a valid portion of the root of an ipppssoot filename (e.g., j6kasn01q).
   The comparison is now done against "_asn" when looking for association
-  names in order to perform the proper actions. [#nnnn]
+  names in order to perform the proper actions. [#2019]
 
 - Added parameter setting, sub_shape, to the IterativePSFPhotometry invocation
   to ensure a rectangular shape around the center of a star is defined when

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,13 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 3.10.0 (24-Mar-2025)
 ====================
+
+- Corrected the use of a string comparison to "asn" in the build_poller_table
+  routine of the poller_utils.py module as these characters are
+  a valid portion of the root of an ipppssoot filename (e.g., j6kasn01q).
+  The comparison is now done against "_asn" when looking for association
+  names in order to perform the proper actions. [#nnnn]
+
 - Added parameter setting, sub_shape, to the IterativePSFPhotometry invocation
   to ensure a rectangular shape around the center of a star is defined when
   subtracting PSF models. [#2014]

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -1294,7 +1294,7 @@ def build_poller_table(
     if not is_poller_file:
         for filename in filenames:
             # Look for dataset in local directory.
-            if "_asn" in filename or not os.path.exists(filename):
+            if "_asn" in filename.lower() or not os.path.exists(filename):
                 # This retrieval will NOT overwrite any ASN members already on local disk
                 # Return value will still be list of all members
                 files = aqutils.retrieve_observation(

--- a/drizzlepac/haputils/poller_utils.py
+++ b/drizzlepac/haputils/poller_utils.py
@@ -1294,7 +1294,7 @@ def build_poller_table(
     if not is_poller_file:
         for filename in filenames:
             # Look for dataset in local directory.
-            if "asn" in filename or not os.path.exists(filename):
+            if "_asn" in filename or not os.path.exists(filename):
                 # This retrieval will NOT overwrite any ASN members already on local disk
                 # Return value will still be list of all members
                 files = aqutils.retrieve_observation(


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1497](https://jira.stsci.edu/browse/HLA-1497)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Corrected the use of a string comparison to "asn" in the build_poller_table routine of the poller_utils.py module as these characters are a valid portion of the root of an ipppssoot filename (e.g., u6kasn01m).  The comparison is now done against "_asn" when looking for association names in order to perform the proper actions.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)