### PR TITLE
Implementing pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,71 @@
+ci:
+  autofix_prs: false
+  autoupdate_schedule: monthly
+
+exclude: ".*\\.fits"
+
+repos:
+  # basic checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-yaml
+        args:
+          - --unsafe
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: debug-statements
+      - id: detect-private-key
+      # - id: end-of-file-fixer
+      # - id: trailing-whitespace
+  # simple text searches for common issues
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char
+  # lint and format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+          - --show-fixes
+      - id: ruff-format
+  # C style
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.8
+    hooks:
+      - id: clang-format
+        types_or: [c]
+  # type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+  # spell-checking
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args:
+          - --write-changes
+          - --summary
+        additional_dependencies:
+          - tomli
+  # validate change log and fragments in `changes/`
+  - repo: https://github.com/twisted/towncrier
+    rev: 25.8.0
+    hooks:
+      - id: towncrier-check
+  # validate numpy-style docstrings
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.10.0
+    hooks:
+      - id: numpydoc-validation

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -191,11 +191,15 @@ Step 4: Making code changes
 
 Now that you've forked, cloned, made a new branch for your feature, and
 installed it in a new environment for development of ``drizzlepac``, you
-are ready to make changes to the code. As you make changes, make sure to
-``git commit -m <"some message">`` frequently (in case you need to undo
-something by reverting back to a previous commit - you cant do this if
-you commit everything at once!). After you've made your desired changes,
-and committed these changes, you will need to push them online to your
+are ready to make changes to the code. In order to commit changes, you must
+have `pre-commit <https://github.com/pre-commit/pre-commit>`__ installed in
+your development environment. This will lint and format any changed files and
+add warnings about any issues in your code. To ignore pre-commit suggestions,
+you can run ``git commit --no-verify -m "commit message"``. As you make
+changes, make sure to ``git commit -m <"some message">`` frequently (in case
+you need to undo something by reverting back to a previous commit - you cant do
+this if you commit everything at once!). After you've made your desired
+changes, and committed these changes, you will need to push them online to your
 'remote' fork of ``drizzlepac``:
 
 ::


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds pre-commit in a similar style as [jwst](https://github.com/spacetelescope/jwst/blob/05eadb7590e8d2877f365af0b1bb89eea8720de8/.pre-commit-config.yaml#L9). 

It will only run on files with changes, and the recommended changes can be ignored with `git commit --no-verify -m "commit message"`. That being said, I don't think there is any harm in adding it. There a lot of changes needed in formatting drizzlepac and I think that this will be useful in adopting these changes. 
