### PR TITLE
HLA-1598: Updates for photutils 3+ deprecations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,8 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 
 3.11.0 (28-Apr-2026)
-===================
+====================
+
 - Deprecated the hapcut_utils module. [#2103]
 
 - Remove WFC3/UVIS Quadrant filter data from SVM total image and catalog creation. [#2093]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,9 +17,15 @@ number of the code change for that issue.  These PRs can be viewed at:
 
     https://github.com/spacetelescope/drizzlepac/pulls
 
-3.11.0 (unreleased)
-===================
 
+3.12.0 (TBD)
+============
+
+- Added code to handle deprecations in photutils v3.0.0. [#2089]
+
+
+3.11.0 (28-Apr-2026)
+===================
 - Deprecated the hapcut_utils module. [#2103]
 
 - Remove WFC3/UVIS Quadrant filter data from SVM total image and catalog creation. [#2093]

--- a/doc/source/mast_data_products/catalog_generation.rst
+++ b/doc/source/mast_data_products/catalog_generation.rst
@@ -1174,9 +1174,9 @@ for the output segmentation catalog are denoted in Table 6.
     +------------------------+----------------+------------------------------------------------------+
     | source_sum_err         | FluxIsoErr     | Uncertainty of FluxIso, propagated from input array  |
     +------------------------+----------------+------------------------------------------------------+
-    | x_centroid              | X-Centroid     | X-coordinate of the centroid in the source segment   |
+    | x_centroid             | X-Centroid     | X-coordinate of the centroid in the source segment   |
     +------------------------+----------------+------------------------------------------------------+
-    | y_centroid              | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
+    | y_centroid             | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
     +------------------------+----------------+------------------------------------------------------
 
 .. note::

--- a/doc/source/mast_data_products/catalog_generation.rst
+++ b/doc/source/mast_data_products/catalog_generation.rst
@@ -1148,17 +1148,17 @@ for the output segmentation catalog are denoted in Table 6.
     +------------------------+----------------+------------------------------------------------------+
     | bbox_ymax              | Ymax           | Max Y pixel in the minimal bounding box segment      |
     +------------------------+----------------+------------------------------------------------------+
-    | covar_sigx2            | X2             | Variance of position along X (pixels^2)              |
+    | covariance_xx          | X2             | Variance of position along X (pixels^2)              |
     +------------------------+----------------+------------------------------------------------------+
-    | covar_sigxy            | XY             | Covariance of position between X and Y (pixels^2)    |
+    | covariance_xy          | XY             | Covariance of position between X and Y (pixels^2)    |
     +------------------------+----------------+------------------------------------------------------+
-    | covar_sigy2            | Y2             | Variance of position along Y (pixels^2)              |
+    | covariance_yy          | Y2             | Variance of position along Y (pixels^2)              |
     +------------------------+----------------+------------------------------------------------------+
-    | cxx                    | CXX            | SExtractor's CXX ellipse parameter (pixel^-2)        |
+    | ellipse_cxx            | CXX            | SExtractor's CXX ellipse parameter (pixel^-2)        |
     +------------------------+----------------+------------------------------------------------------+
-    | cxy                    | CXY            | SExtractor's CXY ellipse parameter (pixel^-2)        |
+    | ellipse_cxy            | CXY            | SExtractor's CXY ellipse parameter (pixel^-2)        |
     +------------------------+----------------+------------------------------------------------------+
-    | cyy                    | CYY            | SExtractor's CYY ellipse parameter (pixel^-2)        |
+    | ellipse_cyy            | CYY            | SExtractor's CYY ellipse parameter (pixel^-2)        |
     +------------------------+----------------+------------------------------------------------------+
     | elongation             | Elongation     | Ratio of the semi-major to the semi-minor length     |
     +------------------------+----------------+------------------------------------------------------+
@@ -1174,11 +1174,15 @@ for the output segmentation catalog are denoted in Table 6.
     +------------------------+----------------+------------------------------------------------------+
     | source_sum_err         | FluxIsoErr     | Uncertainty of FluxIso, propagated from input array  |
     +------------------------+----------------+------------------------------------------------------+
-    | xcentroid              | X-Centroid     | X-coordinate of the centroid in the source segment   |
+    | x_centroid              | X-Centroid     | X-coordinate of the centroid in the source segment   |
     +------------------------+----------------+------------------------------------------------------+
-    | ycentroid              | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
-    +------------------------+----------------+------------------------------------------------------+
+    | y_centroid              | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
+    +------------------------+----------------+------------------------------------------------------
 
+.. note::
+    These column names were updated with photutils version 3.0.0, and differ 
+    slightly from the previous versions. These former column names are still 
+    valid when using prior versions of phoutils. 
 
 4.3: Aperture Photometry Measurements
 -------------------------------------

--- a/doc/source/mast_data_products/catalog_generation.rst
+++ b/doc/source/mast_data_products/catalog_generation.rst
@@ -1174,9 +1174,9 @@ for the output segmentation catalog are denoted in Table 6.
     +------------------------+----------------+------------------------------------------------------+
     | source_sum_err         | FluxIsoErr     | Uncertainty of FluxIso, propagated from input array  |
     +------------------------+----------------+------------------------------------------------------+
-    | x_centroid             | X-Centroid     | X-coordinate of the centroid in the source segment   |
+    | x\_centroid            | X-Centroid     | X-coordinate of the centroid in the source segment   |
     +------------------------+----------------+------------------------------------------------------+
-    | y_centroid             | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
+    | y\_centroid            | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
     +------------------------+----------------+------------------------------------------------------
 
 .. note::

--- a/doc/source/mast_data_products/catalog_generation.rst
+++ b/doc/source/mast_data_products/catalog_generation.rst
@@ -1174,10 +1174,10 @@ for the output segmentation catalog are denoted in Table 6.
     +------------------------+----------------+------------------------------------------------------+
     | source_sum_err         | FluxIsoErr     | Uncertainty of FluxIso, propagated from input array  |
     +------------------------+----------------+------------------------------------------------------+
-    | x\_centroid            | X-Centroid     | X-coordinate of the centroid in the source segment   |
+    | x_centroid             | X-Centroid     | X-coordinate of the centroid in the source segment   |
     +------------------------+----------------+------------------------------------------------------+
-    | y\_centroid            | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
-    +------------------------+----------------+------------------------------------------------------
+    | y_centroid             | Y-Centroid     | Y-coordinate of the centroid in the source segment   |
+    +------------------------+----------------+------------------------------------------------------+
 
 .. note::
     These column names were updated with photutils version 3.0.0, and differ 

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -19,7 +19,9 @@ from stsci.tools.bitmask import bitfield_to_boolean_mask
 from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 from astropy.modeling import models, fitting
+from astropy.utils import minversion
 
+import photutils
 from photutils import background
 from photutils.background import Background2D
 from photutils.detection import DAOStarFinder
@@ -37,6 +39,7 @@ from .. import updatehdr
 from . import astrometric_utils as amutils
 from . import analyze
 from . import deconvolve_utils as decutils
+from .astrometric_utils import _translate_columns
 
 from tweakwcs.matchutils import XYXYMatch
 from tweakwcs.imalign import align_wcs
@@ -56,6 +59,15 @@ MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
+
+PHOTUTILS_GE_3 = minversion(photutils, "2.3.1.dev")
+photutils.future_column_names = True
+if PHOTUTILS_GE_3:
+    X_CENTROID = 'x_centroid'
+    Y_CENTROID = 'y_centroid'
+else:
+    X_CENTROID = X_CENTROID
+    Y_CENTROID = Y_CENTROID
 
 
 class AlignmentTable:
@@ -262,10 +274,17 @@ class AlignmentTable:
                             regfilename = "{}_sci{}_src.reg".format(imgroot, chip)
                             out_table = Table(chip_cat)
                             # To align with positions of sources in DS9/IRAF
-                            out_table['xcentroid'] += 1
-                            out_table['ycentroid'] += 1
+                            out_table[X_CENTROID] += 1
+                            out_table[Y_CENTROID] += 1
+
+                            # Preserve pre-photutils 3+ column names in
+                            # output table for backwards compatibility
+                            _translate_columns(out_table)
+
                             out_table.write(regfilename,
-                                            include_names=["xcentroid", "ycentroid", "mag"],
+                                            include_names=["xcentroid",
+                                                           "ycentroid",
+                                                           "mag"],
                                             format="ascii.fast_commented_header")
                             log.info("Wrote region file {}\n".format(regfilename))
 
@@ -602,10 +621,16 @@ class HAPImage:
 
             for percentile in exclude_percentiles:
                 try:
-                    bkg = Background2D(scidata, box_size, filter_size=win_size,
-                                       bkg_estimator=bkg_estimator(),
-                                       bkgrms_estimator=rms_estimator(),
-                                       exclude_percentile=percentile)
+                    if PHOTUTILS_GE_3:
+                        bkg = Background2D(scidata, box_size, filter_size=win_size,
+                                           bkg_estimator=bkg_estimator(),
+                                           bkg_rms_estimator=rms_estimator(),
+                                           exclude_percentile=percentile)
+                    else:
+                        bkg = Background2D(scidata, box_size, filter_size=win_size,
+                                           bkg_estimator=bkg_estimator(),
+                                           bkgrms_estimator=rms_estimator(),
+                                           exclude_percentile=percentile)
                 except Exception:
                     bkg = None
                     continue
@@ -805,11 +830,16 @@ class SBCHAPImage(HAPImage):
         tbl['cat_id'] = np.arange(1, len(tbl) + 1)
 
         if outroot:
-            tbl['xcentroid'].info.format = '.10f'  # optional format
-            tbl['ycentroid'].info.format = '.10f'
+            tbl[X_CENTROID].info.format = '.10f'  # optional format
+            tbl[Y_CENTROID].info.format = '.10f'
             tbl['flux'].info.format = '.10f'
             if not outroot.endswith('.cat'):
                 outroot += '.cat'
+
+            # Preserve pre-photutils 3+ column names in output table for
+            # backwards compatibility
+            _translate_columns(tbl)
+
             tbl.write(outroot, format='ascii.commented_header', overwrite=True)
             log.info("Wrote source catalog: {}".format(outroot))
 

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -274,8 +274,8 @@ class AlignmentTable:
                             regfilename = "{}_sci{}_src.reg".format(imgroot, chip)
                             out_table = Table(chip_cat)
                             # To align with positions of sources in DS9/IRAF
-                            out_table[X_CENTROID] += 1
-                            out_table[Y_CENTROID] += 1
+                            out_table['xcentroid'] += 1
+                            out_table['ycentroid'] += 1
 
                             # Preserve pre-photutils 3+ column names in
                             # output table for backwards compatibility

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -66,9 +66,8 @@ if PHOTUTILS_GE_3:
     X_CENTROID = 'x_centroid'
     Y_CENTROID = 'y_centroid'
 else:
-    # X_CENTROID = X_CENTROID
-    # Y_CENTROID = Y_CENTROID
-    pass
+    X_CENTROID = 'xcentroid'
+    Y_CENTROID = 'ycentroid'
 
 
 class AlignmentTable:

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -66,8 +66,9 @@ if PHOTUTILS_GE_3:
     X_CENTROID = 'x_centroid'
     Y_CENTROID = 'y_centroid'
 else:
-    X_CENTROID = X_CENTROID
-    Y_CENTROID = Y_CENTROID
+    # X_CENTROID = X_CENTROID
+    # Y_CENTROID = Y_CENTROID
+    pass
 
 
 class AlignmentTable:

--- a/drizzlepac/haputils/align_utils.py
+++ b/drizzlepac/haputils/align_utils.py
@@ -282,9 +282,7 @@ class AlignmentTable:
                             _translate_columns(out_table)
 
                             out_table.write(regfilename,
-                                            include_names=["xcentroid",
-                                                           "ycentroid",
-                                                           "mag"],
+                                            include_names=["xcentroid","ycentroid","mag"],
                                             format="ascii.fast_commented_header")
                             log.info("Wrote region file {}\n".format(regfilename))
 

--- a/drizzlepac/haputils/analyze.py
+++ b/drizzlepac/haputils/analyze.py
@@ -19,8 +19,10 @@ from astropy.io import fits
 from astropy.io.fits import getheader, getdata
 from astropy.table import Table
 from astropy.stats import sigma_clipped_stats
+from astropy.utils import minversion
 import numpy as np
 
+import photutils
 from photutils.segmentation import SourceCatalog, detect_sources
 
 from scipy import ndimage
@@ -39,6 +41,9 @@ MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.INFO, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
+
+PHOTUTILS_GE_3 = minversion(photutils, "2.3.1.dev")
+photutils.future_column_names = True
 
 __all__ = ['analyze_data', 'analyze_wrapper', 'mvm_analyze_wrapper']
 
@@ -91,11 +96,11 @@ MIN_LINES = 4  # Minimum number of detected lines for consideration of bad guidi
 # Return codes
 class Ret_code(Enum):
     """
-    Define return status codes for Operations 
+    Define return status codes for Operations
     """
     OK = 0
     KEYWORD_UPDATE_PROBLEM = 15
-    SBCHRC_DATA = 55 
+    SBCHRC_DATA = 55
     NO_VIABLE_DATA = 65
 
 # Annotates level to which image can be aligned according observational parameters
@@ -180,7 +185,7 @@ def analyze_wrapper(input_file_list, log_level=logutil.logging.DEBUG, use_sbchrc
     =======
     viable_images_list : list
        List of images which can be used in the drizzle process.
-       
+
     good_index : list
         indices of the viable images in the input_file_list
 
@@ -193,7 +198,7 @@ def analyze_wrapper(input_file_list, log_level=logutil.logging.DEBUG, use_sbchrc
     """
     # Set logging level to user-specified level
     log.setLevel(log_level)
- 
+
     # Analyze the input file list and get the full table assessment
     filtered_table, analyze_data_good_index = analyze_data(input_file_list, type=type)
 
@@ -214,7 +219,7 @@ def analyze_wrapper(input_file_list, log_level=logutil.logging.DEBUG, use_sbchrc
     return_value = Ret_code.OK.value
 
     # MVM processing, but excluding SBC/HRC data
-    if use_sbchrc == False and type.upper() == "MVM": 
+    if use_sbchrc == False and type.upper() == "MVM":
         # Check the table to determine presence of SBC/HRC data
         if filtered_table:
             for i, old_row in enumerate(filtered_table):
@@ -238,7 +243,7 @@ def analyze_wrapper(input_file_list, log_level=logutil.logging.DEBUG, use_sbchrc
         else:
             log.warning("No viable images in multi-visit table - no processing done.\n")
             return_value = Ret_code.NO_VIABLE_DATA.value
- 
+
     # SVM processing or MVM processing with SBC/HRC data included in the MVM processing
     else:
         if filtered_table:
@@ -279,7 +284,7 @@ def analyze_data(input_file_list, log_level=logutil.logging.DEBUG, type=""):
         Astropy Table object containing data pertaining to the associated dataset, including
         the do_process bool.  It is intended this table is updated by subsequent functions for
         bookkeeping purposes.
-    
+
     analyze_data_good_index : list
         indices of the viable images in the input_file_list
 
@@ -452,7 +457,7 @@ def analyze_data(input_file_list, log_level=logutil.logging.DEBUG, type=""):
                     log.warning(
                         f"{input_file} (SCI, {sci_ext_ind}) is all zeros, but processing will continue with the other science extensions."
                     )
-    
+
         else:
             log.warning(f'No science extension in file: {input_file}')
 
@@ -531,7 +536,7 @@ def analyze_data(input_file_list, log_level=logutil.logging.DEBUG, type=""):
                 no_proc_value = None
                 log.info("The Grism/Prism data, {}, will be processed.".format(input_file))
             # Grism/Prism WILL NOT be processed primarily if MVM processing or with an exposure time of zero.
-            elif item.startswith(('G', 'PR')): 
+            elif item.startswith(('G', 'PR')):
                 if type.upper() == "MVM":
                     no_proc_value += ", Grism/Prism data and MVM processing"
                     log.warning("The Grism/Prism data {} with MVM processing will be ignored.".format(input_file))
@@ -679,11 +684,15 @@ def verify_guiding(filename, min_length=33):
     # Determine rough number of probable sources
     # Trying to ignore small sources (<= 4x4 pixels in size, or npixels < 17)
     #   which are either noise peaks or head-on CRs.
-    segm = detect_sources(imgarr, 0, npixels=17)
-    if segm is None or segm.nlabels < 2:
+    if PHOTUTILS_GE_3:
+        segm = detect_sources(imgarr, 0, n_pixels=17)
+    else:
+        segm = detect_sources(imgarr, 0, npixels=17)
+    if segm is None:
         log.debug(f'Did NOT detect enough raw sources in {filename} for guiding verification.')
         return False
-    log.debug(f'Detected {segm.nlabels} raw sources in {filename} for guiding verification.')
+    n_sources = segm.n_labels if PHOTUTILS_GE_3 else segm.nlabels
+    log.debug(f'Detected {n_sources} raw sources in {filename} for guiding verification.')
 
     src_cat = SourceCatalog(imgarr, segm)
     # Remove likely cosmic-rays based on central_moments classification

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -45,6 +45,7 @@ from astropy.visualization import SqrtStretch
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.modeling.fitting import TRFLSQFitter
 from astropy.time import Time
+from astropy.utils import minversion
 from astropy.utils.decorators import deprecated
 
 import photutils
@@ -84,6 +85,17 @@ log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.s
 
 ASTROMETRIC_CAT_ENVVAR = "ASTROMETRIC_CATALOG_URL"
 DEF_CAT_URL = 'http://gsss.stsci.edu/webservices'
+
+PHOTUTILS_GE_3 = minversion(photutils, "2.3.1.dev")
+photutils.future_column_names = True
+if PHOTUTILS_GE_3:
+    X_CENTROID = 'x_centroid'
+    Y_CENTROID = 'y_centroid'
+    FERR_COLNAME = 'segment_flux_err'
+else:
+    X_CENTROID = 'xcentroid'
+    Y_CENTROID = 'ycentroid'
+    FERR_COLNAME = 'segment_fluxerr'
 
 # Check if the environment variable is defined, and if so, use that value
 if ASTROMETRIC_CAT_ENVVAR in os.environ:
@@ -171,6 +183,26 @@ log.info(f'ASTROMETRIC_CATALOG_URL = {SERVICELOCATION}')
 
 # CRBIT definitions
 CRBIT = 4096
+
+
+def _translate_columns(tbl):
+    """
+    Translate photutils 3+ column names to pre-photutils 3+ column names
+    to preserve drizzlepac/haputils output table files.
+
+    The input table is modified in place.
+    """
+    if not PHOTUTILS_GE_3:
+        return tbl
+
+    rename_map = {
+        X_CENTROID: 'xcentroid',
+        Y_CENTROID: 'ycentroid',
+    }
+    tbl.rename_columns(rename_map.keys(), rename_map.values())
+    return tbl
+
+
 """
 
 Primary function for creating an astrometric reference catalog.
@@ -699,8 +731,14 @@ def compute_2d_background(imgarr, box_size, win_size,
         log.info("Background2D failure detected. Using alternative background calculation instead....")
 
         sigma_clip = SigmaClip(sigma=3.0, maxiters=9)
-        threshold = detect_threshold(imgarr, nsigma=2.0, sigma_clip=sigma_clip)
-        segment_img = detect_sources(imgarr, threshold, npixels=5)
+        if PHOTUTILS_GE_3:
+            threshold = detect_threshold(imgarr, n_sigma=2.0,
+                                         sigma_clip=sigma_clip)
+            segment_img = detect_sources(imgarr, threshold, n_pixels=5)
+        else:
+            threshold = detect_threshold(imgarr, nsigma=2.0,
+                                         sigma_clip=sigma_clip)
+            segment_img = detect_sources(imgarr, threshold, npixels=5)
         footprint = circular_footprint(radius=11)
         mask = segment_img.make_source_mask(footprint=footprint)
         sigcl_mean, sigcl_median, sigcl_std = sigma_clipped_stats(imgarr, sigma=3.0, mask=mask)
@@ -936,7 +974,8 @@ def extract_point_sources(img, dqmask=None, fwhm=3.0, kernel=None,
                                                        fwhm, bkg[1],
                                                        nbright=nbright,
                                                        use_sharp_round=True)
-    srcs = Table([x, y, flux, src_id], names=['xcentroid', 'ycentroid', 'flux', 'id'])
+    names = [X_CENTROID, Y_CENTROID, 'flux', 'id']
+    srcs = Table([x, y, flux, src_id], names=names)
 
     """
     # Now, use IRAFStarFinder to identify sources across chip
@@ -1057,11 +1096,14 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         dao_threshold, bkg = sigma_clipped_bkg(imgarr, sigma=4.0, nsigma=dao_nsigma)
         segment_threshold = np.ones(imgarr.shape, imgarr.dtype) * dao_threshold
 
-    segm = detect_sources(convolve(imgarr, kernel), segment_threshold, npixels=source_box,
-                          connectivity=4)
+    if PHOTUTILS_GE_3:
+        segm = detect_sources(convolve(imgarr, kernel), segment_threshold,
+                              n_pixels=source_box, connectivity=4)
+    else:
+        segm = detect_sources(convolve(imgarr, kernel), segment_threshold,
+                              npixels=source_box, connectivity=4)
 
-    # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0
-    if segm is None or segm.nlabels == 0:
+    if segm is None:
         log.info("No detected sources!")
         return None, None, None
 
@@ -1088,12 +1130,18 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                         kcenter - koffset: kcenter + koffset + 1].copy()
         kernel /= kernel.sum()  # normalize to total sum == 1
         log.info("Looking for crowded sources using smaller kernel with shape: {}".format(kernel.shape))
-        segm = detect_sources(convolve(imgarr, kernel), segment_threshold, npixels=source_box)
+        if PHOTUTILS_GE_3:
+            segm = detect_sources(convolve(imgarr, kernel), segment_threshold, n_pixels=source_box)
+    else:
+            segm = detect_sources(convolve(imgarr, kernel), segment_threshold, npixels=source_box)
 
     if deblend:
-        segm = deblend_sources(convolve(imgarr, kernel), segm, npixels=5,
-                               nlevels=32,
-                               contrast=0.01)
+        if PHOTUTILS_GE_3:
+            segm = deblend_sources(convolve(imgarr, kernel), segm, n_pixels=5,
+                                   n_levels=32, contrast=0.01)
+        else:
+            segm = deblend_sources(convolve(imgarr, kernel), segm, npixels=5,
+                                   nlevels=32, contrast=0.01)
 
     # If classify is turned on, it should modify the segmentation map
     dqmap = None
@@ -1110,7 +1158,6 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         segm.remove_labels(bad_srcs)
 
     flux_colname = 'segment_flux'
-    ferr_colname = 'segment_fluxerr'
 
     # convert segm to mask for daofind
     if centering_mode == 'starfind':
@@ -1134,9 +1181,6 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         for indx in src_brightest:
             segment = segm.segments[indx]
 
-        # for segment in segm.segments:
-            # check needed for photutils <= 0.6; it can be removed when
-            # the drizzlepac depends on photutils >= 0.7
             if segment is None:
                 continue
 
@@ -1181,18 +1225,18 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                     sat_table = segment_properties.to_table()
                     seg_table['flux'][max_row] = sat_table[flux_colname][0]
                     seg_table['peak'][max_row] = sat_table['max_value'][0]
-                    xcentroid = sat_table['xcentroid'][0]
-                    ycentroid = sat_table['ycentroid'][0]
+                    xcentroid = sat_table[X_CENTROID][0]
+                    ycentroid = sat_table[Y_CENTROID][0]
                     sky = sat_table['local_background'][0]
-                    seg_table['xcentroid'][max_row] = xcentroid
-                    seg_table['ycentroid'][max_row] = ycentroid
+                    seg_table[X_CENTROID][max_row] = xcentroid
+                    seg_table[Y_CENTROID][max_row] = ycentroid
                     seg_table['npix'][max_row] = sat_table['area'][0].value
                     seg_table['mag'][max_row] = -2.5 * np.log10(sat_table[flux_colname][0])
 
                 # Add row for detected source to master catalog
                 # apply offset to slice to convert positions into full-frame coordinates
-                seg_table['xcentroid'] += seg_xoffset
-                seg_table['ycentroid'] += seg_yoffset
+                seg_table[X_CENTROID] += seg_xoffset
+                seg_table[Y_CENTROID] += seg_yoffset
                 src_table.add_row(seg_table[max_row])
 
             # If we have accumulated the desired number of sources, stop looking for more...
@@ -1204,7 +1248,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         src_table = cat.to_table()
         # Make column names consistent with IRAFStarFinder column names
         src_table.rename_column(flux_colname, 'flux')
-        src_table.rename_column(ferr_colname, 'flux_err')
+        src_table.rename_column(FERR_COLNAME, 'flux_err')
         src_table.rename_column('max_value', 'peak')
 
     if src_table is not None:
@@ -1221,11 +1265,16 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
     tbl['cat_id'] = np.arange(1, len(tbl) + 1)
 
     if outroot:
-        tbl['xcentroid'].info.format = '.10f'  # optional format
-        tbl['ycentroid'].info.format = '.10f'
+        tbl[X_CENTROID].info.format = '.10f'  # optional format
+        tbl[Y_CENTROID].info.format = '.10f'
         tbl['flux'].info.format = '.10f'
         if not outroot.endswith('.cat'):
             outroot += '.cat'
+
+        # Preserve pre-photutils 3+ column names in output table for
+        # backwards compatibility
+        _translate_columns(tbl)
+
         tbl.write(outroot, format='ascii.commented_header', overwrite=True)
         log.info("Wrote source catalog: {}".format(outroot))
 
@@ -1252,19 +1301,26 @@ def crclean_image(imgarr, segment_threshold, kernel, fwhm,
         Input array with pixels flagged as CRs set to 0.0
     """
     # Perform basic image segmentation to look for sources in image
-    segm = detect_sources(convolve(imgarr, kernel), segment_threshold, npixels=source_box,
-                          connectivity=4)
+    if PHOTUTILS_GE_3:
+        segm = detect_sources(convolve(imgarr, kernel), segment_threshold,
+                              n_pixels=source_box, connectivity=4)
+    else:
+        segm = detect_sources(convolve(imgarr, kernel), segment_threshold,
+                              npixels=source_box, connectivity=4)
 
-    log.debug("Detected {} sources of all types ".format(segm.nlabels))
-    # photutils >= 0.7: segm=None; photutils < 0.7: segm.nlabels=0
-    if segm is None or segm.nlabels == 0:
+    n_sources = segm.n_labels if PHOTUTILS_GE_3 else segm.nlabels
+    log.debug("Detected {} sources of all types ".format(n_sources))
+    if segm is None:
         log.info("No sources to identify as cosmic-rays!")
         return imgarr
 
     if deblend:
-        segm = deblend_sources(convolve(imgarr, kernel), segm, npixels=5,
-                               nlevels=32,
-                               contrast=0.01)
+        if PHOTUTILS_GE_3:
+            segm = deblend_sources(convolve(imgarr, kernel), segm, n_pixels=5,
+                                   n_levels=32, contrast=0.01)
+        else:
+            segm = deblend_sources(convolve(imgarr, kernel), segm, npixels=5,
+                                   nlevels=32, contrast=0.01)
 
     # Measure segment sources to compute centralized moments for each source
     cat = SourceCatalog(imgarr, segm)
@@ -1317,7 +1373,10 @@ def classify_sources(catalog, fwhm, sources=None):
     """
     # All these return ndarray objects
     moments = catalog.moments_central  # (num_sources, 4, 4)
-    semiminor_axis = catalog.semiminor_sigma.to_value()  # (num_sources,)
+    if PHOTUTILS_GE_3:
+        semiminor_axis = catalog.semiminor_axis.to_value()  # (num_sources,)
+    else:
+        semiminor_axis = catalog.semiminor_sigma.to_value()  # (num_sources,)
     elon = catalog.elongation.to_value()  # (num_sources,)
     # Determine how many sources we have.
     if sources is None:
@@ -1338,8 +1397,12 @@ def classify_sources(catalog, fwhm, sources=None):
     mx = np.array([np.where(moments[src] == moments[src].max())[0][0] for src in range(num_sources)], np.int32)
     my = np.array([np.where(moments[src] == moments[src].max())[1][0] for src in range(num_sources)], np.int32)
     # Now avoid processing sources which had NaN as either/both of their X,Y positions (rare, but does happen)
-    src_x = catalog.xcentroid  # (num_sources, )
-    src_y = catalog.ycentroid  # (num_sources, )
+    if PHOTUTILS_GE_3:
+        src_x = catalog.x_centroid  # (num_sources, )
+        src_y = catalog.y_centroid  # (num_sources, )
+    else:
+        src_x = catalog.xcentroid  # (num_sources, )
+        src_y = catalog.ycentroid  # (num_sources, )
     valid_xy = ~np.bitwise_or(np.isnan(src_x), np.isnan(src_y))
 
     # Define descriptors of CRs
@@ -1543,11 +1606,11 @@ def generate_sky_catalog(image, refwcs, dqname="DQ", output=False):
             continue
         # Convert pixel coordinates from this chip to sky coordinates
         chip_wcs = wcsutil.HSTWCS(image, ext=('sci', chip))
-        seg_ra, seg_dec = chip_wcs.all_pix2world(seg_tab_phot['xcentroid'], seg_tab_phot['ycentroid'], 1)
+        seg_ra, seg_dec = chip_wcs.all_pix2world(seg_tab_phot[X_CENTROID], seg_tab_phot[Y_CENTROID], 1)
         # Convert sky positions to pixel positions in the reference WCS frame
         seg_xy_out = refwcs.all_world2pix(seg_ra, seg_dec, 1)
-        seg_tab_phot['xcentroid'] = seg_xy_out[0]
-        seg_tab_phot['ycentroid'] = seg_xy_out[1]
+        seg_tab_phot[X_CENTROID] = seg_xy_out[0]
+        seg_tab_phot[Y_CENTROID] = seg_xy_out[1]
         if master_cat is None:
             master_cat = seg_tab_phot
         else:
@@ -1858,11 +1921,16 @@ def find_hist2d_offset(filename, reference, refwcs=None, refnames=['ra', 'dec'],
 
     # Build source catalog for entire image
     img_cat = generate_source_catalog(image, refwcs, output=chip_catalog, classify=classify)
+
+    # Preserve pre-photutils 3+ column names in output table for
+    # backwards compatibility
+    _translate_columns(img_cat)
+
     img_cat.write(filename.replace(".fits", "_xy.cat"), format='ascii.no_header',
                   overwrite=True)
 
     # Retrieve source XY positions in reference frame
-    seg_xy = np.column_stack((img_cat['xcentroid'], img_cat['ycentroid']))
+    seg_xy = np.column_stack((img_cat[X_CENTROID], img_cat[Y_CENTROID]))
     seg_xy = seg_xy[~np.isnan(seg_xy[:, 0])]
 
     # Translate reference catalog positions into input image coordinate frame
@@ -1954,16 +2022,16 @@ def build_wcscat(image, group_id, source_catalog):
 
         # rename xcentroid/ycentroid columns, if necessary, to be consistent with tweakwcs
         if imcat is None:
-            imcat = Table(names=['xcentroid', 'ycentroid', 'mag'])
+            imcat = Table(names=[X_CENTROID, Y_CENTROID, 'mag'])
         if isinstance(imcat, str):
             imcat = Table.read(imcat, format='ascii.fast_commented_header',
                                 names=['x', 'y'])
             if 'mag' not in imcat.colnames:
                 imcat['mag'] = [-999.9] * len(imcat['x'])
 
-        if 'xcentroid' in imcat.colnames:
-            imcat.rename_column('xcentroid', 'x')
-            imcat.rename_column('ycentroid', 'y')
+        if X_CENTROID in imcat.colnames:
+            imcat.rename_column(X_CENTROID, 'x')
+            imcat.rename_column(Y_CENTROID, 'y')
 
         wcscat = FITSWCSCorrector(
             w,

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -1234,7 +1234,6 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                     seg_table['peak'][max_row] = sat_table['max_value'][0]
                     xcentroid = sat_table[X_CENTROID][0]
                     ycentroid = sat_table[Y_CENTROID][0]
-                    # sky = sat_table['local_background'][0]
                     seg_table[X_CENTROID][max_row] = xcentroid
                     seg_table[Y_CENTROID][max_row] = ycentroid
                     seg_table[NPIX_COLNAME][max_row] = sat_table['area'][0].value

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -92,10 +92,12 @@ if PHOTUTILS_GE_3:
     X_CENTROID = 'x_centroid'
     Y_CENTROID = 'y_centroid'
     FERR_COLNAME = 'segment_flux_err'
+    NPIX_COLNAME = 'n_pixels'
 else:
     X_CENTROID = 'xcentroid'
     Y_CENTROID = 'ycentroid'
     FERR_COLNAME = 'segment_fluxerr'
+    NPIX_COLNAME = 'npix'
 
 # Check if the environment variable is defined, and if so, use that value
 if ASTROMETRIC_CAT_ENVVAR in os.environ:
@@ -199,7 +201,13 @@ def _translate_columns(tbl):
         X_CENTROID: 'xcentroid',
         Y_CENTROID: 'ycentroid',
     }
-    tbl.rename_columns(rename_map.keys(), rename_map.values())
+
+    # Astropy expects concrete sequences (list/tuple), not dict view objects.
+    # Rename only columns that are present to avoid KeyError on partial tables.
+    old_names = [old for old in rename_map if old in tbl.colnames]
+    new_names = [rename_map[old] for old in old_names]
+    if old_names:
+        tbl.rename_columns(old_names, new_names)
     return tbl
 
 
@@ -1227,10 +1235,10 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
                     seg_table['peak'][max_row] = sat_table['max_value'][0]
                     xcentroid = sat_table[X_CENTROID][0]
                     ycentroid = sat_table[Y_CENTROID][0]
-                    sky = sat_table['local_background'][0]
+                    # sky = sat_table['local_background'][0]
                     seg_table[X_CENTROID][max_row] = xcentroid
                     seg_table[Y_CENTROID][max_row] = ycentroid
-                    seg_table['npix'][max_row] = sat_table['area'][0].value
+                    seg_table[NPIX_COLNAME][max_row] = sat_table['area'][0].value
                     seg_table['mag'][max_row] = -2.5 * np.log10(sat_table[flux_colname][0])
 
                 # Add row for detected source to master catalog

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -2020,7 +2020,7 @@ def build_wcscat(image, group_id, source_catalog):
         if source_catalog:
             imcat = source_catalog[chip]
 
-        # rename xcentroid/ycentroid columns, if necessary, to be consistent with tweakwcs
+        # Rename centroid columns, if necessary, to be consistent with tweakwcs.
         if imcat is None:
             imcat = Table(names=[X_CENTROID, Y_CENTROID, 'mag'])
         if isinstance(imcat, str):
@@ -2029,9 +2029,13 @@ def build_wcscat(image, group_id, source_catalog):
             if 'mag' not in imcat.colnames:
                 imcat['mag'] = [-999.9] * len(imcat['x'])
 
-        if X_CENTROID in imcat.colnames:
-            imcat.rename_column(X_CENTROID, 'x')
-            imcat.rename_column(Y_CENTROID, 'y')
+        for x_name, y_name in ((X_CENTROID, Y_CENTROID), ('xcentroid', 'ycentroid'), ('x', 'y')):
+            if x_name in imcat.colnames and y_name in imcat.colnames:
+                if x_name != 'x' or y_name != 'y':
+                    imcat.rename_columns([x_name, y_name], ['x', 'y'])
+                break
+        else:
+            raise KeyError('No centroid columns found in source catalog for tweakwcs')
 
         wcscat = FITSWCSCorrector(
             w,

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -982,8 +982,7 @@ def extract_point_sources(img, dqmask=None, fwhm=3.0, kernel=None,
                                                        fwhm, bkg[1],
                                                        nbright=nbright,
                                                        use_sharp_round=True)
-    names = [X_CENTROID, Y_CENTROID, 'flux', 'id']
-    srcs = Table([x, y, flux, src_id], names=names)
+    srcs = Table([x, y, flux, src_id], names = [X_CENTROID, Y_CENTROID, 'flux', 'id'])
 
     """
     # Now, use IRAFStarFinder to identify sources across chip

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -1132,7 +1132,7 @@ def extract_sources(img, dqmask=None, fwhm=3.0, kernel=None, photmode=None,
         log.info("Looking for crowded sources using smaller kernel with shape: {}".format(kernel.shape))
         if PHOTUTILS_GE_3:
             segm = detect_sources(convolve(imgarr, kernel), segment_threshold, n_pixels=source_box)
-    else:
+        else:
             segm = detect_sources(convolve(imgarr, kernel), segment_threshold, npixels=source_box)
 
     if deblend:

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -9,11 +9,13 @@ from packaging.version import Version
 from astropy.io import fits as fits
 from astropy.stats import sigma_clipped_stats, gaussian_fwhm_to_sigma
 from astropy.table import Column, MaskedColumn, Table, join, vstack
+from astropy.utils import minversion
 from astropy.convolution import RickerWavelet2DKernel, convolve
 from astropy.coordinates import SkyCoord
 import numpy as np
 from scipy import ndimage, stats
 
+import photutils
 from photutils.segmentation import (detect_sources, SourceCatalog,
                                     deblend_sources)
 from photutils.aperture import CircularAperture, CircularAnnulus
@@ -44,7 +46,6 @@ RADESYS_OPTIONS = ['FK4', 'FK5', 'ICRS']
 
 id_colname = 'label'
 flux_colname = 'segment_flux'
-ferr_colname = 'segment_fluxerr'
 bac_colname = 'background_centroid'
 
 __taskname__ = 'catalog_utils'
@@ -53,6 +54,17 @@ MSG_DATEFMT = '%Y%j%H%M%S'
 SPLUNK_MSG_FORMAT = '%(asctime)s %(levelname)s src=%(name)s- %(message)s'
 log = logutil.create_logger(__name__, level=logutil.logging.NOTSET, stream=sys.stdout,
                             format=SPLUNK_MSG_FORMAT, datefmt=MSG_DATEFMT)
+
+PHOTUTILS_GE_3 = minversion(photutils, "2.3.1.dev")
+photutils.future_column_names = True
+if PHOTUTILS_GE_3:
+    X_CENTROID = 'x_centroid'
+    Y_CENTROID = 'y_centroid'
+    FERR_COLNAME = 'segment_flux_err'
+else:
+    X_CENTROID = 'xcentroid'
+    Y_CENTROID = 'ycentroid'
+    FERR_COLNAME = 'segment_fluxerr'
 
 
 class CatalogImage:
@@ -140,7 +152,7 @@ class CatalogImage:
         # of the input image is no longer used here as it could be asymmetric and
         # lead to smeared segments (i.e., centroid coordinates offset from actual source).
         # The value of 11 for the Gaussian kernel is big enough for all detectors. This
-        # value is hard-coded here in contrast to being in the configuration files like 
+        # value is hard-coded here in contrast to being in the configuration files like
         # the RickerWavelet2DKernel.
         self.kernel_fwhm = fwhmpsf / self.imgwcs.pscale
         self.kernel = astrometric_utils.build_gaussian_kernel(self.kernel_fwhm, npixels=11)
@@ -260,7 +272,7 @@ class CatalogImage:
         # which contributed to the value of a pixel.
         #
         # Note that if there are large shifts between images, the pixels in the gaps between the
-        # images have values of 0.  The self.num_images_mask is the mask created by 
+        # images have values of 0.  The self.num_images_mask is the mask created by
         # generate_footprint_mask() in product.py.
         footprint_mask = self.num_images_mask > 0
         self.footprint_mask = ndimage.binary_erosion(footprint_mask, iterations=10)
@@ -364,7 +376,7 @@ class CatalogImage:
             # Create a version of the input image with zeros and NaN values masked
             masked_imgdata = np.ma.masked_array(imgdata, mask=(imgdata == 0) | np.isnan(imgdata))
             diffs = 2*masked_imgdata[:,2:-2] - masked_imgdata[:,:-4] - masked_imgdata[:,4:]
-           
+
             # Median for flattened array yields the rms estimate
             # Ref: Stoehr et al. 2007, See https://ui.adsabs.harvard.edu/abs/2008ASPC..394..505S
             #
@@ -372,8 +384,8 @@ class CatalogImage:
             # sqrt(6.0) = comes from the propagation of errors for the given pixel combination.
             #    Ref: Rick White - If you have a weighted sum of 3 random numbers, s = a*r1 + b*r2 + c*r3,
             #    then the noise in s is sqrt(a**2+b**2+c**2). In the DER_SNR equation (see reference
-            #    paper), the three coefficients are 2, 1 and 1, so the combination is 
-            #    sqrt(4 + 1 + 1) = sqrt(6). 
+            #    paper), the three coefficients are 2, 1 and 1, so the combination is
+            #    sqrt(4 + 1 + 1) = sqrt(6).
             mad_rms = np.ma.median(np.ma.abs(diffs)) * 1.482602 / np.sqrt(6.0)
             log.info("Computation 3 of RMS - median absolute algorithm")
             log.info(f"    MAD rms: {mad_rms:.6f}")
@@ -410,11 +422,22 @@ class CatalogImage:
                 for percentile in exclude_percentiles:
                     log.info("Percentile in use: {}".format(percentile))
                     try:
-                        bkg = Background2D(imgdata, (box_size, box_size), filter_size=(win_size, win_size),
-                                           bkg_estimator=bkg_estimator(),
-                                           bkgrms_estimator=rms_estimator(),
-                                           exclude_percentile=percentile,
-                                           coverage_mask=self.inv_footprint_mask)
+                        if PHOTUTILS_GE_3:
+                            bkg = Background2D(
+                                imgdata, (box_size, box_size),
+                                filter_size=(win_size, win_size),
+                                bkg_estimator=bkg_estimator(),
+                                bkg_rms_estimator=rms_estimator(),
+                                exclude_percentile=percentile,
+                                coverage_mask=self.inv_footprint_mask)
+                        else:
+                            bkg = Background2D(
+                                imgdata, (box_size, box_size),
+                                filter_size=(win_size, win_size),
+                                bkg_estimator=bkg_estimator(),
+                                bkgrms_estimator=rms_estimator(),
+                                exclude_percentile=percentile,
+                                coverage_mask=self.inv_footprint_mask)
 
                     except Exception:
                         bkg = None
@@ -889,7 +912,7 @@ class HAPCatalogBase:
         self.tp_masks = None
         if not self.image.blank:
             self.tp_masks = make_wht_masks(
-                self.image.wht_image, 
+                self.image.wht_image,
                 self.image.inv_footprint_mask,
                 scale=scale,
                 sensitivity=self.param_dict['sensitivity'],
@@ -1168,8 +1191,15 @@ class HAPPointCatalog(HAPCatalogBase):
                         # Try standard daofind instead
                         log.info("Reverting to DAOStarFinder(fwhm={}, threshold={}*{})".format(source_fwhm, self.param_dict['nsigma'],
                                                                                   reg_rms_median))
-                        daofind = DAOStarFinder(fwhm=source_fwhm,
-                                                threshold=self.param_dict['nsigma'] * reg_rms_median)
+                        if PHOTUTILS_GE_3:
+                            daofind = DAOStarFinder(
+                                fwhm=source_fwhm,
+                                threshold=self.param_dict['nsigma'] * reg_rms_median,
+                                min_separation=0)
+                        else:
+                            daofind = DAOStarFinder(
+                                fwhm=source_fwhm,
+                                threshold=self.param_dict['nsigma'] * reg_rms_median)
                         reg_sources = daofind(region, mask=self.image.inv_footprint_mask)
                 else:
                     err_msg = "'{}' is not a valid 'starfinder_algorithm' parameter input in the catalog_generation parameters json file. Valid options are 'dao' for photutils.detection.DAOStarFinder() or 'iraf' for photutils.detection.IRAFStarFinder().".format(self.param_dict["starfinder_algorithm"])
@@ -1206,8 +1236,8 @@ class HAPPointCatalog(HAPCatalogBase):
             log.info("Measured {} sources in {}".format(len(sources), self.image.imgname))
             log.info("   colnames: {}".format(sources.colnames))
             # insure centroid columns are not masked
-            sources['xcentroid'] = Column(sources['xcentroid'])
-            sources['ycentroid'] = Column(sources['ycentroid'])
+            sources['xcentroid'] = Column(sources[X_CENTROID])
+            sources['ycentroid'] = Column(sources[Y_CENTROID])
             # calculate and add RA and DEC columns to table
             ra, dec = self.transform_list_xy_to_ra_dec(sources["xcentroid"], sources["ycentroid"], self.imgname)
             ra_col = Column(name="RA", data=ra, dtype=np.float64)
@@ -1367,8 +1397,8 @@ class HAPPointCatalog(HAPCatalogBase):
         photometry_tbl.add_column(flag_col)
 
         # build final output table
-        final_col_order = ["X-Center", "Y-Center", "RA", "DEC", "ID", "MagAp1", "MagErrAp1", "FluxAp1", 
-                           "FluxErrAp1", "MagAp2", "MagErrAp2", "MSkyAp2", "StdevAp2", "FluxAp2", 
+        final_col_order = ["X-Center", "Y-Center", "RA", "DEC", "ID", "MagAp1", "MagErrAp1", "FluxAp1",
+                           "FluxErrAp1", "MagAp2", "MagErrAp2", "MSkyAp2", "StdevAp2", "FluxAp2",
                            "FluxErrAp2", "CI", "Flags"]
         output_photometry_table = photometry_tbl[final_col_order]
 
@@ -1405,7 +1435,7 @@ class HAPPointCatalog(HAPCatalogBase):
         final_col_units = {"X-Center": "pixel", "Y-Center": "pixel", "RA": "degree", "DEC": "degree",
                            "ID": "", "MagAp1": "mag(AB)", "MagErrAp1": "mag(AB)", "MagAp2": "mag(AB)",
                            "MagErrAp2": "mag(AB)", "MSkyAp2": "electron/(s pixel)", "StdevAp2": "electron/(s pixel)",
-                           "FluxAp1": "electron/s", "FluxErrAp1": "electron/s","FluxAp2": "electron/s", 
+                           "FluxAp1": "electron/s", "FluxErrAp1": "electron/s","FluxAp2": "electron/s",
                            "FluxErrAp2": "electron/s", "CI": "mag(AB)", "Flags": ""}
         for col_title in final_col_units:
             output_photometry_table[col_title].unit = final_col_units[col_title]
@@ -1980,6 +2010,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
             enforce_icrs_compatibility(self.source_cat)
             # Convert source_cat which is a SourceCatalog to an Astropy Table - need the data in tabular
             # form to filter out bad rows and correspondingly bad segments before the filter images are processed.
+            zzzzzz
+
             total_measurements_table = Table(self.source_cat.to_table(columns=['label', 'xcentroid', 'ycentroid', 'sky_centroid_icrs']))
 
             # Filter the table to eliminate nans or inf based on the coordinates, then remove these segments from
@@ -2070,8 +2102,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
             Factor to match the Gaussian core width
 
         kw : int
-            x_size : Size in the x-direction 
-            y_size : Size in the y-direction 
+            x_size : Size in the x-direction
+            y_size : Size in the y-direction
 
         Returns
         -------
@@ -2191,7 +2223,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
            background_img : float
                Computed 2D background for total detection image
-               
+
            ncount : int
                Invocation index for this method.  The index is used to create unique names
                for diagnostic output files.
@@ -2216,15 +2248,21 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Subtract the background image from the white light image and convolve
         #
         # Important to background subtract to get accurate positions for faint sources or
-        # positions will be shifted toward the geometrical center of the segment rather 
+        # positions will be shifted toward the geometrical center of the segment rather
         # than located at the flux-weighted centroid as desired.
         self.convolved_img = convolve(imgarr-background_img, filter_kernel, normalize_kernel=False)
 
         # The threshold should not include the background.
-        segm_img = detect_sources(self.convolved_img,
-                                  threshold,
-                                  npixels=source_box,
-                                  mask=mask)
+        if PHOTUTILS_GE_3:
+            segm_img = detect_sources(self.convolved_img,
+                                      threshold,
+                                      n_pixels=source_box,
+                                      mask=mask)
+        else:
+            segm_img = detect_sources(self.convolved_img,
+                                      threshold,
+                                      npixels=source_box,
+                                      mask=mask)
 
         # If no segments were found, there are no detectable sources in the total detection image.
         # Return as there is nothing more to do.
@@ -2281,12 +2319,20 @@ class HAPSegmentCatalog(HAPCatalogBase):
             # segmentation. Sextractor uses a multi-thresholding technique.
             # npixels = minimum number of connected pixels in source
             # npixels and filter_kernel should match those used by detect_sources()
-            segm_deblended_img = deblend_sources(self.convolved_img,
-                                                 segm_img,
-                                                 npixels=source_box,
-                                                 nlevels=self._nlevels,
-                                                 contrast=self._contrast,
-                                                 labels=segm_img.big_segments)
+            if PHOTUTILS_GE_3:
+                segm_deblended_img = deblend_sources(self.convolved_img,
+                                                     segm_img,
+                                                     n_pixels=source_box,
+                                                     n_levels=self._nlevels,
+                                                     contrast=self._contrast,
+                                                     labels=segm_img.big_segments)
+            else:
+                segm_deblended_img = deblend_sources(self.convolved_img,
+                                                     segm_img,
+                                                     npixels=source_box,
+                                                     nlevels=self._nlevels,
+                                                     contrast=self._contrast,
+                                                     labels=segm_img.big_segments)
 
             if self.diagnostic_mode:
                 log.info("Deblended {} out of {} segments".format(len(segm_img.big_segments), segm_img.nlabels))
@@ -2355,10 +2401,23 @@ class HAPSegmentCatalog(HAPCatalogBase):
 
         # Columns to include from the computation of source properties to save
         # computation time from computing values which are not used
-        include_filter_cols = ['area', bac_colname, 'bbox_xmax', 'bbox_xmin', 'bbox_ymax', 'bbox_ymin',
-                               'covar_sigx2', 'covar_sigxy', 'covar_sigy2', 'cxx', 'cxy', 'cyy',
-                               'ellipticity', 'elongation', id_colname, 'kron_radius', 'orientation', 'sky_centroid_icrs',
-                               flux_colname, ferr_colname, 'xcentroid', 'ycentroid']
+        if PHOTUTILS_GE_3:
+            include_filter_cols = [
+                'area', bac_colname, 'bbox_xmax', 'bbox_xmin', 'bbox_ymax',
+                'bbox_ymin', 'covar_sigx2', 'covar_sigxy', 'covar_sigy2',
+                'cxx', 'cxy', 'cyy', 'ellipticity', 'elongation', id_colname,
+                'kron_radius', 'orientation', 'sky_centroid_icrs',
+                flux_colname, FERR_COLNAME, 'xcentroid', 'ycentroid',
+            ]
+        else:
+            include_filter_cols = [
+                'area', bac_colname, 'bbox_xmax', 'bbox_xmin', 'bbox_ymax',
+                'bbox_ymin', 'covariance_xx', 'covariance_xy', 'covariance_yy',
+                'ellipse_cxx', 'ellipse_cxy', 'ellipse_cyy', 'ellipticity',
+                'elongation', id_colname, 'kron_radius', 'orientation',
+                'sky_centroid_icrs', flux_colname, FERR_COLNAME,
+                X_CENTROID, Y_CENTROID,
+            ]
 
         # Compute source properties...
         # No convolved image needed here since the detection_cat parameter is set.
@@ -2609,16 +2668,30 @@ class HAPSegmentCatalog(HAPCatalogBase):
                 A modified version of the input table which has been reformatted in preparation
                 for catalog generation.
         """
+        if PHOTUTILS_GE_3:
+            # Rename photutils 3+ column names to match photutils 2
+            # column names for consistency with HLA Classic catalogs
+            rename_map = {
+                "ellipse_cxx": "cxx",
+                "ellipse_cxy": "cxy",
+                "ellipse_cyy": "cyy",
+                "covariance_xx": "covar_sigx2",
+                "covariance_xy": "covar_sigxy",
+                "covariance_yy": "covar_sigy2",
+            }
+            for new_colname in rename_map:
+                filter_table.rename_column(new_colname, rename_map[new_colname])
 
         # Rename columns to names used when HLA Classic catalog distributed by MAST
-        final_col_names = {id_colname: "ID", "xcentroid": "X-Centroid", "ycentroid": "Y-Centroid",
-                           bac_colname: "Bck", flux_colname: "FluxSegment", ferr_colname: "FluxSegmentErr",
+        final_col_names = {id_colname: "ID", X_CENTROID: "X-Centroid", Y_CENTROID: "Y-Centroid",
+                           bac_colname: "Bck", flux_colname: "FluxSegment", FERR_COLNAME: "FluxSegmentErr",
                            "bbox_xmin": "Xmin", "bbox_ymin": "Ymin", "bbox_xmax": "Xmax", "bbox_ymax": "Ymax",
-                           "cxx": "CXX", "cyy": "CYY", "cxy": "CXY",
+                            "cxx": "CXX", "cyy": "CYY", "cxy": "CXY",
                            "covar_sigx2": "X2", "covar_sigy2": "Y2", "covar_sigxy": "XY",
                            "orientation": "Theta",
                            "elongation": "Elongation", "ellipticity": "Ellipticity", "area": "Area",
                            "fwhm": "FWHM", "kron_radius": "KronRadius"}
+
         for old_col_title in final_col_names:
             filter_table.rename_column(old_col_title, final_col_names[old_col_title])
 
@@ -2783,7 +2856,9 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # to the total table.  During the combine process, the new columns are renamed,
         # formatted, and described (as necessary). For now this table only has id, xcentroid,
         # ycentroid, RA, and DEC.
-        table = updated_table["label", "xcentroid", "ycentroid"]
+        table = updated_table["label", X_CENTROID, Y_CENTROID]
+        table.rename_column(X_CENTROID, "x_centroid")
+        table.rename_column(Y_CENTROID, "y_centroid")
 
         # Convert the RA/Dec SkyCoord into separate columns
         radec_data = SkyCoord(updated_table["sky_centroid_icrs"])
@@ -2889,7 +2964,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         nbins = segm_img.max_label
         log.info("Number of sources from segmentation map: %d", nbins)
 
-        # Compute the biggest source identified 
+        # Compute the biggest source identified
         # The clip eliminates zero-divides when there are no good pixels in the image
         real_pixels = (np.isfinite(image_data) & (image_data != 0)).sum().clip(min=1)
         biggest_source_pixels = segm_img.areas.max()
@@ -3087,20 +3162,20 @@ def make_inv_mask(mask):
 
 def make_wht_masks(
     whtarr: np.ndarray, # image weight array (dtype=float32), zeros outside of footprint
-    maskarr: np.ndarray, # mask array (dtype=bool), typically inverse of footprint 
+    maskarr: np.ndarray, # mask array (dtype=bool), typically inverse of footprint
     scale: float = 1.5,
     sensitivity: float = 0.95,
     kernel: tuple = (11, 11) # kernel size for maximum filter window
-) -> list: # list containing a dictionary 
-    """ Uses scipy's maximum_filter to create the image weight masks of floats between 0 and 1. 
-    Function produces a list including a dictionary with the scale (float), wht_limit (float), 
-    mask (np.ndarray of bools, dtype=int16), and  relative weight (np.ndarray, dtype=float32). 
-    
+) -> list: # list containing a dictionary
+    """ Uses scipy's maximum_filter to create the image weight masks of floats between 0 and 1.
+    Function produces a list including a dictionary with the scale (float), wht_limit (float),
+    mask (np.ndarray of bools, dtype=int16), and  relative weight (np.ndarray, dtype=float32).
+
     """
-    # uses scipy maximum filter on image. Maximum filter selects the largest value within an ordered 
+    # uses scipy maximum filter on image. Maximum filter selects the largest value within an ordered
     # window of pixel values and replaces the central pixel with the largest value.
     maxwht = ndimage.maximum_filter(whtarr, size=kernel)
-    
+
     # normalized weight array
     rel_wht = maxwht / maxwht.max()
 
@@ -3116,7 +3191,7 @@ def make_wht_masks(
     # this is weird, trying to preserve the peculiar definition of similarity
     osum = master_mask.sum()
     pthresh = (1 - sensitivity) * osum
-    
+
     # loop through scale values until all pixels are used
     while master_mask.any():
 
@@ -3171,9 +3246,7 @@ def enforce_icrs_compatibility(catalog):
     # header keyword REFFRAME can be populated with anything specified by the user in the original
     # proposal.
     """
-    # We need to check whether or not the catalog was generated with photutils<1.6.0 or not
-    # since photutils=1.6.0 (apparently) renamed the 'catalog._wcs' to 'catalog.wcs'.
-    cat_wcs = catalog.wcs if hasattr(catalog, 'wcs') else catalog._wcs
+    cat_wcs = catalog.wcs
     if cat_wcs.wcs.radesys.upper() not in RADESYS_OPTIONS:
         cat_wcs.wcs.radesys = 'ICRS'
         log.warning(f"Assuming input coordinates are ICRS, instead of {cat_wcs.wcs.radesys}")

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2855,8 +2855,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # formatted, and described (as necessary). For now this table only has id, xcentroid,
         # ycentroid, RA, and DEC.
         table = updated_table["label", X_CENTROID, Y_CENTROID]
-        table.rename_column(X_CENTROID, "x_centroid")
-        table.rename_column(Y_CENTROID, "y_centroid")
+        # table.rename_column(X_CENTROID, "x_centroid")
+        # table.rename_column(Y_CENTROID, "y_centroid")
 
         # Convert the RA/Dec SkyCoord into separate columns
         radec_data = SkyCoord(updated_table["sky_centroid_icrs"])
@@ -2869,7 +2869,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Rename columns to names to those used when HLA Classic catalog distributed by MAST
         # and/or to distinguish Point and Segment catalogs
         # The columns that are appended will be renamed during the combine process
-        final_col_names = {"label": "ID", "x_centroid": "X-Centroid", "y_centroid": "Y-Centroid"}
+        final_col_names = {"label": "ID", X_CENTROID: "X-Centroid", Y_CENTROID: "Y-Centroid"}
         for old_col_title in final_col_names:
             if old_col_title in table.colnames:
                 table.rename_column(old_col_title, final_col_names[old_col_title])

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2852,9 +2852,17 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # more columns are appended to this table from the filter results.
         # Actually, the filter columns are in a table which is "database joined"
         # to the total table.  During the combine process, the new columns are renamed,
-        # formatted, and described (as necessary). For now this table only has id, xcentroid,
-        # ycentroid, RA, and DEC.
-        table = updated_table["label", X_CENTROID, Y_CENTROID]
+        # formatted, and described (as necessary). For now this table only has id, centroid,
+        # RA, and DEC.
+        x_col = next(
+            colname for colname in (X_CENTROID, "xcentroid", "x_centroid")
+            if colname in updated_table.colnames
+        )
+        y_col = next(
+            colname for colname in (Y_CENTROID, "ycentroid", "y_centroid")
+            if colname in updated_table.colnames
+        )
+        table = updated_table["label", x_col, y_col]
         # table.rename_column(X_CENTROID, "x_centroid")
         # table.rename_column(Y_CENTROID, "y_centroid")
 
@@ -2869,7 +2877,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Rename columns to names to those used when HLA Classic catalog distributed by MAST
         # and/or to distinguish Point and Segment catalogs
         # The columns that are appended will be renamed during the combine process
-        final_col_names = {"label": "ID", X_CENTROID: "X-Centroid", Y_CENTROID: "Y-Centroid"}
+        final_col_names = {"label": "ID", x_col: "X-Centroid", y_col: "Y-Centroid"}
         for old_col_title in final_col_names:
             if old_col_title in table.colnames:
                 table.rename_column(old_col_title, final_col_names[old_col_title])

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2869,9 +2869,13 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Rename columns to names to those used when HLA Classic catalog distributed by MAST
         # and/or to distinguish Point and Segment catalogs
         # The columns that are appended will be renamed during the combine process
-        final_col_names = {"label": "ID", "xcentroid": "X-Centroid", "ycentroid": "Y-Centroid"}
+        final_col_names = {"label": "ID", "x_centroid": "X-Centroid", "y_centroid": "Y-Centroid"}
         for old_col_title in final_col_names:
-            table.rename_column(old_col_title, final_col_names[old_col_title])
+            if old_col_title in table.colnames:
+                table.rename_column(old_col_title, final_col_names[old_col_title])
+            else:
+                log.warning(f"Column {old_col_title} not found in the input table"+
+                            f"could not be renamed to {final_col_names[old_col_title]}")
 
         # Format the current columns
         final_col_format = {"ID": "7d", "X-Centroid": "10.3f", "Y-Centroid": "10.3f", "RA": "13.7f", "DEC": "13.7f"}

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2873,6 +2873,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Rename columns to names to those used when HLA Classic catalog distributed by MAST
         # and/or to distinguish Point and Segment catalogs
         # The columns that are appended will be renamed during the combine process
+        log.info(f'Table column names before renaming: {table.colnames}')
         final_col_names = {"label": "ID", x_col: "X-Centroid", y_col: "Y-Centroid"}
         for old_col_title in final_col_names:
             if old_col_title in table.colnames:

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2402,19 +2402,19 @@ class HAPSegmentCatalog(HAPCatalogBase):
         if PHOTUTILS_GE_3:
             include_filter_cols = [
                 'area', bac_colname, 'bbox_xmax', 'bbox_xmin', 'bbox_ymax',
-                'bbox_ymin', 'covar_sigx2', 'covar_sigxy', 'covar_sigy2',
-                'cxx', 'cxy', 'cyy', 'ellipticity', 'elongation', id_colname,
-                'kron_radius', 'orientation', 'sky_centroid_icrs',
-                flux_colname, FERR_COLNAME, 'xcentroid', 'ycentroid',
-            ]
-        else:
-            include_filter_cols = [
-                'area', bac_colname, 'bbox_xmax', 'bbox_xmin', 'bbox_ymax',
                 'bbox_ymin', 'covariance_xx', 'covariance_xy', 'covariance_yy',
                 'ellipse_cxx', 'ellipse_cxy', 'ellipse_cyy', 'ellipticity',
                 'elongation', id_colname, 'kron_radius', 'orientation',
                 'sky_centroid_icrs', flux_colname, FERR_COLNAME,
                 X_CENTROID, Y_CENTROID,
+            ]
+        else:
+            include_filter_cols = [
+                'area', bac_colname, 'bbox_xmax', 'bbox_xmin', 'bbox_ymax',
+                'bbox_ymin', 'covar_sigx2', 'covar_sigxy', 'covar_sigy2',
+                'cxx', 'cxy', 'cyy', 'ellipticity', 'elongation', id_colname,
+                'kron_radius', 'orientation', 'sky_centroid_icrs',
+                flux_colname, FERR_COLNAME, X_CENTROID, Y_CENTROID,
             ]
 
         # Compute source properties...

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -1235,9 +1235,7 @@ class HAPPointCatalog(HAPCatalogBase):
 
             log.info("Measured {} sources in {}".format(len(sources), self.image.imgname))
             log.info("   colnames: {}".format(sources.colnames))
-            # insure centroid columns are not masked
-            sources['xcentroid'] = Column(sources[X_CENTROID])
-            sources['ycentroid'] = Column(sources[Y_CENTROID])
+
             # calculate and add RA and DEC columns to table
             ra, dec = self.transform_list_xy_to_ra_dec(sources["xcentroid"], sources["ycentroid"], self.imgname)
             ra_col = Column(name="RA", data=ra, dtype=np.float64)
@@ -2495,7 +2493,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         good_rows_index = []
         bad_rows_index = []
         for i, old_row in enumerate(filter_measurements_table):
-            if np.isfinite(old_row["xcentroid"]):
+            if np.isfinite(old_row[X_CENTROID]):
                 good_rows_index.append(i)
             else:
                 bad_rows_index.append(i)
@@ -2506,7 +2504,7 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # Case: there are good/measurable sources in the input table
         if good_rows_index:
             # Obtain the X and Y positions to compute the circular annulus
-            positions = (filter_measurements_table["xcentroid"][good_rows_index], filter_measurements_table["ycentroid"][good_rows_index])
+            positions = (filter_measurements_table[X_CENTROID][good_rows_index], filter_measurements_table[Y_CENTROID][good_rows_index])
             pos_xy = np.vstack(positions).T
 
             # Define list of background annulii
@@ -2582,8 +2580,8 @@ class HAPSegmentCatalog(HAPCatalogBase):
         # The bad rows have nan values for the xcentroid/ycentroid coordinates, as well as the RA/Dec values,
         # so recover these values from the total source catalog to make it easy for the user to map the filter
         # catalog rows back to the total detection catalog
-        filter_measurements_table['xcentroid'][bad_rows_index] = self.total_source_table['X-Centroid'][bad_rows_index]
-        filter_measurements_table['ycentroid'][bad_rows_index] = self.total_source_table['Y-Centroid'][bad_rows_index]
+        filter_measurements_table[X_CENTROID][bad_rows_index] = self.total_source_table['X-Centroid'][bad_rows_index]
+        filter_measurements_table[Y_CENTROID][bad_rows_index] = self.total_source_table['Y-Centroid'][bad_rows_index]
         filter_measurements_table['RA'][bad_rows_index] = self.total_source_table['RA'][bad_rows_index]
         filter_measurements_table['DEC'][bad_rows_index] = self.total_source_table['DEC'][bad_rows_index]
 
@@ -2863,8 +2861,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
             if colname in updated_table.colnames
         )
         table = updated_table["label", x_col, y_col]
-        # table.rename_column(X_CENTROID, "x_centroid")
-        # table.rename_column(Y_CENTROID, "y_centroid")
 
         # Convert the RA/Dec SkyCoord into separate columns
         radec_data = SkyCoord(updated_table["sky_centroid_icrs"])

--- a/drizzlepac/haputils/catalog_utils.py
+++ b/drizzlepac/haputils/catalog_utils.py
@@ -2010,8 +2010,6 @@ class HAPSegmentCatalog(HAPCatalogBase):
             enforce_icrs_compatibility(self.source_cat)
             # Convert source_cat which is a SourceCatalog to an Astropy Table - need the data in tabular
             # form to filter out bad rows and correspondingly bad segments before the filter images are processed.
-            zzzzzz
-
             total_measurements_table = Table(self.source_cat.to_table(columns=['label', 'xcentroid', 'ycentroid', 'sky_centroid_icrs']))
 
             # Filter the table to eliminate nans or inf based on the coordinates, then remove these segments from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "spherical_geometry>=1.2.22",
     "astroquery>=0.4",
     "astrocut",
-    "photutils<2.4.0",
+    "photutils",
     "lxml",
     "pypdf",
     "scikit-image>=0.14.2",

--- a/tests/hap/test_svm_ci.py
+++ b/tests/hap/test_svm_ci.py
@@ -114,7 +114,7 @@ class BaseWFC3Pipeline:
 
 
 class TestSVMCI(BaseWFC3Pipeline):
-    @pytest.mark.serial
+
     def test_svm_ci(self):
         """ Tests pipeline-style processing of a ASN using runastrodriz.
         """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1598](https://jira.stsci.edu/browse/HLA-1598)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
#2145 

<!-- describe the changes comprising this PR here -->
This PR makes updates for renamed/deprecated columns and arguments in photutils 3+. This will prevent new deprecation warnings in devdeps tests.

The output tables from haputils should be identical, but please let me know if any of the column names changes.  I can easily fix that.

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)

Regression test: 

[Photutils v2.3.0 test 
](https://github.com/spacetelescope/RegressionTests/actions/runs/26107899344) [Photutils v3.0.0 test](https://github.com/spacetelescope/RegressionTests/actions/runs/26111040077)
