### PR TITLE
Parameter file trailing comma bug

### DIFF
--- a/drizzlepac/pars/hap_pars/mvm_parameters/wfc3_ir_index.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/wfc3_ir_index.json
@@ -7,7 +7,7 @@
         "filter_basic": "any/any_astrodrizzle_filter_hap_basic.json",
         "single_basic": "any/any_astrodrizzle_single_hap_basic.json",
         "total_basic": "wfc3/ir/wfc3_ir_astrodrizzle_any_total.json",
-        "wfc3_ir_any_n2":"wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json",
+        "wfc3_ir_any_n2":"wfc3/ir/wfc3_ir_astrodrizzle_any_n2.json"
     },
     "catalog generation": {
         "all": "wfc3/ir/wfc3_ir_catalog_generation_all.json"

--- a/drizzlepac/pars/hap_pars/mvm_parameters/wfc3_uvis_index.json
+++ b/drizzlepac/pars/hap_pars/mvm_parameters/wfc3_uvis_index.json
@@ -8,7 +8,7 @@
         "single_basic": "any/any_astrodrizzle_single_hap_basic.json",
         "total_basic_pre": "wfc3/uvis/wfc3_uvis_astrodrizzle_any_total_pre2012.json",
         "total_basic_post": "wfc3/uvis/wfc3_uvis_astrodrizzle_any_total.json",
-        "wfc3_uvis_any_post_n2": "wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json",
+        "wfc3_uvis_any_post_n2": "wfc3/uvis/wfc3_uvis_astrodrizzle_any_n2.json"
     },
     "catalog generation": {
         "all": "wfc3/uvis/wfc3_uvis_catalog_generation_all.json"


### PR DESCRIPTION
Trailing commas are making it so that the json files can't be loaded. This bug was a result of a change in #2037. An MVM test may have caught this. 

Regression test: https://github.com/spacetelescope/RegressionTests/actions/runs/20068330550