### PR TITLE
HLA-1579: Regression test added for tweakback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,12 +152,14 @@ builder = "html"
 configuration = "docs/source/conf.py"
 fail_on_warning = false
 
-[tool.pytest.ini_options]
+[tool.pytest]
 minversion = "9"
-norecursedirs = ".eggs build .tox doc/build doc/exts"
+norecursedirs = [".eggs", "build", ".tox", "doc/build", "doc/exts"]
 junit_family = "xunit2"
-inputs_root = "drizzlepac"
-results_root = "drizzlepac-results"
+
+[tool.pytest.ini_options]
+inputs_root = ["drizzlepac"]
+results_root = ["drizzlepac-results"]
 
 [tool.ruff]
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ fail_on_warning = false
 minversion = "9"
 norecursedirs = [".eggs", "build", ".tox", "doc/build", "doc/exts"]
 junit_family = "xunit2"
+inputs_root = ["drizzlepac"]
+results_root = ["drizzlepac-results"]
 
 [tool.pytest.ini_options]
 inputs_root = ["drizzlepac"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,16 +152,12 @@ builder = "html"
 configuration = "docs/source/conf.py"
 fail_on_warning = false
 
-[tool.pytest]
-minversion = "9"
-norecursedirs = [".eggs", "build", ".tox", "doc/build", "doc/exts"]
-junit_family = "xunit2"
-inputs_root = ["drizzlepac"]
-results_root = ["drizzlepac-results"]
-
 [tool.pytest.ini_options]
-inputs_root = ["drizzlepac"]
-results_root = ["drizzlepac-results"]
+minversion = "9"
+norecursedirs = ".eggs build .tox doc/build doc/exts"
+junit_family = "xunit2"
+inputs_root = "drizzlepac"
+results_root = "drizzlepac-results"
 
 [tool.ruff]
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,10 +156,8 @@ fail_on_warning = false
 minversion = "9"
 norecursedirs = [".eggs", "build", ".tox", "doc/build", "doc/exts"]
 junit_family = "xunit2"
-
-[tool.pytest.ini_options]
-inputs_root = ["drizzlepac"]
-results_root = ["drizzlepac-results"]
+inputs_root = "drizzlepac"
+results_root = "drizzlepac-results"
 
 [tool.ruff]
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ requires = [
     "numpy>=2",
     "astropy>=5.0.4",
     "markupsafe<=2.0.1",
+    "pytest>=9.0"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -152,12 +153,12 @@ builder = "html"
 configuration = "docs/source/conf.py"
 fail_on_warning = false
 
-[tool.pytest]
+[tool.pytest.ini_options]
 minversion = "9"
 norecursedirs = [".eggs", "build", ".tox", "doc/build", "doc/exts"]
 junit_family = "xunit2"
-inputs_root = "drizzlepac"
-results_root = "drizzlepac-results"
+inputs_root = ["drizzlepac"]
+results_root = ["drizzlepac-results"]
 
 [tool.ruff]
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ fail_on_warning = false
 minversion = "9"
 norecursedirs = [".eggs", "build", ".tox", "doc/build", "doc/exts"]
 junit_family = "xunit2"
+
+[tool.pytest.ini_options]
 inputs_root = ["drizzlepac"]
 results_root = ["drizzlepac-results"]
 

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -78,9 +78,26 @@ class BaseCal:
         # Update tree to point to correct environment
         self.tree = envopt
 
-        # Collect pytest configuration values specified in setup.cfg or pytest.ini
-        self.inputs_root = pytestconfig.getini('inputs_root')[0]
-        self.results_root = pytestconfig.getini('results_root')[0]
+        # Collect pytest configuration values; fall back to defaults when not provided
+        self.inputs_root = self._get_first_ini_value(pytestconfig, "inputs_root", "drizzlepac")
+        self.results_root = self._get_first_ini_value(pytestconfig, "results_root", "drizzlepac-results")
+
+    def _get_first_ini_value(self, pytestconfig, option, default):
+        """Return the first configured value for a pytest ini option or a default."""
+        try:
+            values = pytestconfig.getini(option)
+        except (AttributeError, ValueError):
+            values = []
+
+        if isinstance(values, str):
+            values = [values]
+
+        for raw in values:
+            candidate = (raw or "").strip()
+            if candidate:
+                return candidate
+
+        return default
 
     def teardown_class(self):
         """Reset path and variables."""

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -78,26 +78,9 @@ class BaseCal:
         # Update tree to point to correct environment
         self.tree = envopt
 
-        # Collect pytest configuration values; fall back to defaults when not provided
-        self.inputs_root = self._get_first_ini_value(pytestconfig, "inputs_root", "drizzlepac")
-        self.results_root = self._get_first_ini_value(pytestconfig, "results_root", "drizzlepac-results")
-
-    def _get_first_ini_value(self, pytestconfig, option, default):
-        """Return the first configured value for a pytest ini option or a default."""
-        try:
-            values = pytestconfig.getini(option)
-        except (AttributeError, ValueError):
-            values = []
-
-        if isinstance(values, str):
-            values = [values]
-
-        for raw in values:
-            candidate = (raw or "").strip()
-            if candidate:
-                return candidate
-
-        return default
+        # Collect pytest configuration values specified in setup.cfg or pytest.ini
+        self.inputs_root = pytestconfig.getini('inputs_root')[0]
+        self.results_root = pytestconfig.getini('results_root')[0]
 
     def teardown_class(self):
         """Reset path and variables."""


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1579](https://jira.stsci.edu/browse/HLA-1579)

<!-- describe the changes comprising this PR here -->
This PR adds a regression test for tweakback to /tests/acs/test_acs_tweak.py.

It also updates the pyproject.toml to add the artifactory truth file directory names with `tool.pytest.ini_options` instead of `tool.pytest` because the latter is not picked up when the tests are run locally. This also requires pyproject>=9.0, which I have required in that same file. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)

Regression test:  https://github.com/spacetelescope/RegressionTests/actions/runs/24357174301
