### PR TITLE
HLA-1503: Report correct sigma value for computing threshold for source detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.10.0 (21-May-2025)
 ====================
 
+- Clarified the sigma value used to compute the threshold above which
+  sources are detected for the segmentation catalog when using the
+  Gaussian or RickerWavelet smoothing kernel.  The value has corrected
+  in the output Segmentation catalogs and given greater visibility in
+  the trailer log files.  [#2027]
+
 - Updated the multiplicative values in the catalog configuration files
   which are used in conjunction with the computed image RMS to derive
   a threshold above which sources are detected. The Point catalog uses

--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -171,11 +171,14 @@ def create_catalog_products(total_obj_list, log_level, diagnostic_mode=False, ph
                 sources_dict[cat_type] = {}
                 sources_dict[cat_type]['sources'] = total_product_catalogs.catalogs[cat_type].sources
                 # For the segmentation source finding, both the segmentation image AND the segmentation catalog
-                # computed for the total object need to be provided to the filter objects
+                # computed for the total object need to be provided to the filter objects as well as other
+                # information (smoothing kernel and final sigma used to compute threshold above which sources
+                # have been detected).
                 if cat_type == "segment":
                     sources_dict['segment']['kernel'] = total_product_catalogs.catalogs['segment'].kernel
                     sources_dict['segment']['source_cat'] = total_product_catalogs.catalogs['segment'].source_cat
                     sources_dict['segment']['total_source_cat'] = total_product_catalogs.catalogs['segment'].total_source_cat
+                    sources_dict['segment']['final_nsigma'] = total_product_catalogs.catalogs['segment'].final_nsigma
 
             # Get parameter from config files for CR rejection of catalogs
             cr_residual = total_product_obj.configobj_pars.get_pars('catalog generation')['cr_residual']


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1503](https://jira.stsci.edu/browse/HLA-1503)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Clarified the sigma value used to compute the threshold above which sources are detected for the segmentation catalog.  The sigma value is different when using the Gaussian or RickerWavelet smoothing kernel for Round 1 processing, as well as both being doubled for Round 2 processing if and only if switching from a sigma-clipped background to a Background2D. The value has been corrected in the output Segmentation
catalogs, and given greater visibility in the trailer log files.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)