### PR TITLE
Import change to avoid scipy deprecation.

### DIFF
--- a/drizzlepac/findobj.py
+++ b/drizzlepac/findobj.py
@@ -188,7 +188,7 @@ def findstars(jdata, fwhm, threshold, skymode,
         tdata=np.where((convdata > threshold) & mask, convdata, 0)
 
     # segment image and find sources
-    s = ndimage.morphology.generate_binary_structure(2, 2)
+    s = ndimage.generate_binary_structure(2, 2)
     ldata, nobj = ndimage.label(tdata, structure=s)
     fobjects = ndimage.find_objects(ldata)
 

--- a/drizzlepac/haputils/starmatch_hist.py
+++ b/drizzlepac/haputils/starmatch_hist.py
@@ -22,7 +22,7 @@ Classes and Functions
 import os,sys,numpy
 import scipy.special, scipy.signal
 from scipy.ndimage.filters import maximum_filter
-from scipy.ndimage.morphology import generate_binary_structure
+from scipy.ndimage import generate_binary_structure
 import astropy.io.fits as pyfits
 from astropy.table import Table
 


### PR DESCRIPTION
We are making the recommended change for two instances of the following warning:

`/Users/sgoldman/Documents/drizzlepac_dev/drizzlepac/findobj.py:191: DeprecationWarning: Please import `generate_binary_structure` from the `scipy.ndimage` namespace; the `scipy.ndimage.morphology` namespace is deprecated and will be removed in SciPy 2.0.0`