### PR TITLE
HLA-1476: Log all environment variables used

### DIFF
--- a/drizzlepac/hapsequencer.py
+++ b/drizzlepac/hapsequencer.py
@@ -87,7 +87,6 @@ log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.s
 
 # Environment variable which controls the quality assurance testing
 # for the Single Visit Mosaic processing.
-envvar_bool_dict = {'off': False, 'on': True, 'no': False, 'yes': True, 'false': False, 'true': True}
 envvar_qa_svm = "SVM_QUALITY_TESTING"
 
 envvar_cat_svm = {"SVM_CATALOG_SBC": 'on',
@@ -539,7 +538,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_
     log.info("Run start time: {}".format(str(starting_dt)))
 
     # Start by reading in any environment variable related to catalog generation that has been set
-    cat_switches = {sw: _get_envvar_switch(sw, default=envvar_cat_svm[sw]) for sw in envvar_cat_svm}
+    cat_switches = {sw: util.get_envvar_switch(sw,default=envvar_cat_svm[sw]) for sw in envvar_cat_svm}
 
     # Since these are used in the finally block, make sure they are initialized
     total_obj_list = []
@@ -685,7 +684,7 @@ def run_hap_processing(input_filename, diagnostic_mode=False, input_custom_pars_
 
         # Quality assurance portion of the processing - done only if the environment
         # variable, SVM_QUALITY_TESTING, is set to 'on', 'yes', or 'true'.
-        qa_switch = _get_envvar_switch(envvar_qa_svm)
+        qa_switch = util.get_envvar_switch(envvar_qa_svm, description="'QA statistics'", default=False)
 
         # If requested, generate quality assessment statistics for the SVM products
         if qa_switch:
@@ -954,35 +953,6 @@ def run_sourcelist_flagging(filter_product_obj, filter_product_catalogs, log_lev
         filter_product_catalogs.catalogs[cat_type].source_cat = source_cat
 
     return filter_product_catalogs
-
-
-def _get_envvar_switch(envvar_name, default=None):
-    """
-    This private routine interprets any environment variable, such as SVM_QUALITY_TESTING.
-
-    PARAMETERS
-    -----------
-    envvar_name : str
-        name of environment variable to be interpreted
-
-    default : str or None
-        Value to be used in case environment variable was not defined or set.
-
-    .. note :
-    This is a copy of the routine in runastrodriz.py.  This code should be put in a common place.
-
-    """
-    if envvar_name in os.environ:
-        val = os.environ[envvar_name].lower()
-        if val not in envvar_bool_dict:
-            msg = "ERROR: invalid value for {}.".format(envvar_name)
-            msg += "  \n    Valid Values: on, off, yes, no, true, false"
-            raise ValueError(msg)
-        switch_val = envvar_bool_dict[val]
-    else:
-        switch_val = envvar_bool_dict[default] if default else None
-
-    return switch_val
 
 # ------------------------------------------------------------------------------
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -85,10 +85,13 @@ log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.s
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = 'http://gsss.stsci.edu/webservices'
 
+# Check if the environment variable is defined, and if so, use that value
 if ASTROMETRIC_CAT_ENVVAR in os.environ:
     SERVICELOCATION = os.environ[ASTROMETRIC_CAT_ENVVAR]
+    log.debug(f"ENVVAR {ASTROMETRIC_CAT_ENVVAR} found, setting SERVICELOCATION to {SERVICELOCATION}.")
 else:
     SERVICELOCATION = DEF_CAT_URL
+    log.debug(f"ENVVAR {ASTROMETRIC_CAT_ENVVAR} not found, setting SERVICELOCATION to {SERVICELOCATION}.")
 
 MODULE_PATH = os.path.dirname(inspect.getfile(inspect.currentframe()))
 

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -248,19 +248,21 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
 
     # interpret envvar variable, if specified
     align_to_gaia = _get_envvar_switch(
-        envvar_compute_name, description="align_to_gaia", default=align_to_gaia
+        envvar_compute_name, description="'align to gaia'", default=align_to_gaia
     )
 
     # Insure os.environ ALWAYS contains an entry for envvar_new_apriori_name
     # and it will default to being 'on'
     align_with_apriori = _get_envvar_switch(
-        envvar_new_apriori_name, description="align_with_apriori", default=True
+        envvar_new_apriori_name, description="'align with apriori'", default=True
     )
 
     # Add support for environment variable switch to automatically
     # reset IDCTAB in FLT/FLC files if different from IDCTAB in RAW files.
     reset_idctab_switch = _get_envvar_switch(
-        envvar_reset_idctab_name, description="reset_idctab_switch", default=False
+        envvar_reset_idctab_name,
+        description="'reset idctab in flt if different from raw'",
+        default=False,
     )
 
     if headerlets or align_to_gaia:
@@ -915,7 +917,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     # wcsname = fits.getval(drz_products[0], 'wcsname', ext=1)
 
     # interpret envvar variable, if specified
-    qa_switch = _get_envvar_switch(envvar_qa_stats_name, description="QA statistics", default=False)
+    qa_switch = _get_envvar_switch(envvar_qa_stats_name, description="'QA statistics'", default=False)
 
     if qa_switch and dcorr == 'PERFORM':
 
@@ -2105,6 +2107,27 @@ def _copyToNewWorkingDir(newdir, input):
 
 
 def _get_envvar_switch(envvar_name, description, default):
+    """Get the value of an environment variable as a boolean switch.
+
+    Parameters
+    ----------
+    envvar_name : str
+        The name of the environment variable to check.
+    description : str
+        A description of the environment variable's purpose.
+    default : bool
+        The default value to use if the environment variable is not set.
+
+    Returns
+    -------
+    bool
+        The value of the environment variable as a boolean.
+
+    Raises
+    ------
+    ValueError
+        If the environment variable is set to an invalid value.
+    """
     # interpret envvar variable, if specified
     if envvar_name in os.environ:
         val = os.environ[envvar_name].lower()

--- a/drizzlepac/runastrodriz.py
+++ b/drizzlepac/runastrodriz.py
@@ -179,9 +179,6 @@ FILTER_NAMES = {'WFPC2': ['FILTNAM1', 'FILTNAM2'],
 # default marker for trailer files
 __trlmarker__ = '*** astrodrizzle Processing Version ' + __version__ + '***\n'
 
-envvar_bool_dict = {'off': False, 'on': True, 'no': False, 'yes': True, 'false': False, 'true': True}
-envvar_dict = {'off': 'off', 'on': 'on', 'yes': 'on', 'no': 'off', 'true': 'on', 'false': 'off'}
-
 envvar_compute_name = 'ASTROMETRY_COMPUTE_APOSTERIORI'
 # ASTROMETRY_APPLY_APRIORI supersedes a previously existing environment variable
 envvar_new_apriori_name = "ASTROMETRY_APPLY_APRIORI"
@@ -247,22 +244,22 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     manifest_list = []
 
     # interpret envvar variable, if specified
-    align_to_gaia = _get_envvar_switch(
-        envvar_compute_name, description="'align to gaia'", default=align_to_gaia
+    align_to_gaia = util.get_envvar_switch(
+        envvar_compute_name, default=align_to_gaia, description="'align to gaia'"
     )
 
     # Insure os.environ ALWAYS contains an entry for envvar_new_apriori_name
     # and it will default to being 'on'
-    align_with_apriori = _get_envvar_switch(
-        envvar_new_apriori_name, description="'align with apriori'", default=True
+    align_with_apriori = util.get_envvar_switch(
+        envvar_new_apriori_name, default=True, description="'align with apriori'"
     )
 
     # Add support for environment variable switch to automatically
     # reset IDCTAB in FLT/FLC files if different from IDCTAB in RAW files.
-    reset_idctab_switch = _get_envvar_switch(
+    reset_idctab_switch = util.get_envvar_switch(
         envvar_reset_idctab_name,
-        description="'reset idctab in flt if different from raw'",
         default=False,
+        description="'reset idctab in flt if different from raw'",
     )
 
     if headerlets or align_to_gaia:
@@ -917,7 +914,7 @@ def process(inFile, force=False, newpath=None, num_cores=None, inmemory=True,
     # wcsname = fits.getval(drz_products[0], 'wcsname', ext=1)
 
     # interpret envvar variable, if specified
-    qa_switch = _get_envvar_switch(envvar_qa_stats_name, description="'QA statistics'", default=False)
+    qa_switch = util.get_envvar_switch(envvar_qa_stats_name, description="'QA statistics'", default=False)
 
     if qa_switch and dcorr == 'PERFORM':
 
@@ -2105,44 +2102,6 @@ def _copyToNewWorkingDir(newdir, input):
         for fname in glob.glob(rootname + '*'):
             shutil.copy(fname, os.path.join(newdir, fname))
 
-
-def _get_envvar_switch(envvar_name, description, default):
-    """Get the value of an environment variable as a boolean switch.
-
-    Parameters
-    ----------
-    envvar_name : str
-        The name of the environment variable to check.
-    description : str
-        A description of the environment variable's purpose.
-    default : bool
-        The default value to use if the environment variable is not set.
-
-    Returns
-    -------
-    bool
-        The value of the environment variable as a boolean.
-
-    Raises
-    ------
-    ValueError
-        If the environment variable is set to an invalid value.
-    """
-    # interpret envvar variable, if specified
-    if envvar_name in os.environ:
-        val = os.environ[envvar_name].lower()
-        if val not in envvar_bool_dict:
-            msg = "ERROR: invalid value for {}.".format(envvar_name)
-            msg += "  \n    Valid Values: on, off, yes, no, true, false"
-            raise ValueError(msg)
-        return_bool = envvar_bool_dict[val]
-        print(f"ENVVAR {envvar_name} found, setting {description} to {return_bool}.")
-    else:
-        return_bool = default
-        print(
-            f"ENVVAR {envvar_name} not found, setting {description} to default of {return_bool}."
-        )
-    return return_bool
 
 
 def _restoreResults(newdir, origdir):

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -36,6 +36,18 @@ __numpy_version__ = np.__version__
 _cpu_count = 1
 can_parallel = False
 
+envvar_bool_dict = {
+    "off": False,
+    "no": False,
+    "false": False,
+    "False": False,
+    False: False,
+    "yes": True,
+    "on": True,
+    "true": True,
+    "True": True,
+    True: True,
+}
 
 if 'ASTRODRIZ_NO_PARALLEL' not in os.environ and platform.system() != "Windows":
     try:
@@ -1427,3 +1439,44 @@ def _parse_ext_spec(hdulist, extno, extname=None):
     # return a list of extension versions corresponding to input 'extname'
     extvers = [extv for _, extv in groups]
     return extvers
+
+def get_envvar_switch(envvar_name, default, description=''):
+    """Get the value of an environment variable as a boolean switch.
+
+    Parameters
+    ----------
+    envvar_name : str
+        The name of the environment variable to check.
+    default : bool
+        The default value to use if the environment variable is not set.
+    description : str, optional
+        A description of the environment variable's purpose.
+
+    Returns
+    -------
+    bool
+        The value of the environment variable as a boolean.
+
+    Raises
+    ------
+    ValueError
+        If the environment variable is set to an invalid value.
+    """
+    # Format description for consistent spacing
+    description_text = f"{description} " if description else ""
+    
+    env_value = os.environ.get(envvar_name)
+    if env_value is not None:
+        val = env_value.strip().lower()
+        if val not in envvar_bool_dict:
+            valid_values = [k for k in envvar_bool_dict.keys() if isinstance(k, str)]
+            msg = f"Invalid value '{env_value}' for environment variable '{envvar_name}'. "
+            msg += f"Valid values: {', '.join(sorted(valid_values))}"
+            raise ValueError(msg)
+        result = envvar_bool_dict[val]
+        print(f"ENVVAR {envvar_name} found, setting {description_text}to {result}.")
+    else:
+        result = envvar_bool_dict[default]
+        print(f"ENVVAR {envvar_name} not found, setting {description_text}to default of {result}.")
+    
+    return result

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -40,12 +40,10 @@ envvar_bool_dict = {
     "off": False,
     "no": False,
     "false": False,
-    "False": False,
     False: False,
     "yes": True,
     "on": True,
     "true": True,
-    "True": True,
     True: True,
 }
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1476](https://jira.stsci.edu/browse/HLA-1476)

<!-- describe the changes comprising this PR here -->
This PR prints out all of the environment variables used, their status, and whether the default values are being used. In the future, these will be log statements as opposed to printed statements. 

I've moved some duplicated code for runastrodriz, hapsequencer and hapmultisequer to a function in drizzlepac.util now called `get_ennvar_switch`. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)