### PR TITLE
HLA-1617: Reduce number unhelpful warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ number of the code change for that issue.  These PRs can be viewed at:
 3.12.0 (TBD)
 ============
 
+- Silenced some warnings from astropy.wcs.wcs and astropy.io.fits when running 
+  runastrodriz.py. [#2184]
+
 - Improved MVM guide star failure check to reintroduce exposures that
   were incorrectly excluded due to PSF spikes, saturation, and CTE issues. [#2101]
 

--- a/drizzlepac/haputils/astrometric_utils.py
+++ b/drizzlepac/haputils/astrometric_utils.py
@@ -887,7 +887,7 @@ def build_auto_kernel(imgarr, whtarr, fwhm=3.0, threshold=None, source_box=7,
     return (kernel, kernel_psf), kernel_fwhm
 
 
-def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
+def find_fwhm(psf, default_fwhm):
     """Determine FWHM for auto-kernel PSF
 
     This function iteratively fits a Gaussian model to the extracted PSF
@@ -934,22 +934,22 @@ def find_fwhm(psf, default_fwhm, log_level=logutil.logging.INFO):
         with use_future_column_names():
             phot_results = itr_phot_obj(psf)
     except Exception as x_cept:
-        log.warning(f"The find_fwhm() failed due to problem with fitting. Trying again. Exception: {x_cept}")
+        log.debug(f"The find_fwhm() failed due to problem with fitting. Trying again. Exception: {x_cept}")
         return None
 
     # Check the phot_results table was generated successfully
     if isinstance(phot_results, (type(None))):
-        log.warning("The PHOT_RESULTS table was not generated successfully. Trying again.")
+        log.debug("The PHOT_RESULTS table was not generated successfully. Trying again.")
         return None
 
     # Check the table actually has rows
     if len(phot_results['flux_fit']) == 0:
-        log.warning("The PHOT_RESULTS table has no rows. Trying again.")
+        log.debug("The PHOT_RESULTS table has no rows. Trying again.")
         return None
 
     # Check the 'flags' column has at least one row with a flag value of zero
     if (phot_results['flags'] == 0).sum() == 0:
-        log.warning("The PHOT_RESULTS table has no good rows. Trying again.")
+        log.debug("The PHOT_RESULTS table has no good rows. Trying again.")
         return None
 
     # Insure none of the fluxes determined by photutils is np.nan

--- a/drizzlepac/util.py
+++ b/drizzlepac/util.py
@@ -187,6 +187,22 @@ def end_logging(filename=None):
     root_logger = logging.getLogger()
     root_logger.removeHandler(_log_file_handler)
 
+
+class SuppressNoisyAstropyWCS(logging.Filter):
+    """Filter known non-actionable Astropy WCS informational messages."""
+
+    _messages = (
+        "Inconsistent SIP distortion information",
+        "Some non-standard WCS keywords were excluded",
+    )
+
+    def filter(self, record):
+        return not any(message in record.getMessage() for message in self._messages)
+
+
+logging.getLogger('astropy').addFilter(SuppressNoisyAstropyWCS())
+
+
 class WithLogging:
     def __init__(self):
         self.depth = 0


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1617](https://jira.stsci.edu/browse/HLA-1617)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #2178 

<!-- describe the changes comprising this PR here -->
This PR silences some very common, yet unhelpful warnings that appear in logs and printed outputs for runastrodriz. I've changed the log level for some and added a logging filter for two other astropy logged messages. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)

Regression test: 
https://github.com/spacetelescope/RegressionTests/actions/runs/34877831938
