### PR TITLE
Fix deprecations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Fix aposteriori alignment for cases when headerlets are missing IDCSCALE. [#2047]
 
+- Fixed DeprecationWarnings. [#2050]
+
 3.10.0 (21-May-2025)
 ====================
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -43,7 +43,7 @@ from astropy.stats import (gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm,
                            sigma_clipped_stats, SigmaClip)
 from astropy.visualization import SqrtStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
-from astropy.modeling.fitting import LMLSQFitter, TRFLSQFitter
+from astropy.modeling.fitting import TRFLSQFitter
 from astropy.time import Time
 from astropy.utils.decorators import deprecated
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -43,7 +43,7 @@ from astropy.stats import (gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm,
                            sigma_clipped_stats, SigmaClip)
 from astropy.visualization import SqrtStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
-from astropy.modeling.fitting import LMLSQFitter
+from astropy.modeling.fitting import LMLSQFitter, TRFLSQFitter
 from astropy.time import Time
 from astropy.utils.decorators import deprecated
 
@@ -465,9 +465,9 @@ def get_catalog(ra, dec, sr=0.1, epoch=None, catalog='GSC241'):
 
     # If we still have an error returned by the web-service, report the exact error
     if rstr[0].startswith('Error'):
-        log.warning("Astrometric catalog generation FAILED with: \n{}." 
+        log.warning("Astrometric catalog generation FAILED with: \n{}."
                     " No output table has been generated.".format(rstr))
-         
+
         # More information is still needed for the user. Regardless of the
         # portion of the the specification which is incorrect, the returned
         # error is still "Cannot find table 0".
@@ -868,8 +868,8 @@ def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
     # 2.5 x the background value can be considered part of a source.
     iraffind = DAOStarFinder(threshold=2.5 * mmm_bkg(psf), fwhm=default_fwhm)
     # The LevMarLSQFitter fitter is no longer recommended. To use the
-    # Levenberg-Marquardt algorithm without bounds, use LMLSQFitter.
-    fitter = LMLSQFitter()
+    # Levenberg-Marquardt algorithm without bounds, use TRFLSQFitter.
+    fitter = TRFLSQFitter()
     sigma_psf = gaussian_fwhm_to_sigma * default_fwhm
     gaussian_prf = CircularGaussianSigmaPRF(sigma=sigma_psf)
     gaussian_prf.sigma.fixed = False
@@ -884,17 +884,17 @@ def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
 
         phot_results = itr_phot_obj(psf)
     except Exception as x_cept:
-        log.warn(f"The find_fwhm() failed due to problem with fitting. Trying again. Exception: {x_cept}")
+        log.warning(f"The find_fwhm() failed due to problem with fitting. Trying again. Exception: {x_cept}")
         return None
 
     # Check the phot_results table was generated successfully
     if isinstance(phot_results, (type(None))):
-        log.warn("The PHOT_RESULTS table was not generated successfully. Trying again.")
+        log.warning("The PHOT_RESULTS table was not generated successfully. Trying again.")
         return None
 
     # Check the table actually has rows
     if len(phot_results['flux_fit']) == 0:
-        log.warn("The PHOT_RESULTS table has no rows. Trying again.")
+        log.warning("The PHOT_RESULTS table has no rows. Trying again.")
         return None
 
     # Insure none of the fluxes determined by photutils is np.nan
@@ -2509,4 +2509,3 @@ def evaluate_overlap_diffs(diff_dict, limit=1.0):
         log.info("Alignment NOT verified based on overlap...")
 
     return verified, max_diff
-

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -43,7 +43,7 @@ from astropy.stats import (gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm,
                            sigma_clipped_stats, SigmaClip)
 from astropy.visualization import SqrtStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
-from astropy.modeling.fitting import TRFLSQFitter
+from astropy.modeling.fitting import LMLSQFitter
 from astropy.time import Time
 from astropy.utils.decorators import deprecated
 
@@ -868,8 +868,8 @@ def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
     # 2.5 x the background value can be considered part of a source.
     iraffind = DAOStarFinder(threshold=2.5 * mmm_bkg(psf), fwhm=default_fwhm)
     # The LevMarLSQFitter fitter is no longer recommended. To use the
-    # Levenberg-Marquardt algorithm without bounds, use TRFLSQFitter.
-    fitter = TRFLSQFitter()
+    # Levenberg-Marquardt algorithm without bounds, use LMLSQFitter.
+    fitter = LMLSQFitter()
     sigma_psf = gaussian_fwhm_to_sigma * default_fwhm
     gaussian_prf = CircularGaussianSigmaPRF(sigma=sigma_psf)
     gaussian_prf.sigma.fixed = False

--- a/drizzlepac/haputils/deconvolve_utils.py
+++ b/drizzlepac/haputils/deconvolve_utils.py
@@ -1004,6 +1004,6 @@ def determine_input_image(image):
     if calimg:
         calimg = calimg.split('[')[0]
     else:
-        log.warn('No input image found in "D001DATA" keyword for {}'.format(image))
+        log.warning('No input image found in "D001DATA" keyword for {}'.format(image))
 
     return calimg

--- a/drizzlepac/imgclasses.py
+++ b/drizzlepac/imgclasses.py
@@ -1068,7 +1068,7 @@ class RefImage:
                     if self.wcs.instrument == 'DEFAULT':
                         raise ValueError("Distorted non-HST reference images "
                                          "are not supported.")
-                    log.warn("\nReference image contains a distorted WCS.\n"
+                    log.warning("\nReference image contains a distorted WCS.\n"
                              "Using the undistorted version of this WCS.\n")
                     self.wcs = utils.output_wcs([self.wcs], undistort=True)
             except KeyError as e:
@@ -1110,7 +1110,7 @@ class RefImage:
                     if self.wcs.instrument == 'DEFAULT':
                         raise ValueError("Distorted non-HST reference images "
                                          "are not supported.")
-                    log.warn("\nReference image contains a distorted WCS.\n"
+                    log.warning("\nReference image contains a distorted WCS.\n"
                              "Using the undistorted version of this WCS.\n")
                     self.wcs = utils.output_wcs([self.wcs], undistort=True)
                     self.wcs.filename = froot

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1653,9 +1653,6 @@ def update_wcs_in_list(exp_list, logfile=None):
                 print(msg)
                 update_msg += msg
                 update_active_wcs(filename, final_wcsname, logfile=logfile)
-                # msg = "filename %s , idcscale is %s" % (filename, idcscale)
-                # print(msg)
-                # update_msg = msg
     else:
         # Do nothing
         pass
@@ -1804,7 +1801,7 @@ def update_active_wcs(filename, wcsname, logfile=None):
     key = wcsutil.altwcs.getKeyFromName(hdu['SCI', 1].header, wcsname)
     keyword_wcs_list = [key]  # Initialize to a default value
 
-    # # No need to keep this file handle open anymore
+    # No need to keep this file handle open anymore
     hdu.close()
     del hdu
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1575,11 +1575,6 @@ def update_wcs_in_list(exp_list, logfile=None):
     print(msg)
     update_msg = msg
     primary_wcsnames = set([fits.getval(fname, 'wcsname', ext=('SCI',1)) for fname in exp_list])
-    fyq_ind = exp_list.index('j9pb20fyq_flt.fits')
-    idcscale = fits.getval(exp_list[fyq_ind], ext=1, keyword="IDCSCALE")
-    msg = "\nfyq idcscale is %s " % idcscale
-    print(msg)
-    update_msg = msg
     if len(primary_wcsnames) == 1:
         msg = "\nAll Primary WCS's confirmed as consistent as {}.".format(primary_wcsnames)
         print(msg)

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -1575,6 +1575,11 @@ def update_wcs_in_list(exp_list, logfile=None):
     print(msg)
     update_msg = msg
     primary_wcsnames = set([fits.getval(fname, 'wcsname', ext=('SCI',1)) for fname in exp_list])
+    fyq_ind = exp_list.index('j9pb20fyq_flt.fits')
+    idcscale = fits.getval(exp_list[fyq_ind], ext=1, keyword="IDCSCALE")
+    msg = "\nfyq idcscale is %s " % idcscale
+    print(msg)
+    update_msg = msg
     if len(primary_wcsnames) == 1:
         msg = "\nAll Primary WCS's confirmed as consistent as {}.".format(primary_wcsnames)
         print(msg)
@@ -1653,6 +1658,9 @@ def update_wcs_in_list(exp_list, logfile=None):
                 print(msg)
                 update_msg += msg
                 update_active_wcs(filename, final_wcsname, logfile=logfile)
+                # msg = "filename %s , idcscale is %s" % (filename, idcscale)
+                # print(msg)
+                # update_msg = msg
     else:
         # Do nothing
         pass
@@ -1801,7 +1809,7 @@ def update_active_wcs(filename, wcsname, logfile=None):
     key = wcsutil.altwcs.getKeyFromName(hdu['SCI', 1].header, wcsname)
     keyword_wcs_list = [key]  # Initialize to a default value
 
-    # No need to keep this file handle open anymore
+    # # No need to keep this file handle open anymore
     hdu.close()
     del hdu
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1531](https://jira.stsci.edu/browse/HLA-1531)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2049

<!-- describe the changes comprising this PR here -->
This PR addresses two DeprecationsWarnings in the regression tests. 
- Replaced log.warn with log.warning
- Replaced LMLSQFitter with TRFLSQFitter

Regression tests pass:
https://github.com/spacetelescope/RegressionTests/actions/runs/16352978260/job/4620432714

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)