### PR TITLE
HLA-1569: Remove lingering TEAL text, and deprecate TEAL functions and arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Added code to handle deprecations in photutils v3.0.0. [#2089]
 
-- Deprecated the teal helper "run" functions as well as the editpars 
+- Deprecated the TEAL helper "run" functions as well as the editpars 
   parameters in base drizzlepac functions. [#2152]
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 
 - Added code to handle deprecations in photutils v3.0.0. [#2089]
 
+- Deprecated the teal helper "run" functions as well as the editpars 
+  parameters in base drizzlepac functions. [#2152]
+
 
 3.11.0 (28-Apr-2026)
 ====================

--- a/doc/source/mast_data_products/reproducing_mast_data_products.rst
+++ b/doc/source/mast_data_products/reproducing_mast_data_products.rst
@@ -21,15 +21,6 @@ Alternative Usage
     >>> runastrodriz.process(inputFilename,force=False,newpath=None,inmemory=False)
 
 
-GUI Usage under Python (no longer supported)
-============================================
-
-    >>> python
-    >>> from stsci.tools import teal
-    >>> import wfc3tools
-    >>> cfg = teal.teal('runastrodriz')
-
-
 Options
 =======
 

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -39,7 +39,7 @@ __taskname__ = "ablot"
 STEP_NUM = 5
 PROCSTEPS_NAME = "Blot"
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def blot(
     data,
     reference,

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -229,7 +229,7 @@ def blot(
         run(configObj, wcsmap=wcsmap)
 
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj, wcsmap=None):
     """
     Run the blot task based on parameters provided interactively by the user.

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -13,6 +13,7 @@ import os
 import logging
 import numpy as np
 from stsci.tools import fileutil
+from astropy.utils import deprecated
 from . import outputimage
 from . import wcs_functions
 from . import util
@@ -37,7 +38,7 @@ __taskname__ = "ablot"
 STEP_NUM = 5
 PROCSTEPS_NAME = "Blot"
 
-
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def blot(
     data,
     reference,
@@ -217,10 +218,7 @@ def blot(
     input_dict["reference"] = reference
     input_dict["outdata"] = outdata
 
-    # gets configObj defaults using EPAR/TEAL.
-    #
-    # Also insure that the input_dict (user-specified values) are folded in
-    # with a fully populated configObj instance.
+    # get default configuration parameters using teal.load
     configObj = util.getDefaultConfigObj(__taskname__, configObj,
                                          input_dict, loadOnly=(not editpars))
     if configObj is None:
@@ -230,6 +228,7 @@ def blot(
         run(configObj, wcsmap=wcsmap)
 
 
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj, wcsmap=None):
     """
     Run the blot task based on parameters provided interactively by the user.

--- a/drizzlepac/ablot.py
+++ b/drizzlepac/ablot.py
@@ -14,6 +14,7 @@ import logging
 import numpy as np
 from stsci.tools import fileutil
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 from . import outputimage
 from . import wcs_functions
 from . import util
@@ -38,7 +39,7 @@ __taskname__ = "ablot"
 STEP_NUM = 5
 PROCSTEPS_NAME = "Blot"
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def blot(
     data,
     reference,

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -41,6 +41,7 @@ import logging
 from . import util
 import numpy as np
 from astropy.io import fits
+from astropy.utils import deprecated
 from stsci.tools import fileutil, mputil
 from . import outputimage, wcs_functions
 import stwcs
@@ -87,6 +88,7 @@ time_write_all = []
 #
 
 
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input_dict):
     """Run the high-level drizzle task for a single set of inputs.
 
@@ -99,7 +101,7 @@ def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input
     wcsmap : callable, optional
         Mapping factory that converts between input and output WCS frames.
         Defaults to ``None`` which triggers the package's standard mapping.
-    editpars : bool, optional
+    editpars : bool, (Default = False; deprecated)
         When ``True``, launch the TEAL interface so users can review and edit
         parameter values before execution.
     configObj : configobj.Section, optional
@@ -295,9 +297,7 @@ def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input
         run(configObj, wcsmap=wcsmap)
 
 
-#
-# ###  User level interface to run drizzle tasks from TEAL
-#
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj, wcsmap=None):
     """Interface for running ``drizzle`` Python or command-line.
 

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -42,6 +42,7 @@ from . import util
 import numpy as np
 from astropy.io import fits
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 from stsci.tools import fileutil, mputil
 from . import outputimage, wcs_functions
 import stwcs
@@ -88,7 +89,7 @@ time_write_all = []
 #
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input_dict):
     """Run the high-level drizzle task for a single set of inputs.
 
@@ -101,9 +102,12 @@ def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input
     wcsmap : callable, optional
         Mapping factory that converts between input and output WCS frames.
         Defaults to ``None`` which triggers the package's standard mapping.
-    editpars : bool, (Default = False; deprecated)
+    editpars : bool, (Default = False)
         When ``True``, launch the TEAL interface so users can review and edit
         parameter values before execution.
+
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
     configObj : configobj.Section, optional
         Configuration object describing the AstroDrizzle parameter set to use.
         If omitted, defaults and any ``input_dict`` overrides are applied.
@@ -297,7 +301,7 @@ def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input
         run(configObj, wcsmap=wcsmap)
 
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj, wcsmap=None):
     """Interface for running ``drizzle`` Python or command-line.
 

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -102,7 +102,7 @@ def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input
     wcsmap : callable, optional
         Mapping factory that converts between input and output WCS frames.
         Defaults to ``None`` which triggers the package's standard mapping.
-    editpars : bool, (Default = False)
+    editpars : bool, optional
         When ``True``, launch the TEAL interface so users can review and edit
         parameter values before execution.
 

--- a/drizzlepac/adrizzle.py
+++ b/drizzlepac/adrizzle.py
@@ -89,7 +89,7 @@ time_write_all = []
 #
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def drizzle(input, outdata, wcsmap=None, editpars=False, configObj=None, **input_dict):
     """Run the high-level drizzle task for a single set of inputs.
 

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -36,6 +36,7 @@ import os
 import logging
 
 from stsci.tools import teal, textutil
+from astropy.utils import deprecated
 
 from . import adrizzle
 from . import ablot
@@ -59,6 +60,7 @@ PYTHON_WCSMAP = wcs_functions.WCSMap
 log = logging.getLogger(__name__)
 
 
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def AstroDrizzle(
     input=None,
     mdriztab=False,
@@ -94,12 +96,11 @@ def AstroDrizzle(
             exposure.
 
     mdriztab : bool (Default = False)
-        This button will immediately update the parameter values in the ``TEAL``
-        GUI based on those provided by the ``MDRIZTAB`` reference table referenced
-        in the first input image. This requires that the ``MDRIZTAB`` reference
-        file be available locally.
+        This button will immediately update the parameter values provided by 
+        the ``MDRIZTAB`` reference table referenced in the first input image. 
+        This requires that the ``MDRIZTAB`` reference file be available locally.
 
-    editpars : bool (Default = False)
+    editpars : bool (Default = False; deprecated)
         A parameter that allows user to edit input parameters by hand in the GUI.
         ``True`` to use the GUI to edit parameters.
 
@@ -109,10 +110,7 @@ def AstroDrizzle(
         settings. When ``configobj`` is ``defaults``, default parameter values are
         loaded from the user local configuration file usually located in
         ``~/.teal/astrodrizzle.cfg`` or a matching configuration file in the
-        current directory. This configuration file stores most recent
-        settings that an user used when running ``AstroDrizzle`` through the
-        `TEAL <https://stscitools.readthedocs.io/en/latest/teal_guide.html>`_
-        interface. When ``configobj`` is ``None``, ``AstroDrizzle``
+        current directory. When ``configobj`` is ``None``, ``AstroDrizzle``
         parameters not provided explicitly will be initialized with their
         default values as described in the "Other Parameters" section.
 
@@ -1071,15 +1069,6 @@ def AstroDrizzle(
         passed through to drizzle 'as is', otherwise those updates will be
         over-written by this update.
 
-        .. note::
-            This parameter was preserved in the API for compatibility purposes with
-            existing user processing pipe-lines. However, it has been removed from
-            the ``TEAL`` interface because it is easy to have it set to ``'Yes'``
-            (especially between consecutive runs of ``AstroDrizzle``) with
-            potentially disastrous effects on input image ``WCS`` (for example it
-            could wipe-out previously aligned ``WCS``).
-
-
     Something to keep in mind is that the full ``AstroDrizzle`` interface will
     make backup copies of your original files and place them in the
     ``'OrIg_files'`` directory of you current working directory.
@@ -1111,8 +1100,8 @@ def AstroDrizzle(
     Examples
     ---------
 
-    The ``AstroDrizzle`` task can be run from either the ``TEAL`` GUI or from Python. These examples illustrate the various
-    syntax options available.
+    The ``AstroDrizzle`` command can be run from the command line or from Python. 
+    These examples illustrate the various syntax options available.
 
     **Example 1:**  Drizzle a set of calibrated (``_flt.fits``) images using
     mostly default parameters. Select the desired 'World Coordinate System' (WCS)
@@ -1122,7 +1111,7 @@ def AstroDrizzle(
     images.  Align the final product such that North is
     up, and set the final pixel scale to 0.05 arcseconds/pixel.
 
-    Run the task from Python using the command line. ::
+    Run the task within Python ::
 
         >>> import drizzlepac
         >>> from drizzlepac import astrodrizzle
@@ -1130,20 +1119,17 @@ def AstroDrizzle(
         ...     wcskey='A', driz_sep_bits='64,32', final_wcs=True,
         ...     final_scale=0.05, final_rot=0)
 
-    Or, run the same task from the Python command line, but specify all
-    parameters in a config file named ``myparam.cfg``:
+    Or, run the same task specifying all parameters in a config file 
+    named ``myparam.cfg``:
 
         >>> astrodrizzle.AstroDrizzle('*flt.fits', configobj='myparam.cfg')
 
-    It can also be accessed from the Python command-line and saved
-    to a text file:
+    For more information about the parameters that can be specified in the 
+    config file, see the help file for ``AstroDrizzle``. To access this help 
+    file, run the following command from Python:
 
         >>> from drizzlepac import astrodrizzle
-        >>> astrodrizzle.help()
-
-    or
-
-        >>> astrodrizzle.help(file='help.txt')
+        >>> help(astrodrizzle)
 
     """
 
@@ -1175,11 +1161,7 @@ def AstroDrizzle(
         configobj["updatewcs"] = input_dict["updatewcs"]
         del input_dict["updatewcs"]
 
-    # If called from interactive user-interface, configObj will not be
-    # defined yet, so get defaults using EPAR/TEAL.
-    #
-    # Also insure that the input_dict (user-specified values) are folded in
-    # with a fully populated configObj instance.
+    # get default configuration parameters using teal.load
     try:
         configObj = util.getDefaultConfigObj(
             __taskname__, configobj, input_dict, loadOnly=(not editpars)
@@ -1202,36 +1184,10 @@ def AstroDrizzle(
 
     run(configObj, wcsmap=wcsmap, input_dict=input_dict)
 
-
-##############################
-#   Interfaces used by TEAL  #
-##############################
+@deprecated(since='3.12.0', warning_type=Warning)
 @util.with_logging
 def run(configobj, wcsmap=None, input_dict=None):
-    """
-    Initial example by Nadia ran MD with configobj EPAR using:
-    It can be run in one of two ways:
 
-        from stsci.tools import teal
-
-        1. Passing a config object to teal
-
-        teal.teal('drizzlepac/pars/astrodrizzle.cfg')
-
-
-        2. Passing a task  name:
-
-        teal.teal('astrodrizzle')
-
-        The example config files are in drizzlepac/pars
-
-    input_dict is a dictionary of user-specified parameters
-
-    """
-    # turn on logging, redirecting stdout/stderr messages to a log file
-    # while also printing them out to stdout as well
-    # also, initialize timing of processing steps
-    #
     # We need to define a default logfile name from the user's parameters
     input_list, output, ivmlist, odict = processInput.processFilenames(
         configobj["input"]

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -61,7 +61,7 @@ PYTHON_WCSMAP = wcs_functions.WCSMap
 log = logging.getLogger(__name__)
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def AstroDrizzle(
     input=None,
     mdriztab=False,

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -1104,7 +1104,7 @@ def AstroDrizzle(
     Examples
     ---------
 
-    The ``AstroDrizzle`` command can be run from the command line or from Python. 
+    The ``AstroDrizzle`` class can be run from Python. 
     These examples illustrate the various syntax options available.
 
     **Example 1:**  Drizzle a set of calibrated (``_flt.fits``) images using

--- a/drizzlepac/astrodrizzle.py
+++ b/drizzlepac/astrodrizzle.py
@@ -37,6 +37,7 @@ import logging
 
 from stsci.tools import teal, textutil
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from . import adrizzle
 from . import ablot
@@ -60,7 +61,7 @@ PYTHON_WCSMAP = wcs_functions.WCSMap
 log = logging.getLogger(__name__)
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def AstroDrizzle(
     input=None,
     mdriztab=False,
@@ -100,9 +101,12 @@ def AstroDrizzle(
         the ``MDRIZTAB`` reference table referenced in the first input image. 
         This requires that the ``MDRIZTAB`` reference file be available locally.
 
-    editpars : bool (Default = False; deprecated)
+    editpars : bool, optional
         A parameter that allows user to edit input parameters by hand in the GUI.
         ``True`` to use the GUI to edit parameters.
+        
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
 
     configobj : ConfigObjPars, ConfigObj, dict (Default = None)
         An instance of ``stsci.tools.cfgpars.ConfigObjPars`` or
@@ -1184,7 +1188,7 @@ def AstroDrizzle(
 
     run(configObj, wcsmap=wcsmap, input_dict=input_dict)
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 @util.with_logging
 def run(configobj, wcsmap=None, input_dict=None):
 

--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -54,10 +54,7 @@ __taskname__ = 'buildmask'
 def run(configObj=None, input_dict={}, loadOnly=False):
     """ Build DQ masks from all input images, then apply static mask(s).
     """
-    # gets configObj defaults using EPAR/TEAL.
-    #
-    # Also insure that the input_dict (user-specified values) are folded in
-    # with a fully populated configObj instance.
+    # get default configuration parameters using teal.load
     configObj = util.getDefaultConfigObj(__taskname__,configObj,input_dict,loadOnly=loadOnly)
     if configObj is None:
         return

--- a/drizzlepac/buildmask.py
+++ b/drizzlepac/buildmask.py
@@ -33,7 +33,7 @@ Functions to build mask files for PyDrizzle.
 #                   functions. WJH
 #
 import os
-
+from astropy.utils import deprecated
 from stsci.tools import fileutil
 from stsci.tools.bitmask import bitfield_to_boolean_mask
 
@@ -51,6 +51,7 @@ __taskname__ = 'buildmask'
 #
 
 
+@deprecated(since='3.12.0')
 def run(configObj=None, input_dict={}, loadOnly=False):
     """ Build DQ masks from all input images, then apply static mask(s).
     """

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -38,7 +38,7 @@ model_attrs = ['cpdis1','cpdis2','det2im','det2im1','det2im2',
                     'ocx10','ocx11','ocy10','ocy11','sip']
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def buildwcs(outwcs, configObj=None,editpars=False,**input_dict):
     if input_dict is None:
         input_dict = {}

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -11,6 +11,7 @@ import logging
 from . import util
 import numpy as np
 from astropy.io import fits
+from astropy.utils import deprecated
 
 from stsci.tools import fileutil
 from . import wcs_functions, util
@@ -36,16 +37,13 @@ model_attrs = ['cpdis1','cpdis2','det2im','det2im1','det2im2',
                     'ocx10','ocx11','ocy10','ocy11','sip']
 
 
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def buildwcs(outwcs, configObj=None,editpars=False,**input_dict):
     if input_dict is None:
         input_dict = {}
     input_dict['outwcs'] = outwcs
 
-    # If called from interactive user-interface, configObj will not be
-    # defined yet, so get defaults using EPAR/TEAL.
-    #
-    # Also insure that the input_dict (user-specified values) are folded in
-    # with a fully populated configObj instance.
+    # get default configuration parameters using teal.load
     configObj = util.getDefaultConfigObj(__taskname__,configObj,input_dict,loadOnly=(not editpars))
     if configObj is None:
         return
@@ -53,6 +51,7 @@ def buildwcs(outwcs, configObj=None,editpars=False,**input_dict):
     if not editpars:
         run(configObj,wcsmap=wcsmap)
 
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj,wcsmap=None):
     """ Interpret parameters from TEAL/configObj interface as set interactively
         by the user and build the new WCS instance

--- a/drizzlepac/buildwcs.py
+++ b/drizzlepac/buildwcs.py
@@ -12,6 +12,7 @@ from . import util
 import numpy as np
 from astropy.io import fits
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from stsci.tools import fileutil
 from . import wcs_functions, util
@@ -37,7 +38,7 @@ model_attrs = ['cpdis1','cpdis2','det2im','det2im1','det2im2',
                     'ocx10','ocx11','ocy10','ocy11','sip']
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def buildwcs(outwcs, configObj=None,editpars=False,**input_dict):
     if input_dict is None:
         input_dict = {}
@@ -51,7 +52,7 @@ def buildwcs(outwcs, configObj=None,editpars=False,**input_dict):
     if not editpars:
         run(configObj,wcsmap=wcsmap)
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj,wcsmap=None):
     """ Interpret parameters from TEAL/configObj interface as set interactively
         by the user and build the new WCS instance

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -14,6 +14,7 @@ import logging
 import numpy as np
 from astropy.io import fits
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from stsci.imagestats import ImageStats
 from stsci.image import numcombine
@@ -38,7 +39,7 @@ BUFSIZE = 1024 * 1024  # 1MB cache size
 log = logging.getLogger(__name__)
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def median(input=None, configObj=None, editpars=False, **inputDict):
     """
     The singly drizzled science images are combined to create a single median
@@ -66,9 +67,12 @@ def median(input=None, configObj=None, editpars=False, **inputDict):
     configObj : configObject (Default = None)
         An instance of ``configObject`` which overrides default parameter settings.
 
-    editpars : bool (Default = False; deprecated)
+    editpars : bool, optional
         A parameter that allows user to edit input parameters by hand in the GUI.
         True to use the GUI to edit parameters.
+        
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
 
     inputDict : dict, optional
         An optional list of parameters specified by the user, which can also
@@ -190,7 +194,7 @@ def median(input=None, configObj=None, editpars=False, **inputDict):
         run(configObj)
 
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj):
     # outwcs is not needed here
     imgObjList, outwcs = processInput.setCommonInput(configObj, createOutwcs=False)

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -39,7 +39,7 @@ BUFSIZE = 1024 * 1024  # 1MB cache size
 log = logging.getLogger(__name__)
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def median(input=None, configObj=None, editpars=False, **inputDict):
     """
     The singly drizzled science images are combined to create a single median

--- a/drizzlepac/createMedian.py
+++ b/drizzlepac/createMedian.py
@@ -13,6 +13,7 @@ import math
 import logging
 import numpy as np
 from astropy.io import fits
+from astropy.utils import deprecated
 
 from stsci.imagestats import ImageStats
 from stsci.image import numcombine
@@ -37,7 +38,7 @@ BUFSIZE = 1024 * 1024  # 1MB cache size
 log = logging.getLogger(__name__)
 
 
-# this is the user access function
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def median(input=None, configObj=None, editpars=False, **inputDict):
     """
     The singly drizzled science images are combined to create a single median
@@ -65,7 +66,7 @@ def median(input=None, configObj=None, editpars=False, **inputDict):
     configObj : configObject (Default = None)
         An instance of ``configObject`` which overrides default parameter settings.
 
-    editpars : bool (Default = False)
+    editpars : bool (Default = False; deprecated)
         A parameter that allows user to edit input parameters by hand in the GUI.
         True to use the GUI to edit parameters.
 
@@ -189,7 +190,7 @@ def median(input=None, configObj=None, editpars=False, **inputDict):
         run(configObj)
 
 
-# this is the function that will be called from TEAL
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj):
     # outwcs is not needed here
     imgObjList, outwcs = processInput.setCommonInput(configObj, createOutwcs=False)

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -38,7 +38,7 @@ PROCSTEPS_NAME = "Driz_CR"
 log = logging.getLogger(__name__)
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     """ 
     The blotted median images that are now transformed back into the original

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -14,6 +14,7 @@ import logging
 import numpy as np
 from scipy import signal
 from astropy.io import fits
+from astropy.utils import deprecated
 from stsci.tools import fileutil, mputil
 
 
@@ -36,6 +37,7 @@ PROCSTEPS_NAME = "Driz_CR"
 log = logging.getLogger(__name__)
 
 
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     """ 
     The blotted median images that are now transformed back into the original
@@ -58,7 +60,7 @@ def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     configObj : configObject (Default = None)
         An instance of ``configObject`` which overrides default parameter settings.
 
-    editpars : bool (Default = False)
+    editpars : bool (Default = False; deprecated)
         A parameter that allows user to edit input parameters by hand in the GUI.
         True to use the GUI to edit parameters.
 
@@ -137,10 +139,7 @@ def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     if not editpars:
         run(configObj)
 
-#--------------------------------
-# TEAL Interface functions
-# (these functions are deprecated)
-#---------------------------------
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj):
     # outwcs is not neaded here
     imgObjList, outwcs = processInput.setCommonInput(configObj,

--- a/drizzlepac/drizCR.py
+++ b/drizzlepac/drizCR.py
@@ -15,6 +15,7 @@ import numpy as np
 from scipy import signal
 from astropy.io import fits
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 from stsci.tools import fileutil, mputil
 
 
@@ -37,7 +38,7 @@ PROCSTEPS_NAME = "Driz_CR"
 log = logging.getLogger(__name__)
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     """ 
     The blotted median images that are now transformed back into the original
@@ -60,9 +61,12 @@ def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     configObj : configObject (Default = None)
         An instance of ``configObject`` which overrides default parameter settings.
 
-    editpars : bool (Default = False; deprecated)
+    editpars : bool, optional
         A parameter that allows user to edit input parameters by hand in the GUI.
         True to use the GUI to edit parameters.
+        
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
 
     inputDict : dict, optional
         An optional list of parameters specified by the user, which can also
@@ -139,7 +143,7 @@ def drizCR(input=None, configObj=None, editpars=False, **inputDict):
     if not editpars:
         run(configObj)
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj):
     # outwcs is not neaded here
     imgObjList, outwcs = processInput.setCommonInput(configObj,

--- a/drizzlepac/photeq.py
+++ b/drizzlepac/photeq.py
@@ -125,10 +125,6 @@ def photeq(files='*_flt.fits', sciext='SCI', errext='ERR',
         Multiple keywords can be specified as a Python list of strings:
         ``['PHOTFNU', 'PHOTOHMY']``.
 
-        .. note::
-
-            If specifying multiple secondary photometric keywords in the TEAL
-            interface, use a comma-separated list of keywords.
 
     search_primary : bool (Default = True)
         Specifies whether to first search the primary header for the

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -10,11 +10,11 @@ input image while recording the subtracted value in the image header.
 
 """
 import os
-import sys 
 import logging
 
 import numpy as np
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from stsci.tools import fileutil
 from stsci.tools.bitmask import interpret_bit_flags
@@ -40,7 +40,7 @@ PROCSTEPS_NAME = "Subtract Sky"
 log = logging.getLogger(__name__)
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inputDict):
     """
     Function for computing and subtracting (or equalizing/matching) the backgroud
@@ -92,9 +92,12 @@ def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inp
     group : int (Default = None)
         The group of the input image.
 
-    editpars : bool (Default = False; deprecated)
+    editpars : bool, optional
         A deprecated argument that previously allowed a user to edit input 
         parameters by hand in the TEAL GUI.
+        
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
 
     inputDict : dict, optional
         An optional list of parameters specified by the user.
@@ -493,7 +496,7 @@ def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inp
         run(configObj,outExt=outExt)
 
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj,outExt=None):
 
     #now we really just need the imageObject list created for the dataset

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -40,7 +40,7 @@ PROCSTEPS_NAME = "Subtract Sky"
 log = logging.getLogger(__name__)
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inputDict):
     """
     Function for computing and subtracting (or equalizing/matching) the backgroud

--- a/drizzlepac/sky.py
+++ b/drizzlepac/sky.py
@@ -14,6 +14,7 @@ import sys
 import logging
 
 import numpy as np
+from astropy.utils import deprecated
 
 from stsci.tools import fileutil
 from stsci.tools.bitmask import interpret_bit_flags
@@ -39,7 +40,7 @@ PROCSTEPS_NAME = "Subtract Sky"
 log = logging.getLogger(__name__)
 
 
-#this is the user access function
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inputDict):
     """
     Function for computing and subtracting (or equalizing/matching) the backgroud
@@ -91,7 +92,7 @@ def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inp
     group : int (Default = None)
         The group of the input image.
 
-    editpars : bool (Default = False)
+    editpars : bool (Default = False; deprecated)
         A deprecated argument that previously allowed a user to edit input 
         parameters by hand in the TEAL GUI.
 
@@ -492,7 +493,7 @@ def sky(input=None,outExt=None,configObj=None, group=None, editpars=False, **inp
         run(configObj,outExt=outExt)
 
 
-#this is the function that will be called from TEAL
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj,outExt=None):
 
     #now we really just need the imageObject list created for the dataset

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -16,6 +16,8 @@ import logging
 import numpy as np
 from stsci.tools import fileutil
 from astropy.io import fits
+from astropy.utils import deprecated
+
 from stsci.imagestats import ImageStats
 from . import util
 from . import processInput
@@ -29,6 +31,7 @@ log = logging.getLogger(__name__)
 
 
 # this is called by the user
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def createMask(input=None, static_sig=4.0, group=None, editpars=False, 
                configObj=None, **inputDict):
     """ The user can input a list of images if they like to create static masks
@@ -90,7 +93,7 @@ def createMask(input=None, static_sig=4.0, group=None, editpars=False,
         The number of sigma below the RMS to use as the clipping limit for
         creating the static mask.
 
-    editpars : bool (Default = False)
+    editpars : bool (Default = False; deprecated)
         Set to `True` if you would like to edit the parameters using the GUI
         interface.
 
@@ -135,10 +138,7 @@ def createMask(input=None, static_sig=4.0, group=None, editpars=False,
     if not editpars:
         run(configObj)
 
-#--------------------------------
-# TEAL Interface functions
-# (these functions are deprecated)
-#---------------------------------
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configObj):
 
     #now we really just need the imageObject list created for the dataset

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 # this is called by the user
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def createMask(input=None, static_sig=4.0, group=None, editpars=False, 
                configObj=None, **inputDict):
     """ The user can input a list of images if they like to create static masks

--- a/drizzlepac/staticMask.py
+++ b/drizzlepac/staticMask.py
@@ -17,6 +17,7 @@ import numpy as np
 from stsci.tools import fileutil
 from astropy.io import fits
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from stsci.imagestats import ImageStats
 from . import util
@@ -31,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 # this is called by the user
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def createMask(input=None, static_sig=4.0, group=None, editpars=False, 
                configObj=None, **inputDict):
     """ The user can input a list of images if they like to create static masks
@@ -93,10 +94,12 @@ def createMask(input=None, static_sig=4.0, group=None, editpars=False,
         The number of sigma below the RMS to use as the clipping limit for
         creating the static mask.
 
-    editpars : bool (Default = False; deprecated)
+    editpars : bool, optional
         Set to `True` if you would like to edit the parameters using the GUI
         interface.
 
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
 
     Examples
     --------
@@ -138,7 +141,7 @@ def createMask(input=None, static_sig=4.0, group=None, editpars=False,
     if not editpars:
         run(configObj)
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configObj):
 
     #now we really just need the imageObject list created for the dataset

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -749,7 +749,7 @@ def _max_overlap_image(refimage, images, expand_refcat, enforce_user_order):
     return images.pop(0)
 
 
-@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
+@deprecated_renamed_argument('editpars', None, '3.12.0')
 def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
              refimagefindcfg=None, **input_dict):
     """

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -9,7 +9,7 @@ import os
 import logging
 import numpy as np
 from copy import copy
-from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from stsci.tools import teal
 from stsci.tools import textutil
@@ -749,7 +749,7 @@ def _max_overlap_image(refimage, images, expand_refcat, enforce_user_order):
     return images.pop(0)
 
 
-@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
+@deprecated_renamed_argument(new_name='editpars', old_name='', since='3.12.0')
 def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
              refimagefindcfg=None, **input_dict):
     """
@@ -774,9 +774,12 @@ def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
             - comma-separated list of filenames
             - filelist containing desired input filenames with one filename on each line of the file.
 
-    editpars : bool (Default = False; deprecated)
+    editpars : bool, optional
         A parameter that allows user to edit input parameters by hand in the GUI.
         True to use the GUI to edit parameters.
+        
+        .. deprecated:: 3.12.0
+            This parameter is deprecated and will be removed in a future release.
 
     configobj : ConfigObjPars, ConfigObj, dict (Default = None)
         An instance of ``stsci.tools.cfgpars.ConfigObjPars`` or

--- a/drizzlepac/tweakreg.py
+++ b/drizzlepac/tweakreg.py
@@ -9,6 +9,7 @@ import os
 import logging
 import numpy as np
 from copy import copy
+from astropy.utils import deprecated
 
 from stsci.tools import teal
 from stsci.tools import textutil
@@ -748,9 +749,7 @@ def _max_overlap_image(refimage, images, expand_refcat, enforce_user_order):
     return images.pop(0)
 
 
-#
-# Primary interface for running this task from Python
-#
+@deprecated(since='3.12.0', name='editpars', warning_type=Warning)
 def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
              refimagefindcfg=None, **input_dict):
     """
@@ -775,7 +774,7 @@ def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
             - comma-separated list of filenames
             - filelist containing desired input filenames with one filename on each line of the file.
 
-    editpars : bool (Default = False)
+    editpars : bool (Default = False; deprecated)
         A parameter that allows user to edit input parameters by hand in the GUI.
         True to use the GUI to edit parameters.
 
@@ -1445,11 +1444,7 @@ def TweakReg(files=None, editpars=False, configobj=None, imagefindcfg=None,
         del configobj[PSET_SECTION] # force run() to pull it again after GUI use
         del configobj[PSET_SECTION_REFIMG] # force run() to pull it again after GUI use
 
-    # If called from interactive user-interface, configObj will not be
-    # defined yet, so get defaults using EPAR/TEAL.
-    #
-    # Also insure that the input_dict (user-specified values) are folded in
-    # with a fully populated configObj instance.
+    # get default configuration parameters using teal.load
     try:
         configObj = util.getDefaultConfigObj(__taskname__, configobj,
                                              input_dict,

--- a/drizzlepac/updatenpol.py
+++ b/drizzlepac/updatenpol.py
@@ -21,6 +21,7 @@ __taskname__ = "updatenpol"
 import os,sys,shutil
 
 from astropy.io import fits
+from astropy.utils import deprecated
 from stsci.tools import fileutil as fu
 from stsci.tools import parseinput
 from stsci.tools import teal
@@ -228,10 +229,7 @@ def find_npolfile(flist,detector,filters):
                 npolfile = f
     return npolfile
 
-#--------------------------------
-# TEAL Interface functions
-# (these functions are deprecated)
-#---------------------------------
+@deprecated(since='3.12.0', warning_type=Warning)
 def run(configobj=None,editpars=False):
     """ Teal interface for running this code.
     """

--- a/drizzlepac/updatenpol.py
+++ b/drizzlepac/updatenpol.py
@@ -229,7 +229,7 @@ def find_npolfile(flist,detector,filters):
                 npolfile = f
     return npolfile
 
-@deprecated(since='3.12.0', warning_type=Warning)
+@deprecated(since='3.12.0')
 def run(configobj=None,editpars=False):
     """ Teal interface for running this code.
     """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1569](https://jira.stsci.edu/browse/HLA-1569)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2100

<!-- describe the changes comprising this PR here -->
This PR removed lingering text from the TEAL interface. We still use teal to load our default configuration parameters, but the GUI has not been supported for the last two versions. 

This PR also adds deprecation warnings when using the `run` TEAL helper functions (e.g. `createMedian.run()` as opposed to `createMedian.median()`) that no one seems to call directly. 

It also adds deprecation warnings when using the `editpars` argument for the main drizzlepac functions. It is unlikely that people have been using this argument as it invokes the TEAL GUI. We are using a deprecation warning for this build as opposed to removing it because removing it would cause a call that includes `editpars=False` to return an error.

We will remove the teal helper functions and the editpar argument in the next version of the build. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)

Regression test: 
https://github.com/spacetelescope/RegressionTests/actions/runs/26170684336/job/76987182659
