### PR TITLE
Drizzlepac/HAP: Special case: Ignore the RMS comparison of Background2D and sigma-clipped algorithm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ number of the code change for that issue.  These PRs can be viewed at:
   algorithm when the background is being "forced" to be a "Background2D"
   as indicated by the bkg_skew_threshold=0.0 and the negative_percent=100.0.
   This is done for the case of Round 2 for identification of sources for
-  the HAPSegmentCatalog. [#nnnn]
+  the HAPSegmentCatalog. [#2033]
 
 3.10.0 (21-May-2025)
 ====================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,15 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
+3.xx.x (unreleased)
+===================
+
+- Ignore the RMS comparison between a Background2D and the sigma-clipped
+  algorithm when the background is being "forced" to be a "Background2D"
+  as indicated by the bkg_skew_threshold=0.0 and the negative_percent=100.0.
+  This is done for the case of Round 2 for identification of sources for
+  the HAPSegmentCatalog. [#nnnn]
+
 3.10.0 (21-May-2025)
 ====================
 

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -461,7 +461,13 @@ class CatalogImage:
                     # for the sigma-clipped algorithm, use the sigma-clipped algorithm instead.
                     # The sigma-clipped values have already been set in BACKGROUND COMPUTATION 2
                     # as the class attributes.
-                    elif bkg_rms_median > self.bkg_rms_median:
+                    #
+                    # Ignore the following criterion if the background is being "forced" to be a
+                    # Background2D computation as indicated by the bkg_skew_threshold = 0.0 and
+                    # the negative_percent = 100.0.  This is done for the case of Round 2 in the
+                    # identify_sources() method for the HAPSegmentCatalog.
+                    elif (bkg_rms_median > self.bkg_rms_median) and (bkg_skew_threshold > 0.0) and \
+                          (negative_percent < 100.0):
                         log.info(f"Background2D rms, {bkg_rms_median:.6f}, is greater than sigma-clipped rms, {self.bkg_rms_median:.6f}.")
                         log.info("*** Use the background image determined from the sigma_clip algorithm. ***")
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1509](https://jira.stsci.edu/browse/HLA-1509)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
Ignore the RMS comparison between a Background2D and the sigma-clipped algorithm when the background is being "forced" to be a "Background2D" as indicated by the bkg_skew_threshold=0.0 and the negative_percent=100.0. This is done for the special case of Round 2 for identification of sources for the HAPSegmentCatalog.

**Checklist for maintainers**
- [X] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [X] added relevant label(s)