### PR TITLE
HLA-1501: Clean-up values (move to proper section or delete) from catalog configuration files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,13 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.10.0 (24-Mar-2025)
 ====================
 
+- Updated the catalog configuration files to remove obsolete variables,
+  "fwhm" and "TWEAK_THRESHOLD", from the sourcex and dao sections, respectively.
+  The "TWEAK_FWHMPSF" variable/value now resides in the general section of the
+  file as it applies to both catalogs.  Modified the catalog_utils.py module
+  so the Segmentation catalog now reports the proper value for the Gaussian
+  Filter FWHM which is used to smooth the total detection image. [#nnnn]
+
 - Corrected the use of a string comparison to "asn" in the build_poller_table
   routine of the poller_utils.py module as these characters are
   a valid portion of the root of an ipppssoot filename (e.g., j6kasn01q).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   The "TWEAK_FWHMPSF" variable/value now resides in the general section of the
   file as it applies to both catalogs.  Modified the catalog_utils.py module
   so the Segmentation catalog now reports the proper value for the Gaussian
-  Filter FWHM which is used to smooth the total detection image. [#nnnn]
+  Filter FWHM which is used to smooth the total detection image. [#2024]
 
 - Corrected the use of a string comparison to "asn" in the build_poller_table
   routine of the poller_utils.py module as these characters are

--- a/drizzlepac/devutils/make_cfgobj_files.py
+++ b/drizzlepac/devutils/make_cfgobj_files.py
@@ -2,6 +2,8 @@ from configobj import ConfigObj
 from validate import Validator
 import os
 
+# This file is deprecated.  Various variable entries are now stored in a
+# number of different configuration files and many values here are outdated.
 param_dict = {
     "ACS HRC": {
         "astrodrizzle": {

--- a/drizzlepac/devutils/run_config_utils.py
+++ b/drizzlepac/devutils/run_config_utils.py
@@ -2,6 +2,7 @@
 import pdb
 import sys
 
+# This file is deprecated.
 
 from drizzlepac.haputils import config_utils
 from drizzlepac.haputils import poller_utils

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -658,7 +658,7 @@ class HAPCatalogs:
                                       maxiters=self.param_dict['maxiters'])
 
         self.image.build_kernel(self.param_dict['bkg_box_size'], self.param_dict['bkg_filter_size'],
-                                self.param_dict['dao']['TWEAK_FWHMPSF'],
+                                self.param_dict['TWEAK_FWHMPSF'],
                                 self.param_dict['simple_bkg'],
                                 self.param_dict['bkg_skew_threshold'],
                                 self.param_dict['zero_percent'],
@@ -1600,7 +1600,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
         super().__init__(image, param_dict, param_dict_qc, diagnostic_mode, tp_sources)
 
         # Get the instrument/detector-specific values from the self.param_dict
-        self._fwhm = self.param_dict["sourcex"]["fwhm"]
         self._size_source_box = self.param_dict["sourcex"]["source_box"]
         self._nlevels = self.param_dict["sourcex"]["nlevels"]
         self._contrast = self.param_dict["sourcex"]["contrast"]
@@ -1669,7 +1668,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             log.info("SExtractor-like source finding settings - Photutils segmentation")
             log.info("Total Detection Product - Input Parameters")
             log.info("Image: {}".format(self.imgname))
-            log.info("FWHM: {}".format(self._fwhm))
+            log.info("Gaussian FWHM (Filter for source detection in arcseconds): {}".format(self.param_dict['TWEAK_FWHMPSF']))
             log.info("size_source_box (no. of connected pixels needed for a detection): {}".format(self._size_source_box))
             log.info("nsigma (threshold = nsigma * background_rms): {}".format(self._nsigma))
             log.info("nlevels (no. of multi-thresholding levels for deblending): {}".format(self._nlevels))
@@ -1682,7 +1681,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
             log.info("Percentage limit on biggest source deblending limit: {}".format(100.0 * self._bs_deblend_limit))
             log.info("Percentage limit on source fraction deblending limit: {}".format(100.0 * self._sf_deblend_limit))
             log.info("Scaling parameter of the Kron radius: {}".format(self._kron_scaling_radius))
-            log.info("Kron minimum circular radius: {}".format(self._kron_minimum_radius))
+            log.info("Kron minimum circular radius (pixels): {}".format(self._kron_minimum_radius))
             log.info("")
             log.info("{}".format("=" * 80))
 
@@ -1795,7 +1794,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
                         # Need to remake image kernel as it has a dependence on self.bkg_rms_ra
                         self.image.build_kernel(self.param_dict['bkg_box_size'],
                                                 self.param_dict['bkg_filter_size'],
-                                                self.param_dict['dao']['TWEAK_FWHMPSF'])
+                                                self.param_dict['TWEAK_FWHMPSF'])
 
                         # Reset the local version of the Gaussian kernel and the RickerWavelet
                         # kernel when the background type changes
@@ -2326,8 +2325,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
         log.info("SExtractor-like source property measurements based on Photutils segmentation")
         log.info("Filter Level Product - Input Parameters")
         log.info("image name: {}".format(self.imgname))
-        log.info("FWHM: {}".format(self._fwhm))
-        log.info("size_source_box: {}".format(self._size_source_box))
+        log.info("Gaussian FWHM (Filter for source detection in arcseconds): {}".format(self.param_dict['TWEAK_FWHMPSF']))
+        log.info("size_source_box (pixels): {}".format(self._size_source_box))
         log.info("")
 
         # This is the filter science data and its computed background

--- a/drizzlepac/haputils/svm_quality_analysis.py
+++ b/drizzlepac/haputils/svm_quality_analysis.py
@@ -1041,7 +1041,7 @@ def find_hap_point_sources(filt_obj, log_level=logutil.logging.NOTSET):
                                filt_obj.configobj_pars.get_pars("catalog generation")['bkg_filter_size'])
     img_obj.build_kernel(filt_obj.configobj_pars.get_pars("catalog generation")['bkg_box_size'],
                          filt_obj.configobj_pars.get_pars("catalog generation")['bkg_filter_size'],
-                         filt_obj.configobj_pars.get_pars("catalog generation")['dao']['TWEAK_FWHMPSF'])
+                         filt_obj.configobj_pars.get_pars("catalog generation")['TWEAK_FWHMPSF'])
 
     # Perform background subtraction
     image = img_obj.data.copy()

--- a/drizzlepac/pars/hap_pars/svm_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/acs/hrc/acs_hrc_catalog_generation_all.json
@@ -21,14 +21,12 @@
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
+    "TWEAK_FWHMPSF": 0.073,
     "dao": {
         "bkgsig_sf": 4.0,
-        "kernel_sd_aspect_ratio": 0.8,
-        "TWEAK_FWHMPSF": 0.073,
-        "TWEAK_THRESHOLD": 3.0
+        "kernel_sd_aspect_ratio": 0.8
     },
     "sourcex": {
-        "fwhm": 0.073,
         "source_box": 6,
         "segm_nsigma": 3.0,
         "nlevels": 64,

--- a/drizzlepac/pars/hap_pars/svm_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/acs/sbc/acs_sbc_catalog_generation_all.json
@@ -21,14 +21,12 @@
     "nsigma_clip": 6.0,
     "maxiters": 1,
     "bkg_skew_threshold": 0.5,
+    "TWEAK_FWHMPSF": 0.065,
     "dao": {
         "bkgsig_sf": 4.0,
-        "kernel_sd_aspect_ratio": 0.8,
-        "TWEAK_FWHMPSF": 0.065,
-        "TWEAK_THRESHOLD": 3.0
+        "kernel_sd_aspect_ratio": 0.8
     },
     "sourcex": {
-        "fwhm": 0.065,
         "source_box": 6,
         "segm_nsigma": 10.0,
         "nlevels": 64,

--- a/drizzlepac/pars/hap_pars/svm_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/acs/wfc/acs_wfc_catalog_generation_all.json
@@ -21,14 +21,12 @@
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
+    "TWEAK_FWHMPSF": 0.076,
     "dao": {
         "bkgsig_sf": 4.0,
-        "kernel_sd_aspect_ratio": 0.8,
-        "TWEAK_FWHMPSF": 0.076,
-        "TWEAK_THRESHOLD": null
+        "kernel_sd_aspect_ratio": 0.8
     },
     "sourcex": {
-        "fwhm": 0.13,
         "source_box": 6,
         "segm_nsigma": 3.0,
         "nlevels": 64,

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfc3/ir/wfc3_ir_catalog_generation_all.json
@@ -21,14 +21,12 @@
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
+    "TWEAK_FWHMPSF": 0.14,
     "dao": {
         "bkgsig_sf": 4.0,
-        "kernel_sd_aspect_ratio": 0.8,
-        "TWEAK_FWHMPSF": 0.14,
-        "TWEAK_THRESHOLD": 3.0
+        "kernel_sd_aspect_ratio": 0.8
     },
     "sourcex": {
-        "fwhm": 0.14,
         "source_box": 6,
         "segm_nsigma": 3.0,
         "nlevels": 64,

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfc3/uvis/wfc3_uvis_catalog_generation_all.json
@@ -21,14 +21,12 @@
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
+    "TWEAK_FWHMPSF": 0.076,
     "dao": {
         "bkgsig_sf": 4.0,
-        "kernel_sd_aspect_ratio": 0.8,
-        "TWEAK_FWHMPSF": 0.076,
-        "TWEAK_THRESHOLD": 3.0
+        "kernel_sd_aspect_ratio": 0.8
     },
     "sourcex": {
-        "fwhm": 0.076,
         "source_box": 6,
         "segm_nsigma": 3.0,
         "nlevels": 64,

--- a/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/pc/wfpc2_pc_catalog_generation_all.json
+++ b/drizzlepac/pars/hap_pars/svm_parameters/wfpc2/pc/wfpc2_pc_catalog_generation_all.json
@@ -21,14 +21,12 @@
     "nsigma_clip": 3.0,
     "maxiters": 3,
     "bkg_skew_threshold": 0.5,
+    "TWEAK_FWHMPSF": 0.14,
     "dao": {
         "bkgsig_sf": 4.0,
-        "kernel_sd_aspect_ratio": 0.8,
-        "TWEAK_FWHMPSF": 0.14,
-        "TWEAK_THRESHOLD": 3.0
+        "kernel_sd_aspect_ratio": 0.8
     },
     "sourcex": {
-        "fwhm": 0.14,
         "source_box": 6,
         "segm_nsigma": 3.0,
         "nlevels": 64,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1501](https://jira.stsci.edu/browse/HLA-1501)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Added an internal comment and moved two deprecated modules, make_cfgobj_files.py and run_config_utils.py, to the devutils subdirectory.

Updated the catalog configuration files:
1) Removed the deprecated variable, fwhm, from the sourcex object,
2) Removed the deprecated variable, TWEAK_THRESHOLD, from the dao object, 
3) Moved the variable (key/value pair), "TWEAK_FWHMPSF": <float>, to the
   general object portion of the file as it applies to both catalogs.

Modified the catalog_utils.py module to read the TWEAK_FWHMPSF variable from the proper location in the catalog JSON file.  The Segmentation catalog now reports the proper value for the Gaussian Filter FWHM which is used to smooth the total detection image to enhance peak or multi-scale detection.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)