### PR TITLE
HLA-1512: Fix scipy deprecations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 ====================
 
 - Fixed scipy deprecations in catalog_utils.py and hap_flag_filter.py.
-  [#nnnn]
+  [#2032]
 
 3.10.0 (21-May-2025)
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
+3.xx.x (unreleased)
+====================
+
+- Fixed scipy deprecations in catalog_utils.py and hap_flag_filter.py.
+  [#nnnn]
+
 3.10.0 (21-May-2025)
 ====================
 

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -3093,7 +3093,7 @@ def make_wht_masks(
     """
     # uses scipy maximum filter on image. Maximum filter selects the largest value within an ordered 
     # window of pixel values and replaces the central pixel with the largest value.
-    maxwht = ndimage.filters.maximum_filter(whtarr, size=kernel)
+    maxwht = ndimage.maximum_filter(whtarr, size=kernel)
     
     # normalized weight array
     rel_wht = maxwht / maxwht.max()

--- a/drizzlepac/haputils/hla_flag_filter.py
+++ b/drizzlepac/haputils/hla_flag_filter.py
@@ -1639,8 +1639,8 @@ def make_mask_array(drz_image):
     """
     with fits.open(drz_image) as fh:
         mask = numpy.isfinite(fh[1].data) & (fh[1].data != 0)
-    dilate = scipy.ndimage.morphology.binary_dilation
-    erode = scipy.ndimage.morphology.binary_erosion
+    dilate = scipy.ndimage.binary_dilation
+    erode = scipy.ndimage.binary_erosion
     kernel1 = numpy.ones((25, 25), dtype=int)
     kernel2 = numpy.ones((31, 31), dtype=int)
     # add padding around the edge so pixels close to image boundary are correct


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1512](https://jira.stsci.edu/browse/HLA-1512)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Fixed scipy deprecations in catalog_utils.py and hap_flag_filter.py.   For example:
 ```
DeprecationWarning: Please import `binary_dilation` from the `scipy.ndimage` namespace; the `scipy.ndimage.morphology` namespace is deprecated and will be removed in SciPy 2.0.0.
    dilate = scipy.ndimage.morphology.binary_dilation
```

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)